### PR TITLE
Add additional parameters to order placement

### DIFF
--- a/programs/slab/src/tests.rs
+++ b/programs/slab/src/tests.rs
@@ -141,6 +141,8 @@ mod slab_orderbook_tests {
             Side::Buy,
             1_200_000,
             5_000_000,
+            false,
+            false
         ).unwrap();
 
         assert_eq!(slab.book.num_bids, 1);
@@ -177,6 +179,8 @@ mod slab_orderbook_tests {
             Side::Sell,
             1_500_000,
             3_000_000,
+            false,
+            false
         ).unwrap();
 
         // Try to cancel with owner2 (should fail)


### PR DESCRIPTION
These two test cases — test_cancel_order_wrong_owner — are currently failing because the order cancellation logic requires an explicit and valid owner parameter.