### PR TITLE
docs: add position NFT wrapper reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ cargo kani setup
 cargo kani
 ```
 
+## Ecosystem
+
+- **[Position NFT Wrapper](https://github.com/dcccrypto/percolator-nft)** — Transferable Token-2022 NFTs representing open perpetual futures positions. External wrapper program; no changes to the core engine. See [docs/position-nft.md](docs/position-nft.md).
+
 ## References
 
 - Tarun Chitra, *Autodeleveraging: Impossibilities and Optimization*, arXiv:2512.01112, 2025. https://arxiv.org/abs/2512.01112

--- a/docs/position-nft.md
+++ b/docs/position-nft.md
@@ -1,0 +1,52 @@
+# Position NFT Wrapper
+
+Transferable Token-2022 NFTs representing open Percolator perpetual futures positions.
+
+## Overview
+
+[`dcccrypto/percolator-nft`](https://github.com/dcccrypto/percolator-nft) is an external wrapper program that mints NFTs backed by open positions in Percolator slabs. It reads position state directly from slab account data (no CPI into core) and uses SPL Token-2022 with `decimals=0, supply=1` per position.
+
+## Architecture
+
+```
+percolator-nft (wrapper program)
+  ├── Reads position state from Percolator slab accounts (CPI-free, direct data read)
+  ├── SPL Token-2022 (mint/burn position NFTs)
+  ├── PositionNft PDA (links NFT mint → slab + user_idx)
+  └── SettleFunding (permissionless crank to sync funding index before transfer)
+```
+
+### Why a wrapper?
+
+- **Core stays lean** — no Token-2022 dependency in the Percolator BPF binary
+- **Independent upgradability** — iterate on NFT logic without touching the engine
+- **Security isolation** — NFT bugs cannot affect core funds or margin calculations
+- **Same pattern** as the staking wrapper (`percolator-stake`)
+
+## Instructions
+
+| Tag | Name | Description |
+|-----|------|-------------|
+| 0 | `MintPositionNft` | Mint an NFT for an open position (caller must own the position) |
+| 1 | `BurnPositionNft` | Burn the NFT, release position back to direct ownership |
+| 2 | `SettleFunding` | Permissionless crank — update funding index before transfer |
+
+## PDA Seeds
+
+- **PositionNft**: `["position_nft", slab_pubkey, user_idx_le_bytes]`
+- **MintAuthority**: `["mint_authority"]` (program-wide, signs all mint operations)
+
+## Transfer Hook (Future)
+
+A Token-2022 `TransferHook` extension will enforce that funding is settled before any NFT transfer, preventing stale-funding exploits when positions change hands. The hook invokes `SettleFunding` automatically during `transfer_checked`.
+
+## Security
+
+- `forbid(unsafe_code)` enforced
+- Slab owner verified against known Percolator program IDs
+- Position ownership verified before minting
+- NFT burn closes PDA and returns rent to holder
+
+## Repository
+
+**Source:** [github.com/dcccrypto/percolator-nft](https://github.com/dcccrypto/percolator-nft)


### PR DESCRIPTION
## Summary

Adds documentation for the Token-2022 position NFT wrapper — an external program that mints transferable NFTs representing open Percolator perpetual futures positions.

## Changes

- **docs/position-nft.md** — Architecture overview, instructions, PDA seeds, planned TransferHook extension, security notes
- **README.md** — New "Ecosystem" section referencing the wrapper

## Design

The wrapper program ([dcccrypto/percolator-nft](https://github.com/dcccrypto/percolator-nft)):

- Reads position state directly from slab account data (no CPI into core engine)
- Mints SPL Token-2022 NFTs with `decimals=0, supply=1` per position
- Uses PDA `["position_nft", slab, user_idx]` to link NFT mint → position
- Supports permissionless funding settlement before transfer
- Planned: TransferHook extension for automatic pre-transfer validation

**No changes to core engine code.** Same isolation pattern as `percolator-stake`.

## Testing

Documentation only — no code changes to core.