### PR TITLE
fix: add end-of-instruction lifecycle to force_close_resolved_not_atomic

### DIFF
--- a/src/percolator.rs
+++ b/src/percolator.rs
@@ -3580,7 +3580,9 @@ impl RiskEngine {
     ///
     /// Skips accrue_market_to (market is frozen). Handles both same-epoch
     /// and epoch-mismatch accounts.
-    pub fn force_close_resolved_not_atomic(&mut self, idx: u16, resolved_slot: u64) -> Result<u128> {
+    pub fn force_close_resolved_not_atomic(&mut self, idx: u16, resolved_slot: u64, funding_rate: i64) -> Result<u128> {
+        Self::validate_funding_rate(funding_rate)?;
+
         if idx as usize >= MAX_ACCOUNTS || !self.is_used(idx as usize) {
             return Err(RiskError::AccountNotFound);
         }
@@ -3588,6 +3590,8 @@ impl RiskEngine {
             return Err(RiskError::Overflow);
         }
         self.current_slot = resolved_slot;
+
+        let mut ctx = InstructionContext::new();
 
         let i = idx as usize;
 
@@ -3738,6 +3742,11 @@ impl RiskEngine {
         }
         self.vault = self.vault - capital;
         self.set_capital(i, 0);
+
+        // End-of-instruction resets before freeing (spec §5.7-5.8, §10.0)
+        self.schedule_end_of_instruction_resets(&mut ctx)?;
+        self.finalize_end_of_instruction_resets(&ctx);
+        self.recompute_r_last_from_final_state(funding_rate)?;
 
         self.free_slot(idx);
 

--- a/tests/proofs_audit.rs
+++ b/tests/proofs_audit.rs
@@ -897,7 +897,7 @@ fn proof_force_close_resolved_with_position_conserves() {
     kani::assume(loss >= 1 && loss <= 400_000);
     engine.set_pnl(a as usize, -(loss as i128));
 
-    let result = engine.force_close_resolved_not_atomic(a, 100);
+    let result = engine.force_close_resolved_not_atomic(a, 100, 0);
     assert!(result.is_ok(), "force_close must succeed with open position");
     assert!(!engine.is_used(a as usize), "account must be freed");
     assert!(engine.check_conservation());
@@ -917,7 +917,7 @@ fn proof_force_close_resolved_with_profit_conserves() {
     engine.set_pnl(idx as usize, profit as i128);
 
     let cap_before = engine.accounts[idx as usize].capital.get();
-    let result = engine.force_close_resolved_not_atomic(idx, 100);
+    let result = engine.force_close_resolved_not_atomic(idx, 100, 0);
     assert!(result.is_ok(), "force_close must succeed with positive PnL");
     assert!(result.unwrap() >= cap_before, "returned must include converted profit");
     assert!(!engine.is_used(idx as usize));
@@ -936,7 +936,7 @@ fn proof_force_close_resolved_flat_returns_capital() {
     kani::assume(dep >= 1 && dep <= 1_000_000);
     engine.deposit(idx, dep as u128, DEFAULT_ORACLE, DEFAULT_SLOT).unwrap();
 
-    let result = engine.force_close_resolved_not_atomic(idx, 100);
+    let result = engine.force_close_resolved_not_atomic(idx, 100, 0);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), dep as u128, "flat account must return exact capital");
     assert!(!engine.is_used(idx as usize));
@@ -963,7 +963,7 @@ fn proof_force_close_resolved_position_conservation() {
     engine.keeper_crank_not_atomic(DEFAULT_SLOT + 1, 1500, &[], 64, 0i64).unwrap();
 
     let oi_long_before = engine.oi_eff_long_q;
-    let result = engine.force_close_resolved_not_atomic(a, DEFAULT_SLOT + 1);
+    let result = engine.force_close_resolved_not_atomic(a, DEFAULT_SLOT + 1, 0);
     assert!(result.is_ok());
     assert!(!engine.is_used(a as usize));
     assert!(engine.accounts[a as usize].position_basis_q == 0);
@@ -992,11 +992,11 @@ fn proof_force_close_resolved_pos_count_decrements() {
     let long_before = engine.stored_pos_count_long;
     let short_before = engine.stored_pos_count_short;
 
-    engine.force_close_resolved_not_atomic(a, 100).unwrap(); // a was long
+    engine.force_close_resolved_not_atomic(a, 100, 0).unwrap(); // a was long
     assert_eq!(engine.stored_pos_count_long, long_before - 1);
     assert_eq!(engine.stored_pos_count_short, short_before);
 
-    engine.force_close_resolved_not_atomic(b, 100).unwrap(); // b was short
+    engine.force_close_resolved_not_atomic(b, 100, 0).unwrap(); // b was short
     assert_eq!(engine.stored_pos_count_short, short_before - 1);
 }
 
@@ -1016,7 +1016,7 @@ fn proof_force_close_resolved_fee_sweep_conservation() {
     engine.accounts[idx as usize].fee_credits = I128::new(-(debt as i128));
 
     let ins_before = engine.insurance_fund.balance.get();
-    let result = engine.force_close_resolved_not_atomic(idx, 100);
+    let result = engine.force_close_resolved_not_atomic(idx, 100, 0);
     assert!(result.is_ok());
 
     // Insurance must have increased by swept amount

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -2460,7 +2460,7 @@ fn test_force_close_resolved_flat_no_pnl() {
     // Align last_fee_slot so force_close doesn't charge accrued fee
     engine.accounts[idx as usize].last_fee_slot = 100;
 
-    let returned = engine.force_close_resolved_not_atomic(idx, 100).unwrap();
+    let returned = engine.force_close_resolved_not_atomic(idx, 100, 0).unwrap();
     assert_eq!(returned, 50_000);
     assert!(!engine.is_used(idx as usize));
     assert!(engine.check_conservation());
@@ -2478,7 +2478,7 @@ fn test_force_close_resolved_with_open_position() {
     engine.execute_trade_not_atomic(a, b, 1000, 100, size, 1000, 0i64).unwrap();
 
     // Account has open position — force_close settles K-pair PnL and zeros it
-    let result = engine.force_close_resolved_not_atomic(a, 100);
+    let result = engine.force_close_resolved_not_atomic(a, 100, 0);
     assert!(result.is_ok(), "force_close must handle open positions");
     assert!(!engine.is_used(a as usize));
     assert!(engine.check_conservation());
@@ -2499,7 +2499,7 @@ fn test_force_close_resolved_with_negative_pnl() {
     engine.set_pnl(a as usize, -100_000i128);
 
     let cap_before = engine.accounts[a as usize].capital.get();
-    let returned = engine.force_close_resolved_not_atomic(a, 100).unwrap();
+    let returned = engine.force_close_resolved_not_atomic(a, 100, 0).unwrap();
 
     assert!(returned < cap_before, "loss must reduce returned capital");
     assert!(!engine.is_used(a as usize));
@@ -2516,7 +2516,7 @@ fn test_force_close_resolved_with_positive_pnl() {
     // Inject positive PnL on flat account
     engine.set_pnl(idx as usize, 10_000i128);
 
-    let returned = engine.force_close_resolved_not_atomic(idx, 100).unwrap();
+    let returned = engine.force_close_resolved_not_atomic(idx, 100, 0).unwrap();
     // Positive PnL converted to capital (haircutted) before return
     assert!(returned >= 50_000, "positive PnL must increase returned capital");
     assert!(!engine.is_used(idx as usize));
@@ -2533,7 +2533,7 @@ fn test_force_close_resolved_with_fee_debt() {
     // Inject fee debt of 5000
     engine.accounts[idx as usize].fee_credits = I128::new(-5000);
 
-    let returned = engine.force_close_resolved_not_atomic(idx, 100).unwrap();
+    let returned = engine.force_close_resolved_not_atomic(idx, 100, 0).unwrap();
     // Fee debt swept from capital first (spec §7.5 fee seniority):
     // 50_000 capital - 5_000 fee sweep = 45_000 returned
     assert_eq!(returned, 45_000, "fee debt swept before capital return");
@@ -2544,7 +2544,7 @@ fn test_force_close_resolved_with_fee_debt() {
 #[test]
 fn test_force_close_resolved_unused_slot_rejected() {
     let mut engine = RiskEngine::new(default_params());
-    let result = engine.force_close_resolved_not_atomic(0, 100);
+    let result = engine.force_close_resolved_not_atomic(0, 100, 0);
     assert_eq!(result, Err(RiskError::AccountNotFound));
 }
 
@@ -2571,7 +2571,7 @@ fn test_force_close_same_epoch_positive_k_pair_pnl() {
     engine.accounts[a as usize].last_fee_slot = 200;
 
     // a (long) has unrealized profit from K-pair (K_long increased)
-    let returned = engine.force_close_resolved_not_atomic(a, 200).unwrap();
+    let returned = engine.force_close_resolved_not_atomic(a, 200, 0).unwrap();
 
     // Returned should include settled K-pair profit
     assert!(returned >= cap_after_trade, "K-pair profit must increase returned capital");
@@ -2594,7 +2594,7 @@ fn test_force_close_same_epoch_negative_k_pair_pnl() {
     engine.keeper_crank_not_atomic(200, 500, &[], 64, 0i64).unwrap();
 
     let cap_before = engine.accounts[a as usize].capital.get();
-    let returned = engine.force_close_resolved_not_atomic(a, 200).unwrap();
+    let returned = engine.force_close_resolved_not_atomic(a, 200, 0).unwrap();
 
     // Loss settled from capital
     assert!(returned < cap_before, "K-pair loss must reduce returned capital");
@@ -2611,7 +2611,7 @@ fn test_force_close_with_fee_debt_exceeding_capital() {
     // Fee debt >> capital
     engine.accounts[idx as usize].fee_credits = I128::new(-50_000);
 
-    let returned = engine.force_close_resolved_not_atomic(idx, 100).unwrap();
+    let returned = engine.force_close_resolved_not_atomic(idx, 100, 0).unwrap();
     // Capital (10k) fully swept to insurance, remaining debt forgiven
     assert_eq!(returned, 0, "all capital swept for fee debt");
     assert!(!engine.is_used(idx as usize));
@@ -2624,7 +2624,7 @@ fn test_force_close_zero_capital_zero_pnl() {
     let idx = engine.add_user(1000).unwrap();
     // No deposit — capital = 0 (new_account_fee consumed all)
 
-    let returned = engine.force_close_resolved_not_atomic(idx, 100).unwrap();
+    let returned = engine.force_close_resolved_not_atomic(idx, 100, 0).unwrap();
     assert_eq!(returned, 0);
     assert!(!engine.is_used(idx as usize));
     assert!(engine.check_conservation());
@@ -2646,15 +2646,15 @@ fn test_force_close_c_tot_tracks_exactly() {
 
     let c_tot_before = engine.c_tot.get();
 
-    let ret_a = engine.force_close_resolved_not_atomic(a, 100).unwrap();
+    let ret_a = engine.force_close_resolved_not_atomic(a, 100, 0).unwrap();
     assert_eq!(engine.c_tot.get(), c_tot_before - ret_a);
 
     let c_tot_mid = engine.c_tot.get();
-    let ret_b = engine.force_close_resolved_not_atomic(b, 100).unwrap();
+    let ret_b = engine.force_close_resolved_not_atomic(b, 100, 0).unwrap();
     assert_eq!(engine.c_tot.get(), c_tot_mid - ret_b);
 
     let c_tot_mid2 = engine.c_tot.get();
-    let ret_c = engine.force_close_resolved_not_atomic(c, 100).unwrap();
+    let ret_c = engine.force_close_resolved_not_atomic(c, 100, 0).unwrap();
     assert_eq!(engine.c_tot.get(), c_tot_mid2 - ret_c);
 
     assert_eq!(engine.c_tot.get(), 0, "all accounts closed → C_tot must be 0");
@@ -2673,12 +2673,12 @@ fn test_force_close_stored_pos_count_tracks() {
     assert_eq!(engine.stored_pos_count_long, 1);
     assert_eq!(engine.stored_pos_count_short, 1);
 
-    engine.force_close_resolved_not_atomic(a, 100).unwrap();
+    engine.force_close_resolved_not_atomic(a, 100, 0).unwrap();
     assert_eq!(engine.stored_pos_count_long, 0, "long count must decrement");
     // Short count unchanged — b still has position
     assert_eq!(engine.stored_pos_count_short, 1);
 
-    engine.force_close_resolved_not_atomic(b, 100).unwrap();
+    engine.force_close_resolved_not_atomic(b, 100, 0).unwrap();
     assert_eq!(engine.stored_pos_count_short, 0, "short count must decrement");
 }
 
@@ -2693,7 +2693,7 @@ fn test_force_close_multiple_sequential_no_aggregate_drift() {
     }
 
     for &idx in &accounts {
-        engine.force_close_resolved_not_atomic(idx, 100).unwrap();
+        engine.force_close_resolved_not_atomic(idx, 100, 0).unwrap();
     }
 
     assert_eq!(engine.c_tot.get(), 0);
@@ -2717,13 +2717,13 @@ fn test_force_close_decrements_oi() {
     assert!(engine.oi_eff_long_q > 0);
     assert!(engine.oi_eff_short_q > 0);
 
-    engine.force_close_resolved_not_atomic(a, 100).unwrap();
+    engine.force_close_resolved_not_atomic(a, 100, 0).unwrap();
     // Bilateral decrement: both sides go to 0 together
     assert_eq!(engine.oi_eff_long_q, 0);
     assert_eq!(engine.oi_eff_short_q, 0);
     assert_eq!(engine.oi_eff_long_q, engine.oi_eff_short_q, "OI must stay symmetric");
 
-    engine.force_close_resolved_not_atomic(b, 100).unwrap();
+    engine.force_close_resolved_not_atomic(b, 100, 0).unwrap();
     assert_eq!(engine.oi_eff_long_q, 0);
     assert_eq!(engine.oi_eff_short_q, 0);
     assert_eq!(engine.stored_pos_count_long, 0);
@@ -2748,7 +2748,7 @@ fn test_force_close_oi_symmetry_after_one_side() {
     assert_eq!(engine.oi_eff_long_q, engine.oi_eff_short_q);
 
     // Force-close only account a (the long side)
-    engine.force_close_resolved_not_atomic(a, 100).unwrap();
+    engine.force_close_resolved_not_atomic(a, 100, 0).unwrap();
 
     // After force-closing one side, OI must stay symmetric so the
     // other side's users can still close normally.
@@ -2756,7 +2756,7 @@ fn test_force_close_oi_symmetry_after_one_side() {
         "OI must stay symmetric after force-closing one side");
 
     // b (short side) must be able to force-close without CorruptState
-    engine.force_close_resolved_not_atomic(b, 100).unwrap();
+    engine.force_close_resolved_not_atomic(b, 100, 0).unwrap();
     assert_eq!(engine.oi_eff_long_q, 0);
     assert_eq!(engine.oi_eff_short_q, 0);
     assert!(engine.check_conservation());
@@ -2773,7 +2773,7 @@ fn test_force_close_rejects_corrupt_a_basis() {
     engine.stored_pos_count_long = 1;
     engine.accounts[a as usize].adl_a_basis = 0;
 
-    let result = engine.force_close_resolved_not_atomic(a, 100);
+    let result = engine.force_close_resolved_not_atomic(a, 100, 0);
     assert_eq!(result, Err(RiskError::CorruptState),
         "must reject corrupt a_basis = 0");
 }


### PR DESCRIPTION
## Summary

`force_close_resolved_not_atomic` was the only `_not_atomic` public function (out of 8) that omitted the end-of-instruction lifecycle. This violated spec §5.7, §5.8, and §10.0.

**Without this fix:**
- Phantom OI dust is never cleared after force-closes
- Side-mode transitions (`DrainOnly` → `ResetPending` → `Normal`) never fire on resolved markets
- `r_last` (funding rate) is never persisted, leaving stale state

**Every other `_not_atomic` function calls all three lifecycle steps:**

| Function | `schedule` | `finalize` | `recompute_r_last` |
|----------|:---:|:---:|:---:|
| `withdraw_not_atomic` | ✓ | ✓ | ✓ |
| `settle_account_not_atomic` | ✓ | ✓ | ✓ |
| `execute_trade_not_atomic` | ✓ | ✓ | ✓ |
| `liquidate_at_oracle_not_atomic` | ✓ | ✓ | ✓ |
| `keeper_crank_not_atomic` | ✓ | ✓ | ✓ |
| `convert_released_pnl_not_atomic` | ✓ | ✓ | ✓ |
| `close_account_not_atomic` | ✓ | ✓ | ✓ |
| **`force_close_resolved_not_atomic`** | **✗** | **✗** | **✗** |

## Changes

**`src/percolator.rs`**
- Add `funding_rate: i64` parameter with `validate_funding_rate` guard at entry
- Create `InstructionContext` at function start
- Call `schedule_end_of_instruction_resets`, `finalize_end_of_instruction_resets`, `recompute_r_last_from_final_state` after `set_capital(i, 0)` but before `free_slot(idx)` — matching `close_account_not_atomic`'s exact pattern

**`tests/unit_tests.rs` + `tests/proofs_audit.rs`**
- Update all 28 call sites to pass `funding_rate = 0` (appropriate for resolved/frozen markets)

## Spec References

- §5.7 line 1042: *"`schedule_end_of_instruction_resets(ctx)` MUST be called exactly once at the end of each top-level instruction that can touch accounts, mutate side state, or liquidate."*
- §10.0 line 1431: Standard lifecycle applies unless explicitly excepted — `force_close_resolved` is not in the exception list
- §5.5 line 960: *"Each standard-lifecycle instruction MUST invoke `recompute_r_last_from_final_state(rate)` exactly once"*
- Code comment at line 1480: *"Callers that bypass `keeper_crank_not_atomic` (e.g. the resolved-market settlement crank) must invoke this before returning."*

## Test Plan

- [x] All 122 existing tests pass (`cargo test --features test`)
- [x] All force_close_resolved tests pass with lifecycle calls active
- [x] Conservation invariant (`V >= C_tot + I`) holds across all force_close tests
- [x] OI symmetry maintained after sequential force-closes
- [x] No regressions in any other test