### PR TITLE
fix: wrap raw i128/u128 fields in I128/U128 for cross-platform layout safety

### DIFF
--- a/src/percolator.rs
+++ b/src/percolator.rs
@@ -241,22 +241,22 @@ pub struct Account {
     pub kind: u8,  // 0 = User, 1 = LP (was AccountKind enum)
 
     /// Realized PnL (i128, spec §2.1)
-    pub pnl: i128,
+    pub pnl: I128,
 
     /// Reserved positive PnL (u128, spec §2.1)
-    pub reserved_pnl: u128,
+    pub reserved_pnl: U128,
 
     /// Signed fixed-point base quantity basis (i128, spec §2.1)
-    pub position_basis_q: i128,
+    pub position_basis_q: I128,
 
     /// Side multiplier snapshot at last explicit position attachment (u128)
-    pub adl_a_basis: u128,
+    pub adl_a_basis: U128,
 
     /// K coefficient snapshot (i128)
-    pub adl_k_snap: i128,
+    pub adl_k_snap: I128,
 
     /// Per-account funding snapshot at last attachment (v12.15)
-    pub f_snap: i128,
+    pub f_snap: I128,
 
     /// Side epoch snapshot
     pub adl_epoch_snap: u64,
@@ -274,14 +274,14 @@ pub struct Account {
     // ---- Two-bucket warmup reserve (spec §4.3) ----
     /// Scheduled reserve bucket (older, matures linearly)
     pub sched_present: u8,
-    pub sched_remaining_q: u128,
-    pub sched_anchor_q: u128,
+    pub sched_remaining_q: U128,
+    pub sched_anchor_q: U128,
     pub sched_start_slot: u64,
     pub sched_horizon: u64,
-    pub sched_release_q: u128,
+    pub sched_release_q: U128,
     /// Pending reserve bucket (newest, does not mature while pending)
     pub pending_present: u8,
-    pub pending_remaining_q: u128,
+    pub pending_remaining_q: U128,
     pub pending_horizon: u64,
     pub pending_created_slot: u64,
 }
@@ -303,25 +303,25 @@ fn empty_account() -> Account {
     Account {
         capital: U128::ZERO,
         kind: Account::KIND_USER,
-        pnl: 0i128,
-        reserved_pnl: 0u128,
-        position_basis_q: 0i128,
-        adl_a_basis: ADL_ONE,
-        adl_k_snap: 0i128,
-        f_snap: 0i128,
+        pnl: I128::ZERO,
+        reserved_pnl: U128::ZERO,
+        position_basis_q: I128::ZERO,
+        adl_a_basis: U128::new(ADL_ONE),
+        adl_k_snap: I128::ZERO,
+        f_snap: I128::ZERO,
         adl_epoch_snap: 0,
         matcher_program: [0; 32],
         matcher_context: [0; 32],
         owner: [0; 32],
         fee_credits: I128::ZERO,
         sched_present: 0,
-        sched_remaining_q: 0,
-        sched_anchor_q: 0,
+        sched_remaining_q: U128::ZERO,
+        sched_anchor_q: U128::ZERO,
         sched_start_slot: 0,
         sched_horizon: 0,
-        sched_release_q: 0,
+        sched_release_q: U128::ZERO,
         pending_present: 0,
-        pending_remaining_q: 0,
+        pending_remaining_q: U128::ZERO,
         pending_horizon: 0,
         pending_created_slot: 0,
     }
@@ -349,8 +349,8 @@ pub struct RiskParams {
     pub min_liquidation_abs: U128,
     pub min_initial_deposit: U128,
     /// Absolute nonzero-position margin floors (spec §9.1)
-    pub min_nonzero_mm_req: u128,
-    pub min_nonzero_im_req: u128,
+    pub min_nonzero_mm_req: U128,
+    pub min_nonzero_im_req: U128,
     /// Insurance fund floor (spec §1.4: 0 <= I_floor <= MAX_VAULT_TVL)
     pub insurance_floor: U128,
     /// Warmup horizon bounds (spec §6.1)
@@ -376,8 +376,8 @@ pub struct RiskEngine {
     pub resolved_slot: u64,
     /// Resolved terminal payout snapshot — locked after all positions zeroed.
     /// h_num/h_den frozen once, used for all terminal closes (order-invariant).
-    pub resolved_payout_h_num: u128,
-    pub resolved_payout_h_den: u128,
+    pub resolved_payout_h_num: U128,
+    pub resolved_payout_h_den: U128,
     pub resolved_payout_ready: u8, // 0 = not ready, 1 = snapshot locked
 
     // Keeper crank tracking
@@ -385,23 +385,23 @@ pub struct RiskEngine {
 
     // O(1) aggregates (spec §2.2)
     pub c_tot: U128,
-    pub pnl_pos_tot: u128,
-    pub pnl_matured_pos_tot: u128,
+    pub pnl_pos_tot: U128,
+    pub pnl_matured_pos_tot: U128,
 
     // Crank cursors
     pub gc_cursor: u16,
 
     // ADL side state (spec §2.2)
-    pub adl_mult_long: u128,
-    pub adl_mult_short: u128,
-    pub adl_coeff_long: i128,
-    pub adl_coeff_short: i128,
+    pub adl_mult_long: U128,
+    pub adl_mult_short: U128,
+    pub adl_coeff_long: I128,
+    pub adl_coeff_short: I128,
     pub adl_epoch_long: u64,
     pub adl_epoch_short: u64,
-    pub adl_epoch_start_k_long: i128,
-    pub adl_epoch_start_k_short: i128,
-    pub oi_eff_long_q: u128,
-    pub oi_eff_short_q: u128,
+    pub adl_epoch_start_k_long: I128,
+    pub adl_epoch_start_k_short: I128,
+    pub oi_eff_long_q: U128,
+    pub oi_eff_short_q: U128,
     pub side_mode_long: SideMode,
     pub side_mode_short: SideMode,
     pub stored_pos_count_long: u64,
@@ -410,8 +410,8 @@ pub struct RiskEngine {
     pub stale_account_count_short: u64,
 
     /// Dynamic phantom dust bounds (spec §4.6, §5.7)
-    pub phantom_dust_bound_long_q: u128,
-    pub phantom_dust_bound_short_q: u128,
+    pub phantom_dust_bound_long_q: U128,
+    pub phantom_dust_bound_short_q: U128,
 
     /// Materialized account count (spec §2.2)
     pub materialized_account_count: u64,
@@ -424,13 +424,13 @@ pub struct RiskEngine {
     /// Last slot used in accrue_market_to
     pub last_market_slot: u64,
     /// Cumulative funding numerator for long side (v12.15)
-    pub f_long_num: i128,
+    pub f_long_num: I128,
     /// Cumulative funding numerator for short side (v12.15)
-    pub f_short_num: i128,
+    pub f_short_num: I128,
     /// F snapshot at epoch start for long side (v12.15)
-    pub f_epoch_start_long_num: i128,
+    pub f_epoch_start_long_num: I128,
     /// F snapshot at epoch start for short side (v12.15)
-    pub f_epoch_start_short_num: i128,
+    pub f_epoch_start_short_num: I128,
 
 
     // Insurance floor is read from self.params.insurance_floor (no duplicate field)
@@ -585,15 +585,15 @@ impl RiskEngine {
 
         // Nonzero margin floor ordering: 0 < mm < im <= min_initial_deposit (spec §1.4)
         assert!(
-            params.min_nonzero_mm_req > 0,
+            params.min_nonzero_mm_req.get() > 0,
             "min_nonzero_mm_req must be > 0"
         );
         assert!(
-            params.min_nonzero_mm_req < params.min_nonzero_im_req,
+            params.min_nonzero_mm_req.get() < params.min_nonzero_im_req.get(),
             "min_nonzero_mm_req must be strictly less than min_nonzero_im_req"
         );
         assert!(
-            params.min_nonzero_im_req <= params.min_initial_deposit.get(),
+            params.min_nonzero_im_req.get() <= params.min_initial_deposit.get(),
             "min_nonzero_im_req must be <= min_initial_deposit (spec §1.4)"
         );
 
@@ -661,40 +661,40 @@ impl RiskEngine {
             market_mode: MarketMode::Live,
             resolved_price: 0,
             resolved_slot: 0,
-            resolved_payout_h_num: 0,
-            resolved_payout_h_den: 0,
+            resolved_payout_h_num: U128::ZERO,
+            resolved_payout_h_den: U128::ZERO,
             resolved_payout_ready: 0,
             last_crank_slot: 0,
             c_tot: U128::ZERO,
-            pnl_pos_tot: 0u128,
-            pnl_matured_pos_tot: 0u128,
+            pnl_pos_tot: U128::ZERO,
+            pnl_matured_pos_tot: U128::ZERO,
             gc_cursor: 0,
-            adl_mult_long: ADL_ONE,
-            adl_mult_short: ADL_ONE,
-            adl_coeff_long: 0i128,
-            adl_coeff_short: 0i128,
+            adl_mult_long: U128::new(ADL_ONE),
+            adl_mult_short: U128::new(ADL_ONE),
+            adl_coeff_long: I128::ZERO,
+            adl_coeff_short: I128::ZERO,
             adl_epoch_long: 0,
             adl_epoch_short: 0,
-            adl_epoch_start_k_long: 0i128,
-            adl_epoch_start_k_short: 0i128,
-            oi_eff_long_q: 0u128,
-            oi_eff_short_q: 0u128,
+            adl_epoch_start_k_long: I128::ZERO,
+            adl_epoch_start_k_short: I128::ZERO,
+            oi_eff_long_q: U128::ZERO,
+            oi_eff_short_q: U128::ZERO,
             side_mode_long: SideMode::Normal,
             side_mode_short: SideMode::Normal,
             stored_pos_count_long: 0,
             stored_pos_count_short: 0,
             stale_account_count_long: 0,
             stale_account_count_short: 0,
-            phantom_dust_bound_long_q: 0u128,
-            phantom_dust_bound_short_q: 0u128,
+            phantom_dust_bound_long_q: U128::ZERO,
+            phantom_dust_bound_short_q: U128::ZERO,
             materialized_account_count: 0,
             neg_pnl_account_count: 0,
             last_oracle_price: init_oracle_price,
             last_market_slot: init_slot,
-            f_long_num: 0,
-            f_short_num: 0,
-            f_epoch_start_long_num: 0,
-            f_epoch_start_short_num: 0,
+            f_long_num: I128::ZERO,
+            f_short_num: I128::ZERO,
+            f_epoch_start_long_num: I128::ZERO,
+            f_epoch_start_short_num: I128::ZERO,
             used: [0; BITMAP_WORDS],
             num_used_accounts: 0,
             free_head: 0,
@@ -725,40 +725,40 @@ impl RiskEngine {
         self.market_mode = MarketMode::Live;
         self.resolved_price = 0;
         self.resolved_slot = 0;
-        self.resolved_payout_h_num = 0;
-        self.resolved_payout_h_den = 0;
+        self.resolved_payout_h_num = U128::ZERO;
+        self.resolved_payout_h_den = U128::ZERO;
         self.resolved_payout_ready = 0;
         self.last_crank_slot = 0;
         self.c_tot = U128::ZERO;
-        self.pnl_pos_tot = 0;
-        self.pnl_matured_pos_tot = 0;
+        self.pnl_pos_tot = U128::ZERO;
+        self.pnl_matured_pos_tot = U128::ZERO;
         self.gc_cursor = 0;
-        self.adl_mult_long = ADL_ONE;
-        self.adl_mult_short = ADL_ONE;
-        self.adl_coeff_long = 0;
-        self.adl_coeff_short = 0;
+        self.adl_mult_long = U128::new(ADL_ONE);
+        self.adl_mult_short = U128::new(ADL_ONE);
+        self.adl_coeff_long = I128::ZERO;
+        self.adl_coeff_short = I128::ZERO;
         self.adl_epoch_long = 0;
         self.adl_epoch_short = 0;
-        self.adl_epoch_start_k_long = 0;
-        self.adl_epoch_start_k_short = 0;
-        self.oi_eff_long_q = 0;
-        self.oi_eff_short_q = 0;
+        self.adl_epoch_start_k_long = I128::ZERO;
+        self.adl_epoch_start_k_short = I128::ZERO;
+        self.oi_eff_long_q = U128::ZERO;
+        self.oi_eff_short_q = U128::ZERO;
         self.side_mode_long = SideMode::Normal;
         self.side_mode_short = SideMode::Normal;
         self.stored_pos_count_long = 0;
         self.stored_pos_count_short = 0;
         self.stale_account_count_long = 0;
         self.stale_account_count_short = 0;
-        self.phantom_dust_bound_long_q = 0;
-        self.phantom_dust_bound_short_q = 0;
+        self.phantom_dust_bound_long_q = U128::ZERO;
+        self.phantom_dust_bound_short_q = U128::ZERO;
         self.materialized_account_count = 0;
         self.neg_pnl_account_count = 0;
         self.last_oracle_price = init_oracle_price;
         self.last_market_slot = init_slot;
-        self.f_long_num = 0;
-        self.f_short_num = 0;
-        self.f_epoch_start_long_num = 0;
-        self.f_epoch_start_short_num = 0;
+        self.f_long_num = I128::ZERO;
+        self.f_short_num = I128::ZERO;
+        self.f_epoch_start_long_num = I128::ZERO;
+        self.f_epoch_start_short_num = I128::ZERO;
         // insurance_floor is now read directly from self.params.insurance_floor
         self.used = [0; BITMAP_WORDS];
         self.num_used_accounts = 0;
@@ -767,7 +767,7 @@ impl RiskEngine {
         // The slab is zero-initialized by SystemProgram.createAccount.
         // Only patch the non-zero field (adl_a_basis = ADL_ONE).
         for i in 0..MAX_ACCOUNTS {
-            self.accounts[i].adl_a_basis = ADL_ONE;
+            self.accounts[i].adl_a_basis = U128::new(ADL_ONE);
         }
         for i in 0..MAX_ACCOUNTS - 1 {
             self.next_free[i] = (i + 1) as u16;
@@ -834,7 +834,7 @@ impl RiskEngine {
     test_visible! {
     fn free_slot(&mut self, idx: u16) {
         // Track neg_pnl_account_count before zeroing (spec §4.7, v12.16.4)
-        if self.accounts[idx as usize].pnl < 0 {
+        if self.accounts[idx as usize].pnl.get() < 0 {
             self.neg_pnl_account_count = self.neg_pnl_account_count.checked_sub(1)
                 .expect("free_slot: neg_pnl_account_count underflow");
         }
@@ -842,25 +842,25 @@ impl RiskEngine {
         let a = &mut self.accounts[idx as usize];
         a.capital = U128::ZERO;
         a.kind = Account::KIND_USER;
-        a.pnl = 0;
-        a.reserved_pnl = 0;
-        a.position_basis_q = 0;
-        a.adl_a_basis = ADL_ONE;
-        a.adl_k_snap = 0;
-        a.f_snap = 0;
+        a.pnl = I128::ZERO;
+        a.reserved_pnl = U128::ZERO;
+        a.position_basis_q = I128::ZERO;
+        a.adl_a_basis = U128::new(ADL_ONE);
+        a.adl_k_snap = I128::ZERO;
+        a.f_snap = I128::ZERO;
         a.adl_epoch_snap = 0;
         a.matcher_program = [0; 32];
         a.matcher_context = [0; 32];
         a.owner = [0; 32];
         a.fee_credits = I128::ZERO;
         a.sched_present = 0;
-        a.sched_remaining_q = 0;
-        a.sched_anchor_q = 0;
+        a.sched_remaining_q = U128::ZERO;
+        a.sched_anchor_q = U128::ZERO;
         a.sched_start_slot = 0;
         a.sched_horizon = 0;
-        a.sched_release_q = 0;
+        a.sched_release_q = U128::ZERO;
         a.pending_present = 0;
-        a.pending_remaining_q = 0;
+        a.pending_remaining_q = U128::ZERO;
         a.pending_horizon = 0;
         a.pending_created_slot = 0;
         self.clear_used(idx as usize);
@@ -930,25 +930,25 @@ impl RiskEngine {
             let a = &mut self.accounts[idx as usize];
             a.kind = Account::KIND_USER;
             a.capital = U128::ZERO;
-            a.pnl = 0i128;
-            a.reserved_pnl = 0u128;
-            a.position_basis_q = 0i128;
-            a.adl_a_basis = ADL_ONE;
-            a.adl_k_snap = 0i128;
-            a.f_snap = 0i128;
+            a.pnl = I128::ZERO;
+            a.reserved_pnl = U128::ZERO;
+            a.position_basis_q = I128::ZERO;
+            a.adl_a_basis = U128::new(ADL_ONE);
+            a.adl_k_snap = I128::ZERO;
+            a.f_snap = I128::ZERO;
             a.adl_epoch_snap = 0;
             a.matcher_program = [0; 32];
             a.matcher_context = [0; 32];
             a.owner = [0; 32];
             a.fee_credits = I128::ZERO;
             a.sched_present = 0;
-            a.sched_remaining_q = 0;
-            a.sched_anchor_q = 0;
+            a.sched_remaining_q = U128::ZERO;
+            a.sched_anchor_q = U128::ZERO;
             a.sched_start_slot = 0;
             a.sched_horizon = 0;
-            a.sched_release_q = 0;
+            a.sched_release_q = U128::ZERO;
             a.pending_present = 0;
-            a.pending_remaining_q = 0;
+            a.pending_remaining_q = U128::ZERO;
             a.pending_horizon = 0;
             a.pending_created_slot = 0;
         }
@@ -977,12 +977,12 @@ impl RiskEngine {
     fn set_pnl_with_reserve(&mut self, idx: usize, new_pnl: i128, reserve_mode: ReserveMode) -> Result<()> {
         assert!(new_pnl != i128::MIN, "set_pnl_with_reserve: i128::MIN forbidden");
 
-        let old = self.accounts[idx].pnl;
+        let old = self.accounts[idx].pnl.get();
         let old_pos = i128_clamp_pos(old);
         let old_rel = if self.market_mode == MarketMode::Live {
-            old_pos - self.accounts[idx].reserved_pnl
+            old_pos - self.accounts[idx].reserved_pnl.get()
         } else {
-            assert!(self.accounts[idx].reserved_pnl == 0);
+            assert!(self.accounts[idx].reserved_pnl == U128::ZERO);
             old_pos
         };
         let new_pos = i128_clamp_pos(new_pnl);
@@ -999,7 +999,7 @@ impl RiskEngine {
             self.pnl_pos_tot = self.pnl_pos_tot.checked_sub(delta)
                 .expect("set_pnl_with_reserve: pnl_pos_tot underflow");
         }
-        assert!(self.pnl_pos_tot <= MAX_PNL_POS_TOT);
+        assert!(self.pnl_pos_tot.get() <= MAX_PNL_POS_TOT);
 
         if new_pos > old_pos {
             // Case A: positive increase
@@ -1012,7 +1012,7 @@ impl RiskEngine {
                 self.neg_pnl_account_count = self.neg_pnl_account_count.checked_add(1)
                     .expect("neg_pnl_account_count overflow");
             }
-            self.accounts[idx].pnl = new_pnl;
+            self.accounts[idx].pnl = I128::new(new_pnl);
 
             match reserve_mode {
                 ReserveMode::NoPositiveIncreaseAllowed => {
@@ -1045,7 +1045,7 @@ impl RiskEngine {
             // Case B: no positive increase
             let pos_loss = old_pos - new_pos;
             if self.market_mode == MarketMode::Live {
-                let reserve_loss = core::cmp::min(pos_loss, self.accounts[idx].reserved_pnl);
+                let reserve_loss = core::cmp::min(pos_loss, self.accounts[idx].reserved_pnl.get());
                 if reserve_loss > 0 {
                     self.apply_reserve_loss_newest_first(idx, reserve_loss);
                 }
@@ -1056,7 +1056,7 @@ impl RiskEngine {
                 }
             } else {
                 // Resolved: R_i must be 0
-                assert!(self.accounts[idx].reserved_pnl == 0);
+                assert!(self.accounts[idx].reserved_pnl == U128::ZERO);
                 if pos_loss > 0 {
                     self.pnl_matured_pos_tot = self.pnl_matured_pos_tot.checked_sub(pos_loss)
                         .expect("pnl_matured_pos_tot underflow (resolved)");
@@ -1070,11 +1070,11 @@ impl RiskEngine {
                 self.neg_pnl_account_count = self.neg_pnl_account_count.checked_add(1)
                     .expect("neg_pnl_account_count overflow");
             }
-            self.accounts[idx].pnl = new_pnl;
+            self.accounts[idx].pnl = I128::new(new_pnl);
 
             // Step 20: if new_pos == 0 and Live, require empty queue
             if new_pos == 0 && self.market_mode == MarketMode::Live {
-                assert!(self.accounts[idx].reserved_pnl == 0);
+                assert!(self.accounts[idx].reserved_pnl == U128::ZERO);
                 assert!(self.accounts[idx].sched_present == 0);
                 assert!(self.accounts[idx].pending_present == 0);
             }
@@ -1091,8 +1091,8 @@ impl RiskEngine {
     fn consume_released_pnl(&mut self, idx: usize, x: u128) {
         assert!(x > 0, "consume_released_pnl: x must be > 0");
 
-        let old_pos = i128_clamp_pos(self.accounts[idx].pnl);
-        let old_r = self.accounts[idx].reserved_pnl;
+        let old_pos = i128_clamp_pos(self.accounts[idx].pnl.get());
+        let old_r = self.accounts[idx].reserved_pnl.get();
         let old_rel = old_pos - old_r;
         assert!(x <= old_rel, "consume_released_pnl: x > ReleasedPos_i");
 
@@ -1112,10 +1112,10 @@ impl RiskEngine {
 
         // PNL_i = checked_sub_i128(PNL_i, checked_cast_i128(x))
         let x_i128: i128 = x.try_into().expect("consume_released_pnl: x > i128::MAX");
-        let new_pnl = self.accounts[idx].pnl.checked_sub(x_i128)
+        let new_pnl = self.accounts[idx].pnl.get().checked_sub(x_i128)
             .expect("consume_released_pnl: PNL underflow");
         assert!(new_pnl != i128::MIN, "consume_released_pnl: PNL == i128::MIN");
-        self.accounts[idx].pnl = new_pnl;
+        self.accounts[idx].pnl = I128::new(new_pnl);
         // R_i remains unchanged
     }
     }
@@ -1140,7 +1140,7 @@ impl RiskEngine {
     /// set_position_basis_q (spec §4.4): update stored pos counts based on sign changes
     test_visible! {
     fn set_position_basis_q(&mut self, idx: usize, new_basis: i128) {
-        let old = self.accounts[idx].position_basis_q;
+        let old = self.accounts[idx].position_basis_q.get();
         let old_side = side_of_i128(old);
         let new_side = side_of_i128(new_basis);
 
@@ -1176,7 +1176,7 @@ impl RiskEngine {
             }
         }
 
-        self.accounts[idx].position_basis_q = new_basis;
+        self.accounts[idx].position_basis_q = I128::new(new_basis);
     }
     }
 
@@ -1185,13 +1185,13 @@ impl RiskEngine {
     fn attach_effective_position(&mut self, idx: usize, new_eff_pos_q: i128) {
         // Before replacing a nonzero same-epoch basis, account for the fractional
         // remainder that will be orphaned (dynamic dust accounting).
-        let old_basis = self.accounts[idx].position_basis_q;
+        let old_basis = self.accounts[idx].position_basis_q.get();
         if old_basis != 0 {
             if let Some(old_side) = side_of_i128(old_basis) {
                 let epoch_snap = self.accounts[idx].adl_epoch_snap;
                 let epoch_side = self.get_epoch_side(old_side);
                 if epoch_snap == epoch_side {
-                    let a_basis = self.accounts[idx].adl_a_basis;
+                    let a_basis = self.accounts[idx].adl_a_basis.get();
                     if a_basis != 0 {
                         let a_side = self.get_a_side(old_side);
                         let abs_basis = old_basis.unsigned_abs();
@@ -1214,9 +1214,9 @@ impl RiskEngine {
         if new_eff_pos_q == 0 {
             self.set_position_basis_q(idx, 0i128);
             // Reset to canonical zero-position defaults (spec §2.4)
-            self.accounts[idx].adl_a_basis = ADL_ONE;
-            self.accounts[idx].adl_k_snap = 0i128;
-            self.accounts[idx].f_snap = 0i128;
+            self.accounts[idx].adl_a_basis = U128::new(ADL_ONE);
+            self.accounts[idx].adl_k_snap = I128::ZERO;
+            self.accounts[idx].f_snap = I128::ZERO;
             self.accounts[idx].adl_epoch_snap = 0;
         } else {
             // Spec §4.6: abs(new_eff_pos_q) <= MAX_POSITION_ABS_Q
@@ -1251,15 +1251,15 @@ impl RiskEngine {
 
     fn get_a_side(&self, s: Side) -> u128 {
         match s {
-            Side::Long => self.adl_mult_long,
-            Side::Short => self.adl_mult_short,
+            Side::Long => self.adl_mult_long.get(),
+            Side::Short => self.adl_mult_short.get(),
         }
     }
 
     fn get_k_side(&self, s: Side) -> i128 {
         match s {
-            Side::Long => self.adl_coeff_long,
-            Side::Short => self.adl_coeff_short,
+            Side::Long => self.adl_coeff_long.get(),
+            Side::Short => self.adl_coeff_short.get(),
         }
     }
 
@@ -1272,22 +1272,22 @@ impl RiskEngine {
 
     fn get_k_epoch_start(&self, s: Side) -> i128 {
         match s {
-            Side::Long => self.adl_epoch_start_k_long,
-            Side::Short => self.adl_epoch_start_k_short,
+            Side::Long => self.adl_epoch_start_k_long.get(),
+            Side::Short => self.adl_epoch_start_k_short.get(),
         }
     }
 
     fn get_f_side(&self, s: Side) -> i128 {
         match s {
-            Side::Long => self.f_long_num,
-            Side::Short => self.f_short_num,
+            Side::Long => self.f_long_num.get(),
+            Side::Short => self.f_short_num.get(),
         }
     }
 
     fn get_f_epoch_start(&self, s: Side) -> i128 {
         match s {
-            Side::Long => self.f_epoch_start_long_num,
-            Side::Short => self.f_epoch_start_short_num,
+            Side::Long => self.f_epoch_start_long_num.get(),
+            Side::Short => self.f_epoch_start_short_num.get(),
         }
     }
 
@@ -1300,15 +1300,15 @@ impl RiskEngine {
 
     fn get_oi_eff(&self, s: Side) -> u128 {
         match s {
-            Side::Long => self.oi_eff_long_q,
-            Side::Short => self.oi_eff_short_q,
+            Side::Long => self.oi_eff_long_q.get(),
+            Side::Short => self.oi_eff_short_q.get(),
         }
     }
 
     fn set_oi_eff(&mut self, s: Side, v: u128) {
         match s {
-            Side::Long => self.oi_eff_long_q = v,
-            Side::Short => self.oi_eff_short_q = v,
+            Side::Long => self.oi_eff_long_q = U128::new(v),
+            Side::Short => self.oi_eff_short_q = U128::new(v),
         }
     }
 
@@ -1321,15 +1321,15 @@ impl RiskEngine {
 
     fn set_a_side(&mut self, s: Side, v: u128) {
         match s {
-            Side::Long => self.adl_mult_long = v,
-            Side::Short => self.adl_mult_short = v,
+            Side::Long => self.adl_mult_long = U128::new(v),
+            Side::Short => self.adl_mult_short = U128::new(v),
         }
     }
 
     fn set_k_side(&mut self, s: Side, v: i128) {
         match s {
-            Side::Long => self.adl_coeff_long = v,
-            Side::Short => self.adl_coeff_short = v,
+            Side::Long => self.adl_coeff_long = I128::new(v),
+            Side::Short => self.adl_coeff_short = I128::new(v),
         }
     }
 
@@ -1426,7 +1426,7 @@ impl RiskEngine {
 
     /// Compute effective position quantity for account idx.
     pub fn effective_pos_q(&self, idx: usize) -> i128 {
-        let basis = self.accounts[idx].position_basis_q;
+        let basis = self.accounts[idx].position_basis_q.get();
         if basis == 0 {
             return 0i128;
         }
@@ -1441,7 +1441,7 @@ impl RiskEngine {
         }
 
         let a_side = self.get_a_side(side);
-        let a_basis = self.accounts[idx].adl_a_basis;
+        let a_basis = self.accounts[idx].adl_a_basis.get();
 
         if a_basis == 0 {
             return 0i128;
@@ -1468,13 +1468,13 @@ impl RiskEngine {
     /// through set_pnl_with_reserve with UseHLock for cohort queue.
     test_visible! {
     fn settle_side_effects_with_h_lock(&mut self, idx: usize, h_lock: u64) -> Result<()> {
-        let basis = self.accounts[idx].position_basis_q;
+        let basis = self.accounts[idx].position_basis_q.get();
         if basis == 0 { return Ok(()); }
 
         let side = side_of_i128(basis).unwrap();
         let epoch_snap = self.accounts[idx].adl_epoch_snap;
         let epoch_side = self.get_epoch_side(side);
-        let a_basis = self.accounts[idx].adl_a_basis;
+        let a_basis = self.accounts[idx].adl_a_basis.get();
         if a_basis == 0 { return Err(RiskError::CorruptState); }
         let abs_basis = basis.unsigned_abs();
 
@@ -1482,19 +1482,19 @@ impl RiskEngine {
             // Same epoch
             let a_side = self.get_a_side(side);
             let k_side = self.get_k_side(side);
-            let k_snap = self.accounts[idx].adl_k_snap;
+            let k_snap = self.accounts[idx].adl_k_snap.get();
             let q_eff_new = mul_div_floor_u128(abs_basis, a_side, a_basis);
             let den = a_basis.checked_mul(POS_SCALE).ok_or(RiskError::Overflow)?;
             let pnl_delta_k = wide_signed_mul_div_floor_from_k_pair(abs_basis, k_snap, k_side, den);
 
             // F-delta PnL (v12.15): floor(abs_basis * f_diff / (den * FUNDING_DEN))
             let f_side = self.get_f_side(side);
-            let f_snap = self.accounts[idx].f_snap;
+            let f_snap = self.accounts[idx].f_snap.get();
             let pnl_delta_f = Self::compute_f_pnl_delta(abs_basis, f_snap, f_side, den)?;
 
             let pnl_delta = pnl_delta_k.checked_add(pnl_delta_f).ok_or(RiskError::Overflow)?;
 
-            let new_pnl = self.accounts[idx].pnl.checked_add(pnl_delta)
+            let new_pnl = self.accounts[idx].pnl.get().checked_add(pnl_delta)
                 .ok_or(RiskError::Overflow)?;
             if new_pnl == i128::MIN { return Err(RiskError::Overflow); }
 
@@ -1503,13 +1503,13 @@ impl RiskEngine {
             if q_eff_new == 0 {
                 self.inc_phantom_dust_bound(side);
                 self.set_position_basis_q(idx, 0i128);
-                self.accounts[idx].adl_a_basis = ADL_ONE;
-                self.accounts[idx].adl_k_snap = 0i128;
-                self.accounts[idx].f_snap = 0i128;
+                self.accounts[idx].adl_a_basis = U128::new(ADL_ONE);
+                self.accounts[idx].adl_k_snap = I128::ZERO;
+                self.accounts[idx].f_snap = I128::ZERO;
                 self.accounts[idx].adl_epoch_snap = 0;
             } else {
-                self.accounts[idx].adl_k_snap = k_side;
-                self.accounts[idx].f_snap = f_side;
+                self.accounts[idx].adl_k_snap = I128::new(k_side);
+                self.accounts[idx].f_snap = I128::new(f_side);
                 self.accounts[idx].adl_epoch_snap = epoch_side;
             }
         } else {
@@ -1519,18 +1519,18 @@ impl RiskEngine {
             if epoch_snap.checked_add(1) != Some(epoch_side) { return Err(RiskError::CorruptState); }
 
             let k_epoch_start = self.get_k_epoch_start(side);
-            let k_snap = self.accounts[idx].adl_k_snap;
+            let k_snap = self.accounts[idx].adl_k_snap.get();
             let den = a_basis.checked_mul(POS_SCALE).ok_or(RiskError::Overflow)?;
             let pnl_delta_k = wide_signed_mul_div_floor_from_k_pair(abs_basis, k_snap, k_epoch_start, den);
 
             // F-delta PnL for epoch mismatch (v12.15)
             let f_end = self.get_f_epoch_start(side);
-            let f_snap = self.accounts[idx].f_snap;
+            let f_snap = self.accounts[idx].f_snap.get();
             let pnl_delta_f = Self::compute_f_pnl_delta(abs_basis, f_snap, f_end, den)?;
 
             let pnl_delta = pnl_delta_k.checked_add(pnl_delta_f).ok_or(RiskError::Overflow)?;
 
-            let new_pnl = self.accounts[idx].pnl.checked_add(pnl_delta)
+            let new_pnl = self.accounts[idx].pnl.get().checked_add(pnl_delta)
                 .ok_or(RiskError::Overflow)?;
             if new_pnl == i128::MIN { return Err(RiskError::Overflow); }
 
@@ -1541,9 +1541,9 @@ impl RiskEngine {
             self.set_pnl_with_reserve(idx, new_pnl, ReserveMode::UseHLock(h_lock))?;
             self.set_position_basis_q(idx, 0i128);
             self.set_stale_count(side, new_stale);
-            self.accounts[idx].adl_a_basis = ADL_ONE;
-            self.accounts[idx].adl_k_snap = 0i128;
-            self.accounts[idx].f_snap = 0i128;
+            self.accounts[idx].adl_a_basis = U128::new(ADL_ONE);
+            self.accounts[idx].adl_k_snap = I128::ZERO;
+            self.accounts[idx].f_snap = I128::ZERO;
             self.accounts[idx].adl_epoch_snap = 0;
         }
 
@@ -1578,8 +1578,8 @@ impl RiskEngine {
         }
 
         // Step 4: snapshot OI at start (fixed for all sub-steps per spec §5.4)
-        let long_live = self.oi_eff_long_q != 0;
-        let short_live = self.oi_eff_short_q != 0;
+        let long_live = self.oi_eff_long_q != U128::ZERO;
+        let short_live = self.oi_eff_short_q != U128::ZERO;
 
         let total_dt = now_slot.saturating_sub(self.last_market_slot);
         if total_dt == 0 && self.last_oracle_price == oracle_price {
@@ -1591,8 +1591,8 @@ impl RiskEngine {
         // Use scratch K values for the entire mark + funding computation.
         // Only commit to engine state after ALL computations succeed.
         // This prevents partial K advancement on mid-function errors.
-        let mut k_long = self.adl_coeff_long;
-        let mut k_short = self.adl_coeff_short;
+        let mut k_long = self.adl_coeff_long.get();
+        let mut k_short = self.adl_coeff_short.get();
 
         // Step 5: Mark-to-market (once, spec §1.5 item 21)
         let current_price = self.last_oracle_price;
@@ -1600,11 +1600,11 @@ impl RiskEngine {
             .ok_or(RiskError::Overflow)?;
         if delta_p != 0 {
             if long_live {
-                let dk = checked_u128_mul_i128(self.adl_mult_long, delta_p)?;
+                let dk = checked_u128_mul_i128(self.adl_mult_long.get(), delta_p)?;
                 k_long = k_long.checked_add(dk).ok_or(RiskError::Overflow)?;
             }
             if short_live {
-                let dk = checked_u128_mul_i128(self.adl_mult_short, delta_p)?;
+                let dk = checked_u128_mul_i128(self.adl_mult_short.get(), delta_p)?;
                 k_short = k_short.checked_sub(dk).ok_or(RiskError::Overflow)?;
             }
         }
@@ -1612,8 +1612,8 @@ impl RiskEngine {
         // Step 8: Funding transfer — one exact total delta (spec v12.16.5 §5.5).
         // fund_num_total = fund_px_0 * funding_rate_e9_per_slot * dt
         // computed in exact wide signed domain. No substep loop.
-        let mut f_long = self.f_long_num;
-        let mut f_short = self.f_short_num;
+        let mut f_long = self.f_long_num.get();
+        let mut f_short = self.f_short_num.get();
         if funding_rate_e9 != 0 && total_dt > 0 && long_live && short_live {
             let fund_px_0 = self.last_oracle_price;
 
@@ -1629,20 +1629,20 @@ impl RiskEngine {
                     .ok_or(RiskError::Overflow)?;
 
                 // F_long -= A_long * fund_num_total
-                let df_long = checked_u128_mul_i128(self.adl_mult_long, fund_num_total)?;
+                let df_long = checked_u128_mul_i128(self.adl_mult_long.get(), fund_num_total)?;
                 f_long = f_long.checked_sub(df_long).ok_or(RiskError::Overflow)?;
 
                 // F_short += A_short * fund_num_total
-                let df_short = checked_u128_mul_i128(self.adl_mult_short, fund_num_total)?;
+                let df_short = checked_u128_mul_i128(self.adl_mult_short.get(), fund_num_total)?;
                 f_short = f_short.checked_add(df_short).ok_or(RiskError::Overflow)?;
             }
         }
 
         // ALL computations succeeded — commit K/F values and synchronize state
-        self.adl_coeff_long = k_long;
-        self.adl_coeff_short = k_short;
-        self.f_long_num = f_long;
-        self.f_short_num = f_short;
+        self.adl_coeff_long = I128::new(k_long);
+        self.adl_coeff_short = I128::new(k_short);
+        self.f_long_num = I128::new(f_long);
+        self.f_short_num = I128::new(f_short);
         self.current_slot = now_slot;
         self.last_market_slot = now_slot;
         self.last_oracle_price = oracle_price;
@@ -1854,8 +1854,8 @@ impl RiskEngine {
         // K_epoch_start_side = K_side
         let k = self.get_k_side(side);
         match side {
-            Side::Long => self.adl_epoch_start_k_long = k,
-            Side::Short => self.adl_epoch_start_k_short = k,
+            Side::Long => self.adl_epoch_start_k_long = I128::new(k),
+            Side::Short => self.adl_epoch_start_k_short = I128::new(k),
         }
 
         // F_epoch_start_side = F_side (v12.15)
@@ -1881,8 +1881,8 @@ impl RiskEngine {
 
         // phantom_dust_bound_side_q = 0 (spec §2.5 step 6)
         match side {
-            Side::Long => self.phantom_dust_bound_long_q = 0u128,
-            Side::Short => self.phantom_dust_bound_short_q = 0u128,
+            Side::Long => self.phantom_dust_bound_long_q = U128::ZERO,
+            Side::Short => self.phantom_dust_bound_short_q = U128::ZERO,
         }
 
         // mode = ResetPending
@@ -1918,19 +1918,19 @@ impl RiskEngine {
         // §5.7.A: Bilateral-empty dust clearance
         if self.stored_pos_count_long == 0 && self.stored_pos_count_short == 0 {
             let clear_bound_q = self.phantom_dust_bound_long_q
-                .checked_add(self.phantom_dust_bound_short_q)
+                .checked_add(self.phantom_dust_bound_short_q.get())
                 .ok_or(RiskError::CorruptState)?;
-            let has_residual = self.oi_eff_long_q != 0
-                || self.oi_eff_short_q != 0
-                || self.phantom_dust_bound_long_q != 0
-                || self.phantom_dust_bound_short_q != 0;
+            let has_residual = self.oi_eff_long_q != U128::ZERO
+                || self.oi_eff_short_q != U128::ZERO
+                || self.phantom_dust_bound_long_q != U128::ZERO
+                || self.phantom_dust_bound_short_q != U128::ZERO;
             if has_residual {
                 if self.oi_eff_long_q != self.oi_eff_short_q {
                     return Err(RiskError::CorruptState);
                 }
                 if self.oi_eff_long_q <= clear_bound_q && self.oi_eff_short_q <= clear_bound_q {
-                    self.oi_eff_long_q = 0u128;
-                    self.oi_eff_short_q = 0u128;
+                    self.oi_eff_long_q = U128::ZERO;
+                    self.oi_eff_short_q = U128::ZERO;
                     ctx.pending_reset_long = true;
                     ctx.pending_reset_short = true;
                 } else {
@@ -1940,16 +1940,16 @@ impl RiskEngine {
         }
         // §5.7.B: Unilateral-empty long (long empty, short has positions)
         else if self.stored_pos_count_long == 0 && self.stored_pos_count_short > 0 {
-            let has_residual = self.oi_eff_long_q != 0
-                || self.oi_eff_short_q != 0
-                || self.phantom_dust_bound_long_q != 0;
+            let has_residual = self.oi_eff_long_q != U128::ZERO
+                || self.oi_eff_short_q != U128::ZERO
+                || self.phantom_dust_bound_long_q != U128::ZERO;
             if has_residual {
                 if self.oi_eff_long_q != self.oi_eff_short_q {
                     return Err(RiskError::CorruptState);
                 }
                 if self.oi_eff_long_q <= self.phantom_dust_bound_long_q {
-                    self.oi_eff_long_q = 0u128;
-                    self.oi_eff_short_q = 0u128;
+                    self.oi_eff_long_q = U128::ZERO;
+                    self.oi_eff_short_q = U128::ZERO;
                     ctx.pending_reset_long = true;
                     ctx.pending_reset_short = true;
                 } else {
@@ -1959,16 +1959,16 @@ impl RiskEngine {
         }
         // §5.7.C: Unilateral-empty short (short empty, long has positions)
         else if self.stored_pos_count_short == 0 && self.stored_pos_count_long > 0 {
-            let has_residual = self.oi_eff_long_q != 0
-                || self.oi_eff_short_q != 0
-                || self.phantom_dust_bound_short_q != 0;
+            let has_residual = self.oi_eff_long_q != U128::ZERO
+                || self.oi_eff_short_q != U128::ZERO
+                || self.phantom_dust_bound_short_q != U128::ZERO;
             if has_residual {
                 if self.oi_eff_long_q != self.oi_eff_short_q {
                     return Err(RiskError::CorruptState);
                 }
                 if self.oi_eff_short_q <= self.phantom_dust_bound_short_q {
-                    self.oi_eff_long_q = 0u128;
-                    self.oi_eff_short_q = 0u128;
+                    self.oi_eff_long_q = U128::ZERO;
+                    self.oi_eff_short_q = U128::ZERO;
                     ctx.pending_reset_long = true;
                     ctx.pending_reset_short = true;
                 } else {
@@ -1978,10 +1978,10 @@ impl RiskEngine {
         }
 
         // §5.7.D: DrainOnly sides with zero OI
-        if self.side_mode_long == SideMode::DrainOnly && self.oi_eff_long_q == 0 {
+        if self.side_mode_long == SideMode::DrainOnly && self.oi_eff_long_q == U128::ZERO {
             ctx.pending_reset_long = true;
         }
-        if self.side_mode_short == SideMode::DrainOnly && self.oi_eff_short_q == 0 {
+        if self.side_mode_short == SideMode::DrainOnly && self.oi_eff_short_q == U128::ZERO {
             ctx.pending_reset_short = true;
         }
 
@@ -2029,7 +2029,7 @@ impl RiskEngine {
     /// Compute haircut ratio (h_num, h_den) as u128 pair (spec §3.3)
     /// Uses pnl_matured_pos_tot as denominator per v12.14.0.
     pub fn haircut_ratio(&self) -> (u128, u128) {
-        if self.pnl_matured_pos_tot == 0 {
+        if self.pnl_matured_pos_tot == U128::ZERO {
             return (1u128, 1u128);
         }
         let senior_sum = self.c_tot.get().checked_add(self.insurance_fund.balance.get());
@@ -2043,8 +2043,9 @@ impl RiskEngine {
             }
             None => 0u128, // overflow in senior_sum → deficit
         };
-        let h_num = if residual < self.pnl_matured_pos_tot { residual } else { self.pnl_matured_pos_tot };
-        (h_num, self.pnl_matured_pos_tot)
+        let pnl_mat = self.pnl_matured_pos_tot.get();
+        let h_num = if residual < pnl_mat { residual } else { pnl_mat };
+        (h_num, pnl_mat)
     }
 
     /// PNL_eff_matured_i (spec §3.3): haircutted matured released positive PnL
@@ -2084,7 +2085,7 @@ impl RiskEngine {
     /// (§10.5 step 29). No saturation or clamping.
     pub fn account_equity_maint_raw_wide(&self, account: &Account) -> I256 {
         let cap = I256::from_u128(account.capital.get());
-        let pnl = I256::from_i128(account.pnl);
+        let pnl = I256::from_i128(account.pnl.get());
         let fee_debt = I256::from_u128(fee_debt_u128_checked(account.fee_credits.get()));
 
         // C + PNL - FeeDebt in exact I256 — cannot overflow 256 bits
@@ -2103,7 +2104,7 @@ impl RiskEngine {
     /// Returns i128. Negative overflow projected to i128::MIN + 1 per §3.4.
     pub fn account_equity_init_raw(&self, account: &Account, idx: usize) -> i128 {
         let cap = I256::from_u128(account.capital.get());
-        let neg_pnl = I256::from_i128(if account.pnl < 0 { account.pnl } else { 0i128 });
+        let neg_pnl = I256::from_i128(if account.pnl.get() < 0 { account.pnl.get() } else { 0i128 });
         let eff_matured = I256::from_u128(self.effective_matured_pnl(idx));
         let fee_debt = I256::from_u128(fee_debt_u128_checked(account.fee_credits.get()));
 
@@ -2134,7 +2135,7 @@ impl RiskEngine {
     /// not survive other accounts' subsequent conversions.
     pub fn account_equity_withdraw_raw(&self, account: &Account) -> i128 {
         let cap = account.capital.get() as i128;
-        let pnl_neg = core::cmp::min(account.pnl, 0);
+        let pnl_neg = core::cmp::min(account.pnl.get(), 0);
         let fee_debt = fee_debt_u128_checked(account.fee_credits.get()) as i128;
         cap.saturating_add(pnl_neg).saturating_sub(fee_debt)
     }
@@ -2159,7 +2160,7 @@ impl RiskEngine {
         }
         let not = self.notional(idx, oracle_price);
         let proportional = mul_div_floor_u128(not, self.params.maintenance_margin_bps as u128, 10_000);
-        let mm_req = core::cmp::max(proportional, self.params.min_nonzero_mm_req);
+        let mm_req = core::cmp::max(proportional, self.params.min_nonzero_mm_req.get());
         let mm_req_i128 = if mm_req > i128::MAX as u128 { i128::MAX } else { mm_req as i128 };
         eq_net > mm_req_i128
     }
@@ -2176,7 +2177,7 @@ impl RiskEngine {
         }
         let not = self.notional(idx, oracle_price);
         let proportional = mul_div_floor_u128(not, self.params.initial_margin_bps as u128, 10_000);
-        let im_req = core::cmp::max(proportional, self.params.min_nonzero_im_req);
+        let im_req = core::cmp::max(proportional, self.params.min_nonzero_im_req.get());
         let im_req_i128 = if im_req > i128::MAX as u128 { i128::MAX } else { im_req as i128 };
         eq_init_raw >= im_req_i128
     }
@@ -2194,17 +2195,17 @@ impl RiskEngine {
         // This allows unreleased reserved PnL to support the same account's
         // risk-increasing trades through the global haircut.
         // Only the candidate trade's own positive gain is neutralized.
-        let pos_pnl = i128_clamp_pos(account.pnl);
+        let pos_pnl = i128_clamp_pos(account.pnl.get());
         let pos_pnl_trade_open = pos_pnl.saturating_sub(trade_gain);
 
         // PNL_trade_open_i for loss component
-        let pnl_trade_open = account.pnl.checked_sub(trade_gain as i128)
+        let pnl_trade_open = account.pnl.get().checked_sub(trade_gain as i128)
             .unwrap_or(i128::MIN + 1);
 
         // Counterfactual global positive aggregate (using pnl_pos_tot, not matured)
-        let pnl_pos_tot_trade_open = self.pnl_pos_tot
+        let pnl_pos_tot_trade_open = self.pnl_pos_tot.get()
             .checked_sub(pos_pnl).unwrap_or(0)
-            .checked_add(pos_pnl_trade_open).unwrap_or(self.pnl_pos_tot);
+            .checked_add(pos_pnl_trade_open).unwrap_or(self.pnl_pos_tot.get());
 
         // Counterfactual trade haircut g
         let pnl_eff_trade_open = if pnl_pos_tot_trade_open == 0 {
@@ -2248,7 +2249,7 @@ impl RiskEngine {
         }
         let not = self.notional(idx, oracle_price);
         let proportional = mul_div_floor_u128(not, self.params.initial_margin_bps as u128, 10_000);
-        let im_req = core::cmp::max(proportional, self.params.min_nonzero_im_req);
+        let im_req = core::cmp::max(proportional, self.params.min_nonzero_im_req.get());
         let im_req_i128 = if im_req > i128::MAX as u128 { i128::MAX } else { im_req as i128 };
         eq >= im_req_i128
     }
@@ -2271,9 +2272,9 @@ impl RiskEngine {
 
     /// released_pos (spec §2.1): ReleasedPos_i = max(PNL_i, 0) - R_i
     pub fn released_pos(&self, idx: usize) -> u128 {
-        let pnl = self.accounts[idx].pnl;
+        let pnl = self.accounts[idx].pnl.get();
         let pos_pnl = i128_clamp_pos(pnl);
-        pos_pnl.saturating_sub(self.accounts[idx].reserved_pnl)
+        pos_pnl.saturating_sub(self.accounts[idx].reserved_pnl.get())
     }
 
     // ========================================================================
@@ -2292,9 +2293,9 @@ impl RiskEngine {
             a.sched_anchor_q = a.pending_remaining_q;
             a.sched_start_slot = now_slot;
             a.sched_horizon = a.pending_horizon;
-            a.sched_release_q = 0;
+            a.sched_release_q = U128::ZERO;
             a.pending_present = 0;
-            a.pending_remaining_q = 0;
+            a.pending_remaining_q = U128::ZERO;
             a.pending_horizon = 0;
             a.pending_created_slot = 0;
         }
@@ -2302,13 +2303,13 @@ impl RiskEngine {
         if a.sched_present == 0 {
             // Step 2: sched absent → create scheduled bucket
             a.sched_present = 1;
-            a.sched_remaining_q = reserve_add;
-            a.sched_anchor_q = reserve_add;
+            a.sched_remaining_q = U128::new(reserve_add);
+            a.sched_anchor_q = U128::new(reserve_add);
             a.sched_start_slot = now_slot;
             a.sched_horizon = h_lock;
-            a.sched_release_q = 0;
+            a.sched_release_q = U128::ZERO;
         } else if a.sched_present != 0 && a.pending_present == 0
-            && a.sched_start_slot == now_slot && a.sched_horizon == h_lock && a.sched_release_q == 0
+            && a.sched_start_slot == now_slot && a.sched_horizon == h_lock && a.sched_release_q == U128::ZERO
         {
             // Step 3: merge into scheduled (same slot, same horizon, not yet released)
             a.sched_remaining_q = a.sched_remaining_q.checked_add(reserve_add).expect("reserve overflow");
@@ -2316,7 +2317,7 @@ impl RiskEngine {
         } else if a.pending_present == 0 {
             // Step 4: create pending bucket
             a.pending_present = 1;
-            a.pending_remaining_q = reserve_add;
+            a.pending_remaining_q = U128::new(reserve_add);
             a.pending_horizon = h_lock;
             a.pending_created_slot = now_slot;
         } else {
@@ -2339,10 +2340,10 @@ impl RiskEngine {
 
         // Step 1: consume from pending first
         if a.pending_present != 0 && remaining > 0 {
-            let take = core::cmp::min(remaining, a.pending_remaining_q);
-            a.pending_remaining_q -= take;
+            let take = core::cmp::min(remaining, a.pending_remaining_q.get());
+            a.pending_remaining_q = U128::new(a.pending_remaining_q.get() - take);
             remaining -= take;
-            if a.pending_remaining_q == 0 {
+            if a.pending_remaining_q == U128::ZERO {
                 a.pending_present = 0;
                 a.pending_horizon = 0;
                 a.pending_created_slot = 0;
@@ -2351,15 +2352,15 @@ impl RiskEngine {
 
         // Step 2: consume from scheduled
         if a.sched_present != 0 && remaining > 0 {
-            let take = core::cmp::min(remaining, a.sched_remaining_q);
-            a.sched_remaining_q -= take;
+            let take = core::cmp::min(remaining, a.sched_remaining_q.get());
+            a.sched_remaining_q = U128::new(a.sched_remaining_q.get() - take);
             remaining -= take;
-            if a.sched_remaining_q == 0 {
+            if a.sched_remaining_q == U128::ZERO {
                 a.sched_present = 0;
-                a.sched_anchor_q = 0;
+                a.sched_anchor_q = U128::ZERO;
                 a.sched_start_slot = 0;
                 a.sched_horizon = 0;
-                a.sched_release_q = 0;
+                a.sched_release_q = U128::ZERO;
             }
         }
 
@@ -2377,18 +2378,18 @@ impl RiskEngine {
     test_visible! {
     fn prepare_account_for_resolved_touch(&mut self, idx: usize) {
         let a = &mut self.accounts[idx];
-        if a.reserved_pnl == 0 { return; }
+        if a.reserved_pnl == U128::ZERO { return; }
         a.sched_present = 0;
-        a.sched_remaining_q = 0;
-        a.sched_anchor_q = 0;
+        a.sched_remaining_q = U128::ZERO;
+        a.sched_anchor_q = U128::ZERO;
         a.sched_start_slot = 0;
         a.sched_horizon = 0;
-        a.sched_release_q = 0;
+        a.sched_release_q = U128::ZERO;
         a.pending_present = 0;
-        a.pending_remaining_q = 0;
+        a.pending_remaining_q = U128::ZERO;
         a.pending_horizon = 0;
         a.pending_created_slot = 0;
-        a.reserved_pnl = 0;
+        a.reserved_pnl = U128::ZERO;
         // Do NOT mutate PNL_matured_pos_tot (already set globally at resolve time)
     }
     }
@@ -2397,7 +2398,7 @@ impl RiskEngine {
     /// Releases reserve from the scheduled bucket per linear maturity.
     test_visible! {
     fn advance_profit_warmup(&mut self, idx: usize) {
-        let r = self.accounts[idx].reserved_pnl;
+        let r = self.accounts[idx].reserved_pnl.get();
         if r == 0 {
             // Require both absent
             assert!(self.accounts[idx].sched_present == 0);
@@ -2413,9 +2414,9 @@ impl RiskEngine {
             a.sched_anchor_q = a.pending_remaining_q;
             a.sched_start_slot = self.current_slot;
             a.sched_horizon = a.pending_horizon;
-            a.sched_release_q = 0;
+            a.sched_release_q = U128::ZERO;
             a.pending_present = 0;
-            a.pending_remaining_q = 0;
+            a.pending_remaining_q = U128::ZERO;
             a.pending_horizon = 0;
             a.pending_created_slot = 0;
         }
@@ -2431,38 +2432,38 @@ impl RiskEngine {
         // Step 5: sched_total = min(anchor, floor(anchor * elapsed / horizon))
         let a = &mut self.accounts[idx];
         let sched_total = if a.sched_horizon == 0 || elapsed >= a.sched_horizon as u128 {
-            a.sched_anchor_q
+            a.sched_anchor_q.get()
         } else {
-            mul_div_floor_u128(a.sched_anchor_q, elapsed, a.sched_horizon as u128)
+            mul_div_floor_u128(a.sched_anchor_q.get(), elapsed, a.sched_horizon as u128)
         };
 
         // Step 6: require sched_total >= sched_release_q
-        assert!(sched_total >= a.sched_release_q, "sched_total < sched_release_q");
+        assert!(sched_total >= a.sched_release_q.get(), "sched_total < sched_release_q");
 
         // Step 7: sched_increment
-        let sched_increment = sched_total - a.sched_release_q;
+        let sched_increment = sched_total - a.sched_release_q.get();
 
         // Step 8: release = min(remaining, increment)
-        let release = core::cmp::min(a.sched_remaining_q, sched_increment);
+        let release = core::cmp::min(a.sched_remaining_q.get(), sched_increment);
 
         // Step 9: if release > 0
         if release > 0 {
-            a.sched_remaining_q -= release;
-            a.reserved_pnl -= release;
+            a.sched_remaining_q = U128::new(a.sched_remaining_q.get() - release);
+            a.reserved_pnl = U128::new(a.reserved_pnl.get() - release);
             self.pnl_matured_pos_tot = self.pnl_matured_pos_tot.checked_add(release)
                 .expect("pnl_matured_pos_tot overflow");
         }
 
         // Step 10: sched_release_q = sched_total
-        self.accounts[idx].sched_release_q = sched_total;
+        self.accounts[idx].sched_release_q = U128::new(sched_total);
 
         // Step 11: if scheduled empty → clear, promote pending if present
-        if self.accounts[idx].sched_remaining_q == 0 {
+        if self.accounts[idx].sched_remaining_q == U128::ZERO {
             self.accounts[idx].sched_present = 0;
-            self.accounts[idx].sched_anchor_q = 0;
+            self.accounts[idx].sched_anchor_q = U128::ZERO;
             self.accounts[idx].sched_start_slot = 0;
             self.accounts[idx].sched_horizon = 0;
-            self.accounts[idx].sched_release_q = 0;
+            self.accounts[idx].sched_release_q = U128::ZERO;
 
             // Promote pending if present
             if self.accounts[idx].pending_present != 0 {
@@ -2472,16 +2473,16 @@ impl RiskEngine {
                 a.sched_anchor_q = a.pending_remaining_q;
                 a.sched_start_slot = self.current_slot;
                 a.sched_horizon = a.pending_horizon;
-                a.sched_release_q = 0;
+                a.sched_release_q = U128::ZERO;
                 a.pending_present = 0;
-                a.pending_remaining_q = 0;
+                a.pending_remaining_q = U128::ZERO;
                 a.pending_horizon = 0;
                 a.pending_created_slot = 0;
             }
         }
 
         // Step 12: if R_i == 0 → require both absent
-        if self.accounts[idx].reserved_pnl == 0 {
+        if self.accounts[idx].reserved_pnl == U128::ZERO {
             assert!(self.accounts[idx].sched_present == 0);
             assert!(self.accounts[idx].pending_present == 0);
         }
@@ -2497,7 +2498,7 @@ impl RiskEngine {
 
     /// settle_losses (spec §7.1): settle negative PnL from principal
     fn settle_losses(&mut self, idx: usize) {
-        let pnl = self.accounts[idx].pnl;
+        let pnl = self.accounts[idx].pnl.get();
         if pnl >= 0 {
             return;
         }
@@ -2521,7 +2522,7 @@ impl RiskEngine {
         if eff != 0 {
             return; // Not flat — must resolve through liquidation
         }
-        let pnl = self.accounts[idx].pnl;
+        let pnl = self.accounts[idx].pnl.get();
         if pnl < 0 {
             assert!(pnl != i128::MIN, "resolve_flat_negative: i128::MIN");
             let loss = pnl.unsigned_abs();
@@ -2582,7 +2583,7 @@ impl RiskEngine {
         self.settle_losses(idx);
 
         // Step 7: resolve flat negative
-        if self.effective_pos_q(idx) == 0 && self.accounts[idx].pnl < 0 {
+        if self.effective_pos_q(idx) == 0 && self.accounts[idx].pnl.get() < 0 {
             self.resolve_flat_negative(idx);
         }
 
@@ -2602,7 +2603,7 @@ impl RiskEngine {
         let residual = if self.vault.get() >= senior_sum {
             self.vault.get() - senior_sum
         } else { 0u128 };
-        let h_snapshot_den = self.pnl_matured_pos_tot;
+        let h_snapshot_den = self.pnl_matured_pos_tot.get();
         let h_snapshot_num = if h_snapshot_den == 0 { 0 } else {
             core::cmp::min(residual, h_snapshot_den)
         };
@@ -2625,8 +2626,8 @@ impl RiskEngine {
 
             // Whole-only flat auto-conversion
             if is_whole
-                && self.accounts[idx].position_basis_q == 0
-                && self.accounts[idx].pnl > 0
+                && self.accounts[idx].position_basis_q == I128::ZERO
+                && self.accounts[idx].pnl.get() > 0
             {
                 let released = self.released_pos(idx);
                 if released > 0 {
@@ -2714,25 +2715,25 @@ impl RiskEngine {
             let a = &mut self.accounts[idx as usize];
             a.kind = kind;
             a.capital = U128::new(excess);
-            a.pnl = 0i128;
-            a.reserved_pnl = 0u128;
-            a.position_basis_q = 0i128;
-            a.adl_a_basis = ADL_ONE;
-            a.adl_k_snap = 0i128;
-            a.f_snap = 0i128;
+            a.pnl = I128::ZERO;
+            a.reserved_pnl = U128::ZERO;
+            a.position_basis_q = I128::ZERO;
+            a.adl_a_basis = U128::new(ADL_ONE);
+            a.adl_k_snap = I128::ZERO;
+            a.f_snap = I128::ZERO;
             a.adl_epoch_snap = 0;
             a.matcher_program = matcher_program;
             a.matcher_context = matcher_context;
             a.owner = [0; 32];
             a.fee_credits = I128::ZERO;
             a.sched_present = 0;
-            a.sched_remaining_q = 0;
-            a.sched_anchor_q = 0;
+            a.sched_remaining_q = U128::ZERO;
+            a.sched_anchor_q = U128::ZERO;
             a.sched_start_slot = 0;
             a.sched_horizon = 0;
-            a.sched_release_q = 0;
+            a.sched_release_q = U128::ZERO;
             a.pending_present = 0;
-            a.pending_remaining_q = 0;
+            a.pending_remaining_q = U128::ZERO;
             a.pending_horizon = 0;
             a.pending_created_slot = 0;
         }
@@ -2829,8 +2830,8 @@ impl RiskEngine {
         // Step 9: if flat and PNL >= 0, sweep fee debt (spec §7.5)
         // Per spec §10.3: deposit into account with basis != 0 MUST defer.
         // Per spec §7.5: only a surviving negative PNL_i blocks the sweep.
-        if self.accounts[idx as usize].position_basis_q == 0
-            && self.accounts[idx as usize].pnl >= 0
+        if self.accounts[idx as usize].position_basis_q == I128::ZERO
+            && self.accounts[idx as usize].pnl.get() >= 0
         {
             self.fee_debt_sweep(idx as usize);
         }
@@ -2906,7 +2907,7 @@ impl RiskEngine {
             // notional floors to 0 for microscopic positions.
             let im_req = core::cmp::max(
                 mul_div_floor_u128(notional, self.params.initial_margin_bps as u128, 10_000),
-                self.params.min_nonzero_im_req,
+                self.params.min_nonzero_im_req.get(),
             );
             if eq_post < im_req as i128 {
                 return Err(RiskError::Undercollateralized);
@@ -3045,14 +3046,14 @@ impl RiskEngine {
             let not = self.notional(a as usize, oracle_price);
             core::cmp::max(
                     mul_div_floor_u128(not, self.params.maintenance_margin_bps as u128, 10_000),
-                    self.params.min_nonzero_mm_req
+                    self.params.min_nonzero_mm_req.get()
                 )
         };
         let mm_req_pre_b = if old_eff_b == 0 { 0u128 } else {
             let not = self.notional(b as usize, oracle_price);
             core::cmp::max(
                     mul_div_floor_u128(not, self.params.maintenance_margin_bps as u128, 10_000),
-                    self.params.min_nonzero_mm_req
+                    self.params.min_nonzero_mm_req.get()
                 )
         };
         let maint_raw_wide_pre_a = self.account_equity_maint_raw_wide(&self.accounts[a as usize]);
@@ -3101,11 +3102,11 @@ impl RiskEngine {
 
         // Reject if trade would increase OI on a blocked side
         if (self.side_mode_long == SideMode::DrainOnly || self.side_mode_long == SideMode::ResetPending)
-            && oi_long_after > self.oi_eff_long_q {
+            && oi_long_after > self.oi_eff_long_q.get() {
             return Err(RiskError::SideBlocked);
         }
         if (self.side_mode_short == SideMode::DrainOnly || self.side_mode_short == SideMode::ResetPending)
-            && oi_short_after > self.oi_eff_short_q {
+            && oi_short_after > self.oi_eff_short_q.get() {
             return Err(RiskError::SideBlocked);
         }
 
@@ -3114,11 +3115,11 @@ impl RiskEngine {
         let trade_pnl_a = compute_trade_pnl(size_q, price_diff)?;
         let trade_pnl_b = trade_pnl_a.checked_neg().ok_or(RiskError::Overflow)?;
 
-        let pnl_a = self.accounts[a as usize].pnl.checked_add(trade_pnl_a).ok_or(RiskError::Overflow)?;
+        let pnl_a = self.accounts[a as usize].pnl.get().checked_add(trade_pnl_a).ok_or(RiskError::Overflow)?;
         if pnl_a == i128::MIN { return Err(RiskError::Overflow); }
         self.set_pnl_with_reserve(a as usize, pnl_a, ReserveMode::UseHLock(h_lock))?;
 
-        let pnl_b = self.accounts[b as usize].pnl.checked_add(trade_pnl_b).ok_or(RiskError::Overflow)?;
+        let pnl_b = self.accounts[b as usize].pnl.get().checked_add(trade_pnl_b).ok_or(RiskError::Overflow)?;
         if pnl_b == i128::MIN { return Err(RiskError::Overflow); }
         self.set_pnl_with_reserve(b as usize, pnl_b, ReserveMode::UseHLock(h_lock))?;
 
@@ -3127,8 +3128,8 @@ impl RiskEngine {
         self.attach_effective_position(b as usize, new_eff_b);
 
         // Step 9: write pre-computed OI (same values from step 5, spec §5.2.2)
-        self.oi_eff_long_q = oi_long_after;
-        self.oi_eff_short_q = oi_short_after;
+        self.oi_eff_long_q = U128::new(oi_long_after);
+        self.oi_eff_short_q = U128::new(oi_short_after);
 
         // Step 10: settle post-trade losses from principal for both accounts (spec §10.4 step 18)
         // Loss seniority: losses MUST be settled before explicit fees (spec §0 item 14)
@@ -3162,10 +3163,10 @@ impl RiskEngine {
         }
 
         // Steps 25-26: flat-close PNL guard (spec §10.5)
-        if new_eff_a == 0 && self.accounts[a as usize].pnl < 0 {
+        if new_eff_a == 0 && self.accounts[a as usize].pnl.get() < 0 {
             return Err(RiskError::Undercollateralized);
         }
-        if new_eff_b == 0 && self.accounts[b as usize].pnl < 0 {
+        if new_eff_b == 0 && self.accounts[b as usize].pnl.get() < 0 {
             return Err(RiskError::Undercollateralized);
         }
 
@@ -3251,13 +3252,13 @@ impl RiskEngine {
         old_a: &i128, new_a: &i128,
         old_b: &i128, new_b: &i128,
     ) -> Result<(u128, u128)> {
-        let oi_long_after = self.oi_eff_long_q
+        let oi_long_after = self.oi_eff_long_q.get()
             .checked_sub(Self::oi_long_component(*old_a)).ok_or(RiskError::CorruptState)?
             .checked_sub(Self::oi_long_component(*old_b)).ok_or(RiskError::CorruptState)?
             .checked_add(Self::oi_long_component(*new_a)).ok_or(RiskError::Overflow)?
             .checked_add(Self::oi_long_component(*new_b)).ok_or(RiskError::Overflow)?;
 
-        let oi_short_after = self.oi_eff_short_q
+        let oi_short_after = self.oi_eff_short_q.get()
             .checked_sub(Self::oi_short_component(*old_a)).ok_or(RiskError::CorruptState)?
             .checked_sub(Self::oi_short_component(*old_b)).ok_or(RiskError::CorruptState)?
             .checked_add(Self::oi_short_component(*new_a)).ok_or(RiskError::Overflow)?
@@ -3347,7 +3348,7 @@ impl RiskEngine {
                 let not = self.notional(idx, oracle_price);
                 core::cmp::max(
                     mul_div_floor_u128(not, self.params.maintenance_margin_bps as u128, 10_000),
-                    self.params.min_nonzero_mm_req
+                    self.params.min_nonzero_mm_req.get()
                 )
             };
             let buffer_post_fee_neutral = maint_raw_fee_neutral.checked_sub(I256::from_u128(mm_req_post)).expect("I256 sub");
@@ -3359,7 +3360,7 @@ impl RiskEngine {
                 };
                 core::cmp::max(
                     mul_div_floor_u128(not_pre, self.params.maintenance_margin_bps as u128, 10_000),
-                    self.params.min_nonzero_mm_req
+                    self.params.min_nonzero_mm_req.get()
                 )
             };
             let maint_raw_pre = buffer_pre.checked_add(I256::from_u128(mm_req_pre)).expect("I256 add");
@@ -3545,8 +3546,8 @@ impl RiskEngine {
 
                 // Determine deficit D
                 let eff_post = self.effective_pos_q(idx as usize);
-                let d: u128 = if eff_post == 0 && self.accounts[idx as usize].pnl < 0 {
-                    assert!(self.accounts[idx as usize].pnl != i128::MIN, "liquidate: i128::MIN pnl");
+                let d: u128 = if eff_post == 0 && self.accounts[idx as usize].pnl.get() < 0 {
+                    assert!(self.accounts[idx as usize].pnl.get() != i128::MIN, "liquidate: i128::MIN pnl");
                     self.accounts[idx as usize].pnl.unsigned_abs()
                 } else {
                     0u128
@@ -3757,7 +3758,7 @@ impl RiskEngine {
                 let predicted_mm_req = if rem_eff == 0 {
                     0u128
                 } else {
-                    core::cmp::max(proportional_mm, self.params.min_nonzero_mm_req)
+                    core::cmp::max(proportional_mm, self.params.min_nonzero_mm_req.get())
                 };
 
                 // 4. Health check: predicted_eq > predicted_mm_req
@@ -3892,10 +3893,10 @@ impl RiskEngine {
 
         // PnL must be zero (check BEFORE fee forgiveness to avoid
         // mutating fee_credits on a path that returns Err)
-        if self.accounts[idx as usize].pnl > 0 {
+        if self.accounts[idx as usize].pnl.get() > 0 {
             return Err(RiskError::PnlNotWarmedUp);
         }
-        if self.accounts[idx as usize].pnl < 0 {
+        if self.accounts[idx as usize].pnl.get() < 0 {
             return Err(RiskError::Undercollateralized);
         }
 
@@ -3996,8 +3997,8 @@ impl RiskEngine {
         self.pnl_matured_pos_tot = self.pnl_pos_tot;
 
         // Steps 15-16: zero OI
-        self.oi_eff_long_q = 0;
-        self.oi_eff_short_q = 0;
+        self.oi_eff_long_q = U128::ZERO;
+        self.oi_eff_short_q = U128::ZERO;
 
         // Steps 17-20: drain/finalize sides
         if self.side_mode_long != SideMode::ResetPending {
@@ -4020,7 +4021,7 @@ impl RiskEngine {
         }
 
         // Step 21
-        assert!(self.oi_eff_long_q == 0 && self.oi_eff_short_q == 0);
+        assert!(self.oi_eff_long_q == U128::ZERO && self.oi_eff_short_q == U128::ZERO);
 
         Ok(())
     }
@@ -4038,7 +4039,7 @@ impl RiskEngine {
 
         // pnl <= 0: can close immediately (loser/zero — no payout gate)
         // pnl > 0: needs terminal readiness for payout
-        if self.accounts[i].pnl > 0 && !self.is_terminal_ready() {
+        if self.accounts[i].pnl.get() > 0 && !self.is_terminal_ready() {
             // Reconciled but not yet payable. Progress persisted.
             return Ok(ResolvedCloseResult::ProgressOnly);
         }
@@ -4064,13 +4065,13 @@ impl RiskEngine {
         self.current_slot = resolved_slot;
         let i = idx as usize;
 
-        if self.accounts[i].position_basis_q != 0 {
-            let basis = self.accounts[i].position_basis_q;
+        if self.accounts[i].position_basis_q != I128::ZERO {
+            let basis = self.accounts[i].position_basis_q.get();
             let abs_basis = basis.unsigned_abs();
-            let a_basis = self.accounts[i].adl_a_basis;
+            let a_basis = self.accounts[i].adl_a_basis.get();
             if a_basis == 0 { return Err(RiskError::CorruptState); }
-            let k_snap = self.accounts[i].adl_k_snap;
-            let f_snap_acct = self.accounts[i].f_snap;
+            let k_snap = self.accounts[i].adl_k_snap.get();
+            let f_snap_acct = self.accounts[i].f_snap.get();
             let side = side_of_i128(basis).unwrap();
             let epoch_snap = self.accounts[i].adl_epoch_snap;
             let epoch_side = self.get_epoch_side(side);
@@ -4084,7 +4085,7 @@ impl RiskEngine {
             let pnl_delta_k = wide_signed_mul_div_floor_from_k_pair(abs_basis, k_snap, k_end, den);
             let pnl_delta_f = Self::compute_f_pnl_delta(abs_basis, f_snap_acct, f_end, den)?;
             let pnl_delta = pnl_delta_k.checked_add(pnl_delta_f).ok_or(RiskError::Overflow)?;
-            let new_pnl = self.accounts[i].pnl.checked_add(pnl_delta)
+            let new_pnl = self.accounts[i].pnl.get().checked_add(pnl_delta)
                 .ok_or(RiskError::Overflow)?;
             if new_pnl == i128::MIN { return Err(RiskError::Overflow); }
 
@@ -4108,9 +4109,9 @@ impl RiskEngine {
                 self.set_stale_count(side, old - 1);
             }
             self.set_position_basis_q(i, 0);
-            self.accounts[i].adl_a_basis = ADL_ONE;
-            self.accounts[i].adl_k_snap = 0;
-            self.accounts[i].f_snap = 0;
+            self.accounts[i].adl_a_basis = U128::new(ADL_ONE);
+            self.accounts[i].adl_k_snap = I128::ZERO;
+            self.accounts[i].f_snap = I128::ZERO;
             self.accounts[i].adl_epoch_snap = 0;
         }
 
@@ -4145,14 +4146,14 @@ impl RiskEngine {
         }
         let i = idx as usize;
         // Reject unreconciled accounts: position must be zeroed, PnL >= 0
-        if self.accounts[i].position_basis_q != 0 {
+        if self.accounts[i].position_basis_q != I128::ZERO {
             return Err(RiskError::Undercollateralized);
         }
-        if self.accounts[i].pnl < 0 {
+        if self.accounts[i].pnl.get() < 0 {
             // Negative PnL means losses not yet absorbed — must reconcile first
             return Err(RiskError::Undercollateralized);
         }
-        if self.accounts[i].pnl > 0 {
+        if self.accounts[i].pnl.get() > 0 {
             if !self.is_terminal_ready() {
                 return Err(RiskError::Unauthorized);
             }
@@ -4162,21 +4163,21 @@ impl RiskEngine {
                     self.insurance_fund.balance.get()).unwrap_or(u128::MAX);
                 let residual = if self.vault.get() >= senior {
                     self.vault.get() - senior } else { 0u128 };
-                let h_den = self.pnl_matured_pos_tot;
+                let h_den = self.pnl_matured_pos_tot.get();
                 let h_num = if h_den == 0 { 0 } else {
                     core::cmp::min(residual, h_den) };
-                self.resolved_payout_h_num = h_num;
-                self.resolved_payout_h_den = h_den;
+                self.resolved_payout_h_num = U128::new(h_num);
+                self.resolved_payout_h_den = U128::new(h_den);
                 self.resolved_payout_ready = 1;
             }
             self.prepare_account_for_resolved_touch(i);
             let released = self.released_pos(i);
             if released > 0 {
                 // Spec forbids h_den==0 with positive released PnL when snapshot is ready.
-                assert!(self.resolved_payout_h_den > 0,
+                assert!(self.resolved_payout_h_den.get() > 0,
                     "resolved payout snapshot h_den must be > 0 with positive released PnL");
                 let y = wide_mul_div_floor_u128(released,
-                    self.resolved_payout_h_num, self.resolved_payout_h_den);
+                    self.resolved_payout_h_num.get(), self.resolved_payout_h_den.get());
                 self.consume_released_pnl(i, released);
                 let new_cap = add_u128(self.accounts[i].capital.get(), y);
                 self.set_capital(i, new_cap);
@@ -4214,13 +4215,13 @@ impl RiskEngine {
 
         // Step 3: Pre-realization flat-clean preconditions (spec §10.7 / §2.6)
         let account = &self.accounts[idx as usize];
-        if account.position_basis_q != 0 {
+        if account.position_basis_q != I128::ZERO {
             return Err(RiskError::Undercollateralized);
         }
-        if account.pnl != 0 {
+        if account.pnl.get() != 0 {
             return Err(RiskError::Undercollateralized);
         }
-        if account.reserved_pnl != 0 {
+        if account.reserved_pnl != U128::ZERO {
             return Err(RiskError::Undercollateralized);
         }
         // Require bucket metadata empty (not just reserved_pnl == 0)
@@ -4291,13 +4292,13 @@ impl RiskEngine {
             // Dust predicate: check flat-clean preconditions BEFORE fee realization
             // (matching reclaim_empty_account_not_atomic pattern — spec §8.2.3).
             let account = &self.accounts[idx];
-            if account.position_basis_q != 0 {
+            if account.position_basis_q != I128::ZERO {
                 continue;
             }
-            if account.pnl != 0 {
+            if account.pnl.get() != 0 {
                 continue;
             }
-            if account.reserved_pnl != 0 {
+            if account.reserved_pnl != U128::ZERO {
                 continue;
             }
             if account.sched_present != 0 || account.pending_present != 0 {
@@ -4435,16 +4436,16 @@ impl RiskEngine {
         }
         let i = idx as usize;
         // Flat only, reserve state empty
-        if self.accounts[i].position_basis_q != 0 {
+        if self.accounts[i].position_basis_q != I128::ZERO {
             return Err(RiskError::Undercollateralized);
         }
-        if self.accounts[i].reserved_pnl != 0
+        if self.accounts[i].reserved_pnl != U128::ZERO
             || self.accounts[i].sched_present != 0
             || self.accounts[i].pending_present != 0 {
             return Err(RiskError::Undercollateralized);
         }
         // Noop if PnL >= 0 (per spec §9.2.4)
-        if self.accounts[i].pnl >= 0 {
+        if self.accounts[i].pnl.get() >= 0 {
             return Ok(());
         }
 

--- a/tests/amm_tests.rs
+++ b/tests/amm_tests.rs
@@ -19,8 +19,8 @@ fn default_params() -> RiskParams {
         liquidation_fee_cap: U128::new(100_000),
         min_liquidation_abs: U128::new(0),
         min_initial_deposit: U128::new(2),
-        min_nonzero_mm_req: 1,
-        min_nonzero_im_req: 2,
+        min_nonzero_mm_req: U128::new(1),
+        min_nonzero_im_req: U128::new(2),
         insurance_floor: U128::ZERO,
         h_min: 0,
         h_max: 100,
@@ -103,7 +103,7 @@ fn test_e2e_complete_user_journey() {
 
     let alice_pnl = engine.accounts[alice as usize].pnl;
     // Long position + price up = positive PnL
-    assert!(alice_pnl > 0, "Alice should have positive PnL after price increase");
+    assert!(alice_pnl.get() > 0, "Alice should have positive PnL after price increase");
 
     // === Phase 3: PNL Warmup ===
 

--- a/tests/fuzzing.rs
+++ b/tests/fuzzing.rs
@@ -98,7 +98,7 @@ fn assert_global_invariants(engine: &RiskEngine, context: &str) {
         if is_account_used(engine, i as u16) {
             let acc = &engine.accounts[i];
             sum_capital += acc.capital.get();
-            let pnl = acc.pnl;
+            let pnl = acc.pnl.get();
             if pnl > 0 {
                 sum_pnl_pos += pnl as u128;
             }
@@ -113,11 +113,11 @@ fn assert_global_invariants(engine: &RiskEngine, context: &str) {
         sum_capital
     );
     assert_eq!(
-        engine.pnl_pos_tot,
+        engine.pnl_pos_tot.get(),
         sum_pnl_pos,
         "{}: pnl_pos_tot={} != sum(max(pnl,0))={}",
         context,
-        engine.pnl_pos_tot,
+        engine.pnl_pos_tot.get(),
         sum_pnl_pos
     );
 
@@ -127,14 +127,14 @@ fn assert_global_invariants(engine: &RiskEngine, context: &str) {
             let acc = &engine.accounts[i];
 
             // reserved_pnl <= max(0, pnl)
-            let pnl = acc.pnl;
+            let pnl = acc.pnl.get();
             let positive_pnl = if pnl > 0 { pnl as u128 } else { 0 };
             assert!(
-                acc.reserved_pnl <= positive_pnl,
+                acc.reserved_pnl.get() <= positive_pnl,
                 "{}: Account {} has reserved_pnl={} > positive_pnl={}",
                 context,
                 i,
-                acc.reserved_pnl,
+                acc.reserved_pnl.get(),
                 positive_pnl
             );
         }
@@ -158,8 +158,8 @@ fn params_regime_a() -> RiskParams {
         liquidation_fee_cap: U128::new(100_000),
         min_liquidation_abs: U128::new(100_000),
         min_initial_deposit: U128::new(2),
-        min_nonzero_mm_req: 1,
-        min_nonzero_im_req: 2,
+        min_nonzero_mm_req: U128::new(1),
+        min_nonzero_im_req: U128::new(2),
         insurance_floor: U128::ZERO,
         h_min: 0,
         h_max: 100,
@@ -180,8 +180,8 @@ fn params_regime_b() -> RiskParams {
         liquidation_fee_cap: U128::new(100_000),
         min_liquidation_abs: U128::new(100_000),
         min_initial_deposit: U128::new(1000),
-        min_nonzero_mm_req: 1,
-        min_nonzero_im_req: 2,
+        min_nonzero_mm_req: U128::new(1),
+        min_nonzero_im_req: U128::new(2),
         insurance_floor: U128::ZERO,
         h_min: 0,
         h_max: 100,

--- a/tests/proofs_arithmetic.rs
+++ b/tests/proofs_arithmetic.rs
@@ -241,14 +241,14 @@ fn proof_notional_scales_with_price() {
     // Give the account a non-zero position
     let q_mul: u8 = kani::any();
     kani::assume(q_mul > 0 && q_mul <= 10);
-    engine.accounts[idx as usize].position_basis_q = (POS_SCALE * (q_mul as u128)) as i128;
-    engine.accounts[idx as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[idx as usize].adl_k_snap = 0i128;
+    engine.accounts[idx as usize].position_basis_q = I128::new((POS_SCALE * (q_mul as u128)) as i128);
+    engine.accounts[idx as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[idx as usize].adl_k_snap = I128::ZERO;
     engine.accounts[idx as usize].adl_epoch_snap = 0;
     engine.adl_epoch_long = 0;
-    engine.adl_mult_long = ADL_ONE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
     engine.stored_pos_count_long = 1;
-    engine.oi_eff_long_q = POS_SCALE * (q_mul as u128);
+    engine.oi_eff_long_q = U128::new(POS_SCALE * (q_mul as u128));
 
     let p1: u8 = kani::any();
     let p2: u8 = kani::any();

--- a/tests/proofs_audit.rs
+++ b/tests/proofs_audit.rs
@@ -41,8 +41,8 @@ fn proof_epoch_snap_zero_on_position_zeroout() {
     // Set epoch mismatch to skip the phantom dust U256 path
     // (irrelevant to the epoch_snap fix).
     engine.set_position_basis_q(idx, signed_basis);
-    engine.accounts[idx].adl_a_basis = ADL_ONE;
-    engine.accounts[idx].adl_k_snap = 0;
+    engine.accounts[idx].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[idx].adl_k_snap = I128::ZERO;
     // Epoch mismatch: snap=0 != epoch_long=5 / epoch_short=7
     engine.accounts[idx].adl_epoch_snap = 0;
 
@@ -50,9 +50,9 @@ fn proof_epoch_snap_zero_on_position_zeroout() {
     engine.attach_effective_position(idx, 0);
 
     // Spec §2.4: all canonical zero-position defaults
-    assert!(engine.accounts[idx].position_basis_q == 0, "basis must be zero");
-    assert!(engine.accounts[idx].adl_a_basis == ADL_ONE, "a_basis must be ADL_ONE");
-    assert!(engine.accounts[idx].adl_k_snap == 0, "k_snap must be zero");
+    assert!(engine.accounts[idx].position_basis_q.get() == 0, "basis must be zero");
+    assert!(engine.accounts[idx].adl_a_basis == U128::new(ADL_ONE), "a_basis must be ADL_ONE");
+    assert!(engine.accounts[idx].adl_k_snap.get() == 0, "k_snap must be zero");
     assert!(engine.accounts[idx].adl_epoch_snap == 0, "epoch_snap must be zero per §2.4");
 }
 
@@ -390,7 +390,7 @@ fn proof_close_account_pnl_check_before_fee_forgive() {
     // Use set_pnl to keep pnl_pos_tot in sync
     engine.set_pnl(idx as usize, 5000i128);
     // All PnL is reserved (warmup not complete)
-    engine.accounts[idx as usize].reserved_pnl = 5000;
+    engine.accounts[idx as usize].reserved_pnl = U128::new(5000);
     // Zero capital — fee_debt_sweep will be a no-op
     // (capital is already 0 from add_user with fee=0)
 
@@ -440,7 +440,7 @@ fn proof_settle_epoch_snap_zero_on_truncation() {
     // The simplest way: directly manipulate adl_mult_long to 0 (below MIN_A_SIDE).
     // But that's invalid. Instead, set a very small a_mult to make floor(basis * a / a_basis) = 0.
     // With basis=1, a_basis=ADL_ONE=1_000_000, if a_mult < 1_000_000 the floor gives 0.
-    engine.adl_mult_long = 1; // Very small — floor(1 * 1 / 1_000_000) = 0
+    engine.adl_mult_long = U128::new(1); // Very small — floor(1 * 1 / 1_000_000) = 0
 
     // Now touch the account — settle_side_effects should zero the position
     {
@@ -452,7 +452,7 @@ fn proof_settle_epoch_snap_zero_on_truncation() {
     }
 
     // If position was zeroed, epoch_snap must be 0 per §2.4
-    if engine.accounts[a as usize].position_basis_q == 0 {
+    if engine.accounts[a as usize].position_basis_q.get() == 0 {
         assert!(
             engine.accounts[a as usize].adl_epoch_snap == 0,
             "epoch_snap must be 0 on settle zero-out per §2.4"
@@ -980,7 +980,7 @@ fn proof_force_close_resolved_position_conservation() {
     let result = engine.close_resolved_terminal_not_atomic(a);
     assert!(result.is_ok());
     assert!(!engine.is_used(a as usize));
-    assert!(engine.accounts[a as usize].position_basis_q == 0);
+    assert!(engine.accounts[a as usize].position_basis_q.get() == 0);
     assert!(engine.check_conservation(),
         "V >= C_tot + I must hold after resolved close");
 }

--- a/tests/proofs_checklist.rs
+++ b/tests/proofs_checklist.rs
@@ -23,8 +23,8 @@ fn proof_a2_reserve_bounds_after_set_pnl() {
     kani::assume(init_pnl >= -100_000 && init_pnl <= 100_000);
     engine.set_pnl(idx as usize, init_pnl);
 
-    let r1 = engine.accounts[idx as usize].reserved_pnl;
-    let pos1 = core::cmp::max(engine.accounts[idx as usize].pnl, 0) as u128;
+    let r1 = engine.accounts[idx as usize].reserved_pnl.get();
+    let pos1 = core::cmp::max(engine.accounts[idx as usize].pnl.get(), 0) as u128;
     assert!(r1 <= pos1, "A2: R_i <= max(PNL_i,0) after first set");
 
     let new_pnl: i128 = kani::any();
@@ -33,8 +33,8 @@ fn proof_a2_reserve_bounds_after_set_pnl() {
     kani::assume(new_pnl <= MAX_ACCOUNT_POSITIVE_PNL as i128 || new_pnl <= 0);
     engine.set_pnl(idx as usize, new_pnl);
 
-    let r2 = engine.accounts[idx as usize].reserved_pnl;
-    let pos2 = core::cmp::max(engine.accounts[idx as usize].pnl, 0) as u128;
+    let r2 = engine.accounts[idx as usize].reserved_pnl.get();
+    let pos2 = core::cmp::max(engine.accounts[idx as usize].pnl.get(), 0) as u128;
     assert!(r2 <= pos2, "A2: R_i <= max(PNL_i,0) after transition");
 
     kani::cover!(init_pnl > 0 && new_pnl > init_pnl, "positive increase");
@@ -481,9 +481,9 @@ fn proof_two_bucket_reserve_sum_after_append() {
 
     // R_i must equal sum of both buckets
     let a = &engine.accounts[idx as usize];
-    let sched_r = if a.sched_present != 0 { a.sched_remaining_q } else { 0 };
-    let pend_r = if a.pending_present != 0 { a.pending_remaining_q } else { 0 };
-    assert_eq!(a.reserved_pnl, sched_r + pend_r,
+    let sched_r = if a.sched_present != 0 { a.sched_remaining_q.get() } else { 0 };
+    let pend_r = if a.pending_present != 0 { a.pending_remaining_q.get() } else { 0 };
+    assert_eq!(a.reserved_pnl.get(), sched_r + pend_r,
         "R_i must equal sched + pending");
 
     kani::cover!(a.sched_present != 0 && a.pending_present != 0, "both buckets present");
@@ -499,8 +499,8 @@ fn proof_two_bucket_loss_newest_first() {
     engine.deposit(idx, 1_000_000, DEFAULT_ORACLE, DEFAULT_SLOT).unwrap();
 
     // Create sched + pending
-    engine.accounts[idx as usize].pnl = 30_000;
-    engine.pnl_pos_tot = 30_000;
+    engine.accounts[idx as usize].pnl = I128::new(30_000);
+    engine.pnl_pos_tot = U128::new(30_000);
     engine.append_or_route_new_reserve(idx as usize, 10_000, DEFAULT_SLOT, 10);
     engine.append_or_route_new_reserve(idx as usize, 20_000, DEFAULT_SLOT + 1, 10);
 
@@ -533,17 +533,17 @@ fn proof_two_bucket_scheduled_timing() {
     let h: u64 = kani::any();
     kani::assume(h >= 1 && h <= 20);
 
-    engine.accounts[idx as usize].pnl = anchor as i128;
-    engine.pnl_pos_tot = anchor;
+    engine.accounts[idx as usize].pnl = I128::new(anchor as i128);
+    engine.pnl_pos_tot = U128::new(anchor);
     engine.append_or_route_new_reserve(idx as usize, anchor, DEFAULT_SLOT, h);
 
     let dt: u64 = kani::any();
     kani::assume(dt >= 1 && dt <= 40);
     engine.current_slot = DEFAULT_SLOT + dt;
 
-    let r_before = engine.accounts[idx as usize].reserved_pnl;
+    let r_before = engine.accounts[idx as usize].reserved_pnl.get();
     engine.advance_profit_warmup(idx as usize);
-    let released = r_before - engine.accounts[idx as usize].reserved_pnl;
+    let released = r_before - engine.accounts[idx as usize].reserved_pnl.get();
 
     let expected = if dt as u128 >= h as u128 { anchor }
         else { mul_div_floor_u128(anchor, dt as u128, h as u128) };
@@ -563,8 +563,8 @@ fn proof_two_bucket_pending_non_maturity() {
     engine.deposit(idx, 1_000_000, DEFAULT_ORACLE, DEFAULT_SLOT).unwrap();
 
     // Create sched + pending
-    engine.accounts[idx as usize].pnl = 30_000;
-    engine.pnl_pos_tot = 30_000;
+    engine.accounts[idx as usize].pnl = I128::new(30_000);
+    engine.pnl_pos_tot = U128::new(30_000);
     engine.append_or_route_new_reserve(idx as usize, 10_000, DEFAULT_SLOT, 10);
     engine.append_or_route_new_reserve(idx as usize, 20_000, DEFAULT_SLOT + 1, 10);
 

--- a/tests/proofs_instructions.rs
+++ b/tests/proofs_instructions.rs
@@ -26,19 +26,19 @@ fn t3_16_reset_pending_counter_invariant() {
     let k_val: i8 = kani::any();
     let k = k_val as i128;
 
-    engine.accounts[a as usize].position_basis_q = POS_SCALE as i128;
-    engine.accounts[a as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[a as usize].adl_k_snap = k;
+    engine.accounts[a as usize].position_basis_q = I128::new(POS_SCALE as i128);
+    engine.accounts[a as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[a as usize].adl_k_snap = I128::new(k);
     engine.accounts[a as usize].adl_epoch_snap = 0;
-    engine.accounts[b as usize].position_basis_q = POS_SCALE as i128;
-    engine.accounts[b as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[b as usize].adl_k_snap = k;
+    engine.accounts[b as usize].position_basis_q = I128::new(POS_SCALE as i128);
+    engine.accounts[b as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[b as usize].adl_k_snap = I128::new(k);
     engine.accounts[b as usize].adl_epoch_snap = 0;
     engine.stored_pos_count_long = 2;
 
-    engine.adl_coeff_long = k;
+    engine.adl_coeff_long = I128::new(k);
 
-    engine.oi_eff_long_q = 0u128;
+    engine.oi_eff_long_q = U128::ZERO;
     engine.begin_full_drain_reset(Side::Long);
 
     assert!(engine.side_mode_long == SideMode::ResetPending);
@@ -64,25 +64,25 @@ fn t3_16b_reset_counter_with_nonzero_k_diff() {
 
     let k_snap = 0i128;
 
-    engine.accounts[a as usize].position_basis_q = POS_SCALE as i128;
-    engine.accounts[a as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[a as usize].adl_k_snap = k_snap;
+    engine.accounts[a as usize].position_basis_q = I128::new(POS_SCALE as i128);
+    engine.accounts[a as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[a as usize].adl_k_snap = I128::new(k_snap);
     engine.accounts[a as usize].adl_epoch_snap = 0;
-    engine.accounts[b as usize].position_basis_q = POS_SCALE as i128;
-    engine.accounts[b as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[b as usize].adl_k_snap = k_snap;
+    engine.accounts[b as usize].position_basis_q = I128::new(POS_SCALE as i128);
+    engine.accounts[b as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[b as usize].adl_k_snap = I128::new(k_snap);
     engine.accounts[b as usize].adl_epoch_snap = 0;
     engine.stored_pos_count_long = 2;
 
     let k_diff_val: i8 = kani::any();
     kani::assume(k_diff_val != 0);
     let k_long = k_diff_val as i128;
-    engine.adl_coeff_long = k_long;
+    engine.adl_coeff_long = I128::new(k_long);
 
-    engine.oi_eff_long_q = 0u128;
+    engine.oi_eff_long_q = U128::ZERO;
     engine.begin_full_drain_reset(Side::Long);
 
-    assert!(engine.adl_epoch_start_k_long == k_long);
+    assert!(engine.adl_epoch_start_k_long == I128::new(k_long));
     assert!(engine.stale_account_count_long == 2);
 
     let _ = engine.settle_side_effects_with_h_lock(a as usize, 0);
@@ -100,10 +100,10 @@ fn t3_17_clean_empty_engine_no_retrigger() {
 
     assert!(engine.stored_pos_count_long == 0);
     assert!(engine.stored_pos_count_short == 0);
-    assert!(engine.oi_eff_long_q == 0);
-    assert!(engine.oi_eff_short_q == 0);
-    assert!(engine.phantom_dust_bound_long_q == 0);
-    assert!(engine.phantom_dust_bound_short_q == 0);
+    assert!(engine.oi_eff_long_q.get() == 0);
+    assert!(engine.oi_eff_short_q.get() == 0);
+    assert!(engine.phantom_dust_bound_long_q.get() == 0);
+    assert!(engine.phantom_dust_bound_short_q.get() == 0);
 
     let result = engine.schedule_end_of_instruction_resets(&mut ctx);
     assert!(result.is_ok());
@@ -118,12 +118,12 @@ fn t3_17_clean_empty_engine_no_retrigger() {
 fn t3_18_dust_bound_reset_in_begin_full_drain() {
     let mut engine = RiskEngine::new(zero_fee_params());
 
-    engine.phantom_dust_bound_long_q = 5u128;
-    engine.oi_eff_long_q = 0u128;
+    engine.phantom_dust_bound_long_q = U128::new(5u128);
+    engine.oi_eff_long_q = U128::ZERO;
 
     engine.begin_full_drain_reset(Side::Long);
 
-    assert!(engine.phantom_dust_bound_long_q == 0,
+    assert!(engine.phantom_dust_bound_long_q.get() == 0,
         "phantom_dust_bound must be zeroed by begin_full_drain_reset");
 }
 
@@ -134,7 +134,7 @@ fn t3_19_finalize_side_reset_requires_all_stale_touched() {
     let mut engine = RiskEngine::new(zero_fee_params());
 
     engine.side_mode_long = SideMode::ResetPending;
-    engine.oi_eff_long_q = 0u128;
+    engine.oi_eff_long_q = U128::ZERO;
     engine.stale_account_count_long = 1;
     engine.stored_pos_count_long = 0;
     let result1 = engine.finalize_side_reset(Side::Long);
@@ -159,25 +159,25 @@ fn t6_26b_full_drain_reset_nonzero_k_diff() {
     let idx = engine.add_user(0).unwrap();
     engine.deposit(idx, 10_000_000, 100, 0).unwrap();
 
-    engine.accounts[idx as usize].position_basis_q = POS_SCALE as i128;
-    engine.accounts[idx as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[idx as usize].adl_k_snap = 0i128;
+    engine.accounts[idx as usize].position_basis_q = I128::new(POS_SCALE as i128);
+    engine.accounts[idx as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[idx as usize].adl_k_snap = I128::ZERO;
     engine.accounts[idx as usize].adl_epoch_snap = 0;
     engine.stored_pos_count_long = 1;
 
-    engine.adl_coeff_long = 500i128;
+    engine.adl_coeff_long = I128::new(500i128);
 
-    engine.oi_eff_long_q = 0u128;
+    engine.oi_eff_long_q = U128::ZERO;
     engine.begin_full_drain_reset(Side::Long);
 
-    assert!(engine.adl_epoch_start_k_long == 500i128);
+    assert!(engine.adl_epoch_start_k_long == I128::new(500i128));
     assert!(engine.adl_epoch_long == 1);
     assert!(engine.stale_account_count_long == 1);
 
     let result = engine.settle_side_effects_with_h_lock(idx as usize, 0);
     assert!(result.is_ok());
 
-    assert!(engine.accounts[idx as usize].position_basis_q == 0);
+    assert!(engine.accounts[idx as usize].position_basis_q.get() == 0);
     assert!(engine.stale_account_count_long == 0);
     // Canonical zero-position defaults: epoch_snap = 0 (spec §2.4)
     assert!(engine.accounts[idx as usize].adl_epoch_snap == 0);
@@ -238,16 +238,16 @@ fn t9_36_fee_seniority_after_restart() {
 
     let fc_before = engine.accounts[idx as usize].fee_credits;
 
-    engine.accounts[idx as usize].position_basis_q = POS_SCALE as i128;
-    engine.accounts[idx as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[idx as usize].adl_k_snap = 0i128;
+    engine.accounts[idx as usize].position_basis_q = I128::new(POS_SCALE as i128);
+    engine.accounts[idx as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[idx as usize].adl_k_snap = I128::ZERO;
     engine.accounts[idx as usize].adl_epoch_snap = 0;
     engine.stored_pos_count_long = 1;
     engine.adl_epoch_long = 1;
-    engine.adl_epoch_start_k_long = 0i128;
+    engine.adl_epoch_start_k_long = I128::ZERO;
     engine.side_mode_long = SideMode::ResetPending;
     engine.stale_account_count_long = 1;
-    engine.adl_coeff_long = 0i128;
+    engine.adl_coeff_long = I128::ZERO;
 
     let _ = engine.settle_side_effects_with_h_lock(idx as usize, 0);
 
@@ -265,15 +265,15 @@ fn t9_36_fee_seniority_after_restart() {
 fn t10_37_accrue_mark_matches_eager() {
     let mut engine = RiskEngine::new(zero_fee_params());
 
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
     engine.last_oracle_price = 100;
     engine.last_market_slot = 0;
 
-    let k_long_before = engine.adl_coeff_long;
-    let k_short_before = engine.adl_coeff_short;
+    let k_long_before = engine.adl_coeff_long.get();
+    let k_short_before = engine.adl_coeff_short.get();
 
     let dp: i8 = kani::any();
     kani::assume(dp >= -50 && dp <= 50);
@@ -283,8 +283,8 @@ fn t10_37_accrue_mark_matches_eager() {
     let result = engine.accrue_market_to(1, new_price, 0);
     assert!(result.is_ok());
 
-    let k_long_after = engine.adl_coeff_long;
-    let k_short_after = engine.adl_coeff_short;
+    let k_long_after = engine.adl_coeff_long.get();
+    let k_short_after = engine.adl_coeff_short.get();
 
     let expected_delta = (ADL_ONE as i128) * (dp as i128);
     let actual_long_delta = k_long_after.checked_sub(k_long_before).unwrap();
@@ -302,10 +302,10 @@ fn t10_37_accrue_mark_matches_eager() {
 fn t10_38_accrue_funding_payer_driven() {
     let mut engine = RiskEngine::new(zero_fee_params());
 
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
     engine.last_oracle_price = 100;
     engine.last_market_slot = 0;
 
@@ -313,14 +313,14 @@ fn t10_38_accrue_funding_payer_driven() {
     kani::assume(rate != 0);
     kani::assume(rate >= -100 && rate <= 100);
 
-    let k_long_before = engine.adl_coeff_long;
-    let k_short_before = engine.adl_coeff_short;
+    let k_long_before = engine.adl_coeff_long.get();
+    let k_short_before = engine.adl_coeff_short.get();
 
     let result = engine.accrue_market_to(1, 100, rate as i128);
     assert!(result.is_ok());
 
-    let k_long_after = engine.adl_coeff_long;
-    let k_short_after = engine.adl_coeff_short;
+    let k_long_after = engine.adl_coeff_long.get();
+    let k_short_after = engine.adl_coeff_short.get();
 
     // v12.15: K gets truncation-divided integer part, F gets remainder.
     // fund_num = 100 * rate. fund_term = fund_num / 1e9 (truncation toward zero).
@@ -339,13 +339,13 @@ fn t10_38_accrue_funding_payer_driven() {
     // F captures the remainder (per-side, with A multiplication)
     let expected_f_long = -(a_long * remainder);
     let expected_f_short = a_long * remainder;
-    assert!(engine.f_long_num == expected_f_long, "F_long must capture remainder");
-    assert!(engine.f_short_num == expected_f_short, "F_short must capture remainder");
+    assert!(engine.f_long_num.get() == expected_f_long, "F_long must capture remainder");
+    assert!(engine.f_short_num.get() == expected_f_short, "F_short must capture remainder");
 
     // Combined K + F is exact: no funding is lost
     // K_delta * FUNDING_DEN + F_delta = A_side * fund_num (exact)
     let k_delta_long = k_long_after - k_long_before;
-    let total_long = k_delta_long * 1_000_000_000i128 + engine.f_long_num;
+    let total_long = k_delta_long * 1_000_000_000i128 + engine.f_long_num.get();
     assert!(total_long == -(a_long * fund_num), "K + F must equal exact funding");
 }
 
@@ -361,20 +361,20 @@ fn t11_39_same_epoch_settle_idempotent_real_engine() {
     engine.deposit(idx, 10_000_000, 100, 0).unwrap();
 
     let pos = POS_SCALE as i128;
-    engine.accounts[idx as usize].position_basis_q = pos;
-    engine.accounts[idx as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[idx as usize].adl_k_snap = 0i128;
+    engine.accounts[idx as usize].position_basis_q = I128::new(pos);
+    engine.accounts[idx as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[idx as usize].adl_k_snap = I128::ZERO;
     engine.accounts[idx as usize].adl_epoch_snap = 0;
     engine.stored_pos_count_long = 1;
     engine.adl_epoch_long = 0;
-    engine.oi_eff_long_q = POS_SCALE;
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
 
-    engine.adl_coeff_long = 100i128;
+    engine.adl_coeff_long = I128::new(100i128);
 
     let r1 = engine.settle_side_effects_with_h_lock(idx as usize, 0);
     assert!(r1.is_ok());
     let pnl_after_first = engine.accounts[idx as usize].pnl;
-    assert!(engine.accounts[idx as usize].adl_k_snap == 100i128);
+    assert!(engine.accounts[idx as usize].adl_k_snap == I128::new(100i128));
 
     let r2 = engine.settle_side_effects_with_h_lock(idx as usize, 0);
     assert!(r2.is_ok());
@@ -382,8 +382,8 @@ fn t11_39_same_epoch_settle_idempotent_real_engine() {
 
     assert!(pnl_after_second == pnl_after_first,
         "second settle with unchanged K must produce zero incremental PnL");
-    assert!(engine.accounts[idx as usize].adl_a_basis == ADL_ONE);
-    assert!(engine.accounts[idx as usize].position_basis_q == pos);
+    assert!(engine.accounts[idx as usize].adl_a_basis == U128::new(ADL_ONE));
+    assert!(engine.accounts[idx as usize].position_basis_q == I128::new(pos));
 }
 
 #[kani::proof]
@@ -394,27 +394,27 @@ fn t11_40_non_compounding_quantity_basis_two_touches() {
     engine.deposit(idx, 10_000_000, 100, 0).unwrap();
 
     let pos = POS_SCALE as i128;
-    engine.accounts[idx as usize].position_basis_q = pos;
-    engine.accounts[idx as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[idx as usize].adl_k_snap = 0i128;
+    engine.accounts[idx as usize].position_basis_q = I128::new(pos);
+    engine.accounts[idx as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[idx as usize].adl_k_snap = I128::ZERO;
     engine.accounts[idx as usize].adl_epoch_snap = 0;
     engine.stored_pos_count_long = 1;
     engine.adl_epoch_long = 0;
-    engine.oi_eff_long_q = POS_SCALE;
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
 
-    engine.adl_coeff_long = 50i128;
+    engine.adl_coeff_long = I128::new(50i128);
     let _ = engine.settle_side_effects_with_h_lock(idx as usize, 0);
 
-    assert!(engine.accounts[idx as usize].position_basis_q == pos);
-    assert!(engine.accounts[idx as usize].adl_a_basis == ADL_ONE);
-    assert!(engine.accounts[idx as usize].adl_k_snap == 50i128);
+    assert!(engine.accounts[idx as usize].position_basis_q == I128::new(pos));
+    assert!(engine.accounts[idx as usize].adl_a_basis == U128::new(ADL_ONE));
+    assert!(engine.accounts[idx as usize].adl_k_snap == I128::new(50i128));
 
-    engine.adl_coeff_long = 120i128;
+    engine.adl_coeff_long = I128::new(120i128);
     let _ = engine.settle_side_effects_with_h_lock(idx as usize, 0);
 
-    assert!(engine.accounts[idx as usize].position_basis_q == pos);
-    assert!(engine.accounts[idx as usize].adl_a_basis == ADL_ONE);
-    assert!(engine.accounts[idx as usize].adl_k_snap == 120i128);
+    assert!(engine.accounts[idx as usize].position_basis_q == I128::new(pos));
+    assert!(engine.accounts[idx as usize].adl_a_basis == U128::new(ADL_ONE));
+    assert!(engine.accounts[idx as usize].adl_k_snap == I128::new(120i128));
 }
 
 #[kani::proof]
@@ -425,11 +425,11 @@ fn t11_41_attach_effective_position_remainder_accounting() {
     engine.deposit(idx, 10_000_000, 100, 0).unwrap();
 
     // Use a_basis=7, a_side=6 so that POS_SCALE * 6 % 7 != 0 (nonzero remainder)
-    engine.accounts[idx as usize].position_basis_q = POS_SCALE as i128;
-    engine.accounts[idx as usize].adl_a_basis = 7;
+    engine.accounts[idx as usize].position_basis_q = I128::new(POS_SCALE as i128);
+    engine.accounts[idx as usize].adl_a_basis = U128::new(7);
     engine.accounts[idx as usize].adl_epoch_snap = 0;
     engine.adl_epoch_long = 0;
-    engine.adl_mult_long = 6;
+    engine.adl_mult_long = U128::new(6);
     engine.stored_pos_count_long = 1;
 
     let dust_before = engine.phantom_dust_bound_long_q;
@@ -441,9 +441,9 @@ fn t11_41_attach_effective_position_remainder_accounting() {
         "dust bound must increment on nonzero remainder");
 
     // Now test zero remainder: a_basis == a_side → product evenly divisible
-    engine.accounts[idx as usize].position_basis_q = POS_SCALE as i128;
-    engine.accounts[idx as usize].adl_a_basis = ADL_ONE;
-    engine.adl_mult_long = ADL_ONE;
+    engine.accounts[idx as usize].position_basis_q = I128::new(POS_SCALE as i128);
+    engine.accounts[idx as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.adl_mult_long = U128::new(ADL_ONE);
 
     let dust_before2 = engine.phantom_dust_bound_long_q;
     engine.attach_effective_position(idx as usize, (3 * POS_SCALE) as i128);
@@ -462,27 +462,27 @@ fn t11_42_dynamic_dust_bound_inductive() {
     engine.deposit(b, 10_000_000, 100, 0).unwrap();
 
     // Use basis=1, a_basis=3 so floor(1 * 1 / 3) = 0 → position zeroes
-    engine.accounts[a as usize].position_basis_q = 1i128;
-    engine.accounts[a as usize].adl_a_basis = 3;
-    engine.accounts[a as usize].adl_k_snap = 0i128;
+    engine.accounts[a as usize].position_basis_q = I128::new(1i128);
+    engine.accounts[a as usize].adl_a_basis = U128::new(3);
+    engine.accounts[a as usize].adl_k_snap = I128::ZERO;
     engine.accounts[a as usize].adl_epoch_snap = 0;
-    engine.accounts[b as usize].position_basis_q = 1i128;
-    engine.accounts[b as usize].adl_a_basis = 3;
-    engine.accounts[b as usize].adl_k_snap = 0i128;
+    engine.accounts[b as usize].position_basis_q = I128::new(1i128);
+    engine.accounts[b as usize].adl_a_basis = U128::new(3);
+    engine.accounts[b as usize].adl_k_snap = I128::ZERO;
     engine.accounts[b as usize].adl_epoch_snap = 0;
     engine.stored_pos_count_long = 2;
     engine.adl_epoch_long = 0;
-    engine.oi_eff_long_q = 2;
+    engine.oi_eff_long_q = U128::new(2);
 
-    engine.adl_mult_long = 1;
+    engine.adl_mult_long = U128::new(1);
 
     let _ = engine.settle_side_effects_with_h_lock(a as usize, 0);
-    assert!(engine.accounts[a as usize].position_basis_q == 0);
-    assert!(engine.phantom_dust_bound_long_q == 1u128);
+    assert!(engine.accounts[a as usize].position_basis_q.get() == 0);
+    assert!(engine.phantom_dust_bound_long_q.get() == 1u128);
 
     let _ = engine.settle_side_effects_with_h_lock(b as usize, 0);
-    assert!(engine.accounts[b as usize].position_basis_q == 0);
-    assert!(engine.phantom_dust_bound_long_q == 2u128);
+    assert!(engine.accounts[b as usize].position_basis_q.get() == 0);
+    assert!(engine.phantom_dust_bound_long_q.get() == 2u128);
 }
 
 #[kani::proof]
@@ -546,18 +546,18 @@ fn t11_52_touch_account_full_restart_fee_seniority() {
     engine.deposit(idx, 10_000_000, 100, 0).unwrap();
 
     let pos = POS_SCALE as i128;
-    engine.accounts[idx as usize].position_basis_q = pos;
-    engine.accounts[idx as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[idx as usize].adl_k_snap = 0i128;
+    engine.accounts[idx as usize].position_basis_q = I128::new(pos);
+    engine.accounts[idx as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[idx as usize].adl_k_snap = I128::ZERO;
     engine.accounts[idx as usize].adl_epoch_snap = 0;
     engine.stored_pos_count_long = 1;
     engine.adl_epoch_long = 0;
-    engine.oi_eff_long_q = POS_SCALE;
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
 
-    engine.accounts[idx as usize].pnl = 5000i128;
-    engine.pnl_pos_tot = 5000u128;
+    engine.accounts[idx as usize].pnl = I128::new(5000i128);
+    engine.pnl_pos_tot = U128::new(5000u128);
 
-    engine.adl_coeff_long = (ADL_ONE as i128) * 100;
+    engine.adl_coeff_long = I128::new((ADL_ONE as i128) * 100);
 
     engine.accounts[idx as usize].fee_credits = I128::new(-500i128);
 
@@ -613,9 +613,9 @@ fn t11_54_worked_example_regression() {
     let r2 = engine.enqueue_adl(&mut ctx, Side::Short, q_close, d);
     assert!(r2.is_ok());
 
-    assert!(engine.adl_mult_long < ADL_ONE);
-    assert!(engine.oi_eff_long_q == POS_SCALE);
-    assert!(engine.adl_coeff_long != 0i128);
+    assert!(engine.adl_mult_long.get() < ADL_ONE);
+    assert!(engine.oi_eff_long_q == U128::new(POS_SCALE));
+    assert!(engine.adl_coeff_long.get() != 0i128);
 
     let _ = engine.settle_side_effects_with_h_lock(a as usize, 0);
 
@@ -635,26 +635,26 @@ fn t5_24_dynamic_dust_bound_sufficient() {
     engine.deposit(b, 10_000_000, 100, 0).unwrap();
 
     // Use basis=1, a_basis=3 so floor(1 * 1 / 3) = 0 → position zeroes
-    engine.accounts[a as usize].position_basis_q = 1i128;
-    engine.accounts[a as usize].adl_a_basis = 3;
-    engine.accounts[a as usize].adl_k_snap = 0i128;
+    engine.accounts[a as usize].position_basis_q = I128::new(1i128);
+    engine.accounts[a as usize].adl_a_basis = U128::new(3);
+    engine.accounts[a as usize].adl_k_snap = I128::ZERO;
     engine.accounts[a as usize].adl_epoch_snap = 0;
-    engine.accounts[b as usize].position_basis_q = 1i128;
-    engine.accounts[b as usize].adl_a_basis = 3;
-    engine.accounts[b as usize].adl_k_snap = 0i128;
+    engine.accounts[b as usize].position_basis_q = I128::new(1i128);
+    engine.accounts[b as usize].adl_a_basis = U128::new(3);
+    engine.accounts[b as usize].adl_k_snap = I128::ZERO;
     engine.accounts[b as usize].adl_epoch_snap = 0;
     engine.stored_pos_count_long = 2;
-    engine.oi_eff_long_q = 2;
+    engine.oi_eff_long_q = U128::new(2);
     engine.adl_epoch_long = 0;
 
-    engine.adl_mult_long = 1;
-    engine.adl_coeff_long = 0i128;
+    engine.adl_mult_long = U128::new(1);
+    engine.adl_coeff_long = I128::ZERO;
 
     let _ = engine.settle_side_effects_with_h_lock(a as usize, 0);
-    assert!(engine.phantom_dust_bound_long_q == 1u128);
+    assert!(engine.phantom_dust_bound_long_q.get() == 1u128);
 
     let _ = engine.settle_side_effects_with_h_lock(b as usize, 0);
-    assert!(engine.phantom_dust_bound_long_q == 2u128);
+    assert!(engine.phantom_dust_bound_long_q.get() == 2u128);
 }
 
 // ############################################################################
@@ -670,12 +670,12 @@ fn proof_begin_full_drain_reset() {
     let epoch_before = engine.adl_epoch_long;
     let k_before = engine.adl_coeff_long;
 
-    assert!(engine.oi_eff_long_q == 0);
+    assert!(engine.oi_eff_long_q.get() == 0);
 
     engine.begin_full_drain_reset(Side::Long);
 
     assert!(engine.adl_epoch_long == epoch_before + 1);
-    assert!(engine.adl_mult_long == ADL_ONE);
+    assert!(engine.adl_mult_long == U128::new(ADL_ONE));
     assert!(engine.side_mode_long == SideMode::ResetPending);
     assert!(engine.adl_epoch_start_k_long == k_before);
     assert!(engine.stale_account_count_long == engine.stored_pos_count_long);
@@ -691,11 +691,11 @@ fn proof_finalize_side_reset_requires_conditions() {
     assert!(r1.is_err());
 
     engine.side_mode_long = SideMode::ResetPending;
-    engine.oi_eff_long_q = 100u128;
+    engine.oi_eff_long_q = U128::new(100u128);
     let r2 = engine.finalize_side_reset(Side::Long);
     assert!(r2.is_err());
 
-    engine.oi_eff_long_q = 0u128;
+    engine.oi_eff_long_q = U128::ZERO;
     engine.stale_account_count_long = 1;
     let r3 = engine.finalize_side_reset(Side::Long);
     assert!(r3.is_err());
@@ -718,10 +718,10 @@ fn t13_55_empty_opposing_side_deficit_fallback() {
     let mut engine = RiskEngine::new(zero_fee_params());
     let mut ctx = InstructionContext::new();
 
-    engine.adl_mult_long = POS_SCALE;
-    engine.adl_coeff_long = 12345i128;
-    engine.oi_eff_long_q = 4 * POS_SCALE;
-    engine.oi_eff_short_q = 4 * POS_SCALE;
+    engine.adl_mult_long = U128::new(POS_SCALE);
+    engine.adl_coeff_long = I128::new(12345i128);
+    engine.oi_eff_long_q = U128::new(4 * POS_SCALE);
+    engine.oi_eff_short_q = U128::new(4 * POS_SCALE);
     engine.insurance_fund.balance = U128::new(10_000_000);
     engine.stored_pos_count_long = 0;
 
@@ -736,7 +736,7 @@ fn t13_55_empty_opposing_side_deficit_fallback() {
 
     assert!(engine.adl_coeff_long == k_before, "K must not change when stored_pos_count_opp == 0");
     assert!(engine.insurance_fund.balance.get() < ins_before, "insurance must absorb deficit");
-    assert!(engine.oi_eff_long_q == 3 * POS_SCALE);
+    assert!(engine.oi_eff_long_q.get() == 3 * POS_SCALE);
 }
 
 #[kani::proof]
@@ -747,19 +747,19 @@ fn t13_56_unilateral_empty_orphan_resolution() {
     let mut ctx = InstructionContext::new();
 
     engine.stored_pos_count_long = 0;
-    engine.phantom_dust_bound_long_q = 100u128;
-    engine.oi_eff_long_q = 50u128;
+    engine.phantom_dust_bound_long_q = U128::new(100u128);
+    engine.oi_eff_long_q = U128::new(50u128);
 
     engine.stored_pos_count_short = 2;
-    engine.oi_eff_short_q = 50u128;
+    engine.oi_eff_short_q = U128::new(50u128);
 
     let result = engine.schedule_end_of_instruction_resets(&mut ctx);
     assert!(result.is_ok());
 
     assert!(ctx.pending_reset_long);
     assert!(ctx.pending_reset_short);
-    assert!(engine.oi_eff_long_q == 0);
-    assert!(engine.oi_eff_short_q == 0);
+    assert!(engine.oi_eff_long_q.get() == 0);
+    assert!(engine.oi_eff_short_q.get() == 0);
 }
 
 #[kani::proof]
@@ -770,11 +770,11 @@ fn t13_57_unilateral_empty_corruption_guard() {
     let mut ctx = InstructionContext::new();
 
     engine.stored_pos_count_long = 0;
-    engine.phantom_dust_bound_long_q = 100u128;
-    engine.oi_eff_long_q = 50u128;
+    engine.phantom_dust_bound_long_q = U128::new(100u128);
+    engine.oi_eff_long_q = U128::new(50u128);
 
     engine.stored_pos_count_short = 2;
-    engine.oi_eff_short_q = 999u128;
+    engine.oi_eff_short_q = U128::new(999u128);
 
     let result = engine.schedule_end_of_instruction_resets(&mut ctx);
     assert!(result == Err(RiskError::CorruptState));
@@ -788,19 +788,19 @@ fn t13_58_unilateral_empty_short_side() {
     let mut ctx = InstructionContext::new();
 
     engine.stored_pos_count_short = 0;
-    engine.phantom_dust_bound_short_q = 200u128;
-    engine.oi_eff_short_q = 75u128;
+    engine.phantom_dust_bound_short_q = U128::new(200u128);
+    engine.oi_eff_short_q = U128::new(75u128);
 
     engine.stored_pos_count_long = 3;
-    engine.oi_eff_long_q = 75u128;
+    engine.oi_eff_long_q = U128::new(75u128);
 
     let result = engine.schedule_end_of_instruction_resets(&mut ctx);
     assert!(result.is_ok());
 
     assert!(ctx.pending_reset_long);
     assert!(ctx.pending_reset_short);
-    assert!(engine.oi_eff_long_q == 0);
-    assert!(engine.oi_eff_short_q == 0);
+    assert!(engine.oi_eff_long_q.get() == 0);
+    assert!(engine.oi_eff_short_q.get() == 0);
 }
 
 #[kani::proof]
@@ -812,10 +812,10 @@ fn t13_60_unconditional_dust_bound_on_any_a_decay() {
     let mut engine = RiskEngine::new(zero_fee_params());
     let mut ctx = InstructionContext::new();
 
-    engine.adl_mult_long = 4;
-    engine.adl_coeff_long = 0i128;
-    engine.oi_eff_long_q = 4 * POS_SCALE;
-    engine.oi_eff_short_q = 4 * POS_SCALE;
+    engine.adl_mult_long = U128::new(4);
+    engine.adl_coeff_long = I128::ZERO;
+    engine.oi_eff_long_q = U128::new(4 * POS_SCALE);
+    engine.oi_eff_short_q = U128::new(4 * POS_SCALE);
     engine.stored_pos_count_long = 1;
 
     let dust_before = engine.phantom_dust_bound_long_q;
@@ -824,7 +824,7 @@ fn t13_60_unconditional_dust_bound_on_any_a_decay() {
         &mut ctx, Side::Short, 2 * POS_SCALE, 0u128,
     );
     assert!(result.is_ok());
-    assert!(engine.adl_mult_long == 2);
+    assert!(engine.adl_mult_long.get() == 2);
 
     // Unconditional: dust ALWAYS increments by at least 1 on A decay
     assert!(engine.phantom_dust_bound_long_q >= dust_before + 1,
@@ -843,27 +843,27 @@ fn t12_53_adl_truncation_dust_must_not_deadlock() {
     engine.deposit(b, 10_000_000, 100, 0).unwrap();
 
     // One long (a) at A=7, one short (b) for OI balance.
-    engine.adl_mult_long = 7;
-    engine.adl_mult_short = ADL_ONE;
-    engine.adl_coeff_long = 0i128;
-    engine.adl_coeff_short = 0i128;
+    engine.adl_mult_long = U128::new(7);
+    engine.adl_mult_short = U128::new(ADL_ONE);
+    engine.adl_coeff_long = I128::ZERO;
+    engine.adl_coeff_short = I128::ZERO;
 
     // Account a: long 10*POS_SCALE at a_basis=7
-    engine.accounts[a as usize].position_basis_q = (10 * POS_SCALE) as i128;
-    engine.accounts[a as usize].adl_a_basis = 7;
-    engine.accounts[a as usize].adl_k_snap = 0i128;
+    engine.accounts[a as usize].position_basis_q = I128::new((10 * POS_SCALE) as i128);
+    engine.accounts[a as usize].adl_a_basis = U128::new(7);
+    engine.accounts[a as usize].adl_k_snap = I128::ZERO;
     engine.accounts[a as usize].adl_epoch_snap = 0;
 
     // Account b: short 10*POS_SCALE
-    engine.accounts[b as usize].position_basis_q = -((10 * POS_SCALE) as i128);
-    engine.accounts[b as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[b as usize].adl_k_snap = 0i128;
+    engine.accounts[b as usize].position_basis_q = I128::new(-((10 * POS_SCALE) as i128));
+    engine.accounts[b as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[b as usize].adl_k_snap = I128::ZERO;
     engine.accounts[b as usize].adl_epoch_snap = 0;
 
     engine.stored_pos_count_long = 1;
     engine.stored_pos_count_short = 1;
-    engine.oi_eff_long_q = 10 * POS_SCALE;
-    engine.oi_eff_short_q = 10 * POS_SCALE;
+    engine.oi_eff_long_q = U128::new(10 * POS_SCALE);
+    engine.oi_eff_short_q = U128::new(10 * POS_SCALE);
 
     // ADL: close POS_SCALE from short side → shrinks A_long via truncation
     // enqueue_adl decrements both sides by q_close, then A-truncates opposing
@@ -872,9 +872,9 @@ fn t12_53_adl_truncation_dust_must_not_deadlock() {
     );
     assert!(result.is_ok());
     // A_new = floor(7 * 9M / 10M) = 6
-    assert!(engine.adl_mult_long == 6);
-    assert!(engine.oi_eff_long_q == 9 * POS_SCALE);
-    assert!(engine.oi_eff_short_q == 9 * POS_SCALE);
+    assert!(engine.adl_mult_long.get() == 6);
+    assert!(engine.oi_eff_long_q.get() == 9 * POS_SCALE);
+    assert!(engine.oi_eff_short_q.get() == 9 * POS_SCALE);
 
     // Settle account a to get actual effective position under new A
     let settle_a = engine.settle_side_effects_with_h_lock(a as usize, 0);
@@ -882,18 +882,18 @@ fn t12_53_adl_truncation_dust_must_not_deadlock() {
 
     // eff_a = floor(10_000_000 * 6 / 7) = 8_571_428 (< 9_000_000)
     let eff_a = engine.effective_pos_q(a as usize);
-    let dust = engine.oi_eff_long_q.checked_sub(eff_a.unsigned_abs()).unwrap_or(0);
+    let dust = engine.oi_eff_long_q.get().checked_sub(eff_a.unsigned_abs()).unwrap_or(0);
 
     // Verify phantom_dust_bound covers the A-truncation dust
-    assert!(engine.phantom_dust_bound_long_q >= dust,
+    assert!(engine.phantom_dust_bound_long_q.get() >= dust,
         "dust bound must cover A-truncation phantom OI");
 
     // Simulate final state: all positions closed via balanced trades,
     // which maintain OI_long == OI_short. Residual dust is equal on both sides.
     engine.attach_effective_position(a as usize, 0i128);
     engine.attach_effective_position(b as usize, 0i128);
-    engine.oi_eff_long_q = dust;
-    engine.oi_eff_short_q = dust;
+    engine.oi_eff_long_q = U128::new(dust);
+    engine.oi_eff_short_q = U128::new(dust);
 
     let reset_result = engine.schedule_end_of_instruction_resets(&mut ctx);
     assert!(reset_result.is_ok(), "ADL truncation dust must not deadlock market reset");
@@ -954,16 +954,16 @@ fn t14_62_dust_bound_same_epoch_zeroing() {
     engine.deposit(idx, 10_000_000, 100, 0).unwrap();
 
     // Use basis=1, a_basis=3 so floor(1 * 1 / 3) = 0 → position zeroes
-    engine.accounts[idx as usize].position_basis_q = 1i128;
-    engine.accounts[idx as usize].adl_a_basis = 3;
-    engine.accounts[idx as usize].adl_k_snap = 0i128;
+    engine.accounts[idx as usize].position_basis_q = I128::new(1i128);
+    engine.accounts[idx as usize].adl_a_basis = U128::new(3);
+    engine.accounts[idx as usize].adl_k_snap = I128::ZERO;
     engine.accounts[idx as usize].adl_epoch_snap = 0;
     engine.stored_pos_count_long = 1;
     engine.adl_epoch_long = 0;
-    engine.adl_coeff_long = 0i128;
+    engine.adl_coeff_long = I128::ZERO;
 
     // A_side=1 so floor(1 * 1 / 3) = 0
-    engine.adl_mult_long = 1;
+    engine.adl_mult_long = U128::new(1);
 
     let dust_before = engine.phantom_dust_bound_long_q;
 
@@ -971,7 +971,7 @@ fn t14_62_dust_bound_same_epoch_zeroing() {
     assert!(result.is_ok());
 
     // Position must be zeroed
-    assert!(engine.accounts[idx as usize].position_basis_q == 0);
+    assert!(engine.accounts[idx as usize].position_basis_q.get() == 0);
     // Dust bound must have incremented by 1
     let dust_after = engine.phantom_dust_bound_long_q;
     assert!(dust_after == dust_before + 1u128,
@@ -1017,15 +1017,15 @@ fn t14_63_dust_bound_position_reattach_remainder() {
 fn t14_64_dust_bound_full_drain_reset_zeroes() {
     let mut engine = RiskEngine::new(zero_fee_params());
 
-    engine.phantom_dust_bound_long_q = 42u128;
-    engine.oi_eff_long_q = 0u128;
+    engine.phantom_dust_bound_long_q = U128::new(42u128);
+    engine.oi_eff_long_q = U128::ZERO;
     engine.stored_pos_count_long = 0;
     engine.adl_epoch_long = 0;
 
     engine.begin_full_drain_reset(Side::Long);
 
-    assert!(engine.phantom_dust_bound_long_q == 0u128);
-    assert!(engine.oi_eff_long_q == 0u128);
+    assert!(engine.phantom_dust_bound_long_q.get() == 0u128);
+    assert!(engine.oi_eff_long_q.get() == 0u128);
 }
 
 #[kani::proof]
@@ -1043,34 +1043,34 @@ fn t14_65_dust_bound_end_to_end_clearance() {
     engine.deposit(b_idx, 10_000_000, 100, 0).unwrap();
     engine.deposit(c_idx, 10_000_000, 100, 0).unwrap();
 
-    engine.adl_mult_long = 13;
-    engine.adl_mult_short = ADL_ONE;
-    engine.adl_coeff_long = 0i128;
-    engine.adl_coeff_short = 0i128;
+    engine.adl_mult_long = U128::new(13);
+    engine.adl_mult_short = U128::new(ADL_ONE);
+    engine.adl_coeff_long = I128::ZERO;
+    engine.adl_coeff_short = I128::ZERO;
     engine.adl_epoch_long = 0;
 
     // Account a: long 7*POS_SCALE at a_basis=13
-    engine.accounts[a_idx as usize].position_basis_q = (7 * POS_SCALE) as i128;
-    engine.accounts[a_idx as usize].adl_a_basis = 13;
-    engine.accounts[a_idx as usize].adl_k_snap = 0i128;
+    engine.accounts[a_idx as usize].position_basis_q = I128::new((7 * POS_SCALE) as i128);
+    engine.accounts[a_idx as usize].adl_a_basis = U128::new(13);
+    engine.accounts[a_idx as usize].adl_k_snap = I128::ZERO;
     engine.accounts[a_idx as usize].adl_epoch_snap = 0;
 
     // Account b: long 5*POS_SCALE at a_basis=13
-    engine.accounts[b_idx as usize].position_basis_q = (5 * POS_SCALE) as i128;
-    engine.accounts[b_idx as usize].adl_a_basis = 13;
-    engine.accounts[b_idx as usize].adl_k_snap = 0i128;
+    engine.accounts[b_idx as usize].position_basis_q = I128::new((5 * POS_SCALE) as i128);
+    engine.accounts[b_idx as usize].adl_a_basis = U128::new(13);
+    engine.accounts[b_idx as usize].adl_k_snap = I128::ZERO;
     engine.accounts[b_idx as usize].adl_epoch_snap = 0;
 
     // Account c: short 12*POS_SCALE
-    engine.accounts[c_idx as usize].position_basis_q = -((12 * POS_SCALE) as i128);
-    engine.accounts[c_idx as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[c_idx as usize].adl_k_snap = 0i128;
+    engine.accounts[c_idx as usize].position_basis_q = I128::new(-((12 * POS_SCALE) as i128));
+    engine.accounts[c_idx as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[c_idx as usize].adl_k_snap = I128::ZERO;
     engine.accounts[c_idx as usize].adl_epoch_snap = 0;
 
     engine.stored_pos_count_long = 2;
     engine.stored_pos_count_short = 1;
-    engine.oi_eff_long_q = 12 * POS_SCALE;
-    engine.oi_eff_short_q = 12 * POS_SCALE;
+    engine.oi_eff_long_q = U128::new(12 * POS_SCALE);
+    engine.oi_eff_short_q = U128::new(12 * POS_SCALE);
 
     // ADL: close 3*POS_SCALE from short side → shrinks A_long via truncation
     let result = engine.enqueue_adl(
@@ -1078,10 +1078,10 @@ fn t14_65_dust_bound_end_to_end_clearance() {
     );
     assert!(result.is_ok());
     // A_new = floor(13 * 9M / 12M) = 9
-    assert!(engine.adl_mult_long == 9);
-    assert!(engine.oi_eff_long_q == 9 * POS_SCALE);
-    assert!(engine.oi_eff_short_q == 9 * POS_SCALE);
-    assert!(engine.phantom_dust_bound_long_q != 0);
+    assert!(engine.adl_mult_long.get() == 9);
+    assert!(engine.oi_eff_long_q.get() == 9 * POS_SCALE);
+    assert!(engine.oi_eff_short_q.get() == 9 * POS_SCALE);
+    assert!(engine.phantom_dust_bound_long_q.get() != 0);
 
     // Settle long accounts to get actual effective positions under new A
     let sa = engine.settle_side_effects_with_h_lock(a_idx as usize, 0);
@@ -1095,10 +1095,10 @@ fn t14_65_dust_bound_end_to_end_clearance() {
     let sum_eff = eff_a.unsigned_abs() + eff_b.unsigned_abs();
 
     // Dust = tracked OI - actual sum of effective positions
-    let dust = engine.oi_eff_long_q.checked_sub(sum_eff).unwrap_or(0);
+    let dust = engine.oi_eff_long_q.get().checked_sub(sum_eff).unwrap_or(0);
 
     // Verify phantom_dust_bound covers the multi-account A-truncation dust
-    assert!(engine.phantom_dust_bound_long_q >= dust,
+    assert!(engine.phantom_dust_bound_long_q.get() >= dust,
         "dust bound must cover A-truncation phantom OI for multiple accounts");
 
     // Close all positions and set OI to balanced dust level
@@ -1106,8 +1106,8 @@ fn t14_65_dust_bound_end_to_end_clearance() {
     engine.attach_effective_position(a_idx as usize, 0i128);
     engine.attach_effective_position(b_idx as usize, 0i128);
     engine.attach_effective_position(c_idx as usize, 0i128);
-    engine.oi_eff_long_q = dust;
-    engine.oi_eff_short_q = dust;
+    engine.oi_eff_long_q = U128::new(dust);
+    engine.oi_eff_short_q = U128::new(dust);
 
     let reset_result = engine.schedule_end_of_instruction_resets(&mut ctx);
     assert!(reset_result.is_ok(), "dust bound must be sufficient for reset after all positions closed");
@@ -1358,14 +1358,14 @@ fn proof_property_44_deposit_true_flat_guard() {
     engine.deposit(a, 500_000, DEFAULT_ORACLE, DEFAULT_SLOT).unwrap();
 
     // Directly set up open position with negative PnL (bypassing trade to isolate deposit behavior)
-    engine.accounts[a as usize].position_basis_q = (10 * POS_SCALE) as i128;
+    engine.accounts[a as usize].position_basis_q = I128::new((10 * POS_SCALE) as i128);
     engine.stored_pos_count_long = 1;
-    engine.oi_eff_long_q = 10 * POS_SCALE;
-    engine.oi_eff_short_q = 10 * POS_SCALE;
+    engine.oi_eff_long_q = U128::new(10 * POS_SCALE);
+    engine.oi_eff_short_q = U128::new(10 * POS_SCALE);
     engine.set_pnl(a as usize, -5_000i128);
 
-    assert!(engine.accounts[a as usize].position_basis_q != 0);
-    assert!(engine.accounts[a as usize].pnl < 0);
+    assert!(engine.accounts[a as usize].position_basis_q.get() != 0);
+    assert!(engine.accounts[a as usize].pnl.get() < 0);
 
     let ins_before = engine.insurance_fund.balance.get();
     let pnl_before = engine.accounts[a as usize].pnl;
@@ -1379,7 +1379,7 @@ fn proof_property_44_deposit_true_flat_guard() {
         "insurance must not change: resolve_flat_negative must not run when basis != 0");
 
     // Position must still be intact
-    assert!(engine.accounts[a as usize].position_basis_q != 0,
+    assert!(engine.accounts[a as usize].position_basis_q.get() != 0,
         "position must still be intact after deposit");
 
     // PnL may have been partially settled by settle_losses (step 7),
@@ -1481,7 +1481,7 @@ fn proof_property_50_flat_only_auto_conversion() {
     engine.keeper_crank_not_atomic(slot3, high_oracle, &[(a, None)], 64, 0i128, 0).unwrap();
 
     // a still has position, so should have released profit but NOT auto-converted
-    assert!(engine.accounts[a as usize].position_basis_q != 0,
+    assert!(engine.accounts[a as usize].position_basis_q.get() != 0,
         "account must still have open position");
 
     let released = engine.released_pos(a as usize);
@@ -1494,7 +1494,7 @@ fn proof_property_50_flat_only_auto_conversion() {
         cap_a);
 
     // Verify released profit exists but wasn't consumed
-    assert!(released > 0 || engine.accounts[a as usize].reserved_pnl == 0,
+    assert!(released > 0 || engine.accounts[a as usize].reserved_pnl.get() == 0,
         "warmup must have released profit or reserve is zero");
 
     assert!(engine.check_conservation());

--- a/tests/proofs_invariants.rs
+++ b/tests/proofs_invariants.rs
@@ -162,7 +162,7 @@ fn inductive_set_pnl_preserves_pnl_pos_tot_delta() {
 
     let pos_a: u128 = if pnl_a > 0 { pnl_a as u128 } else { 0 };
     let pos_b: u128 = if pnl_b > 0 { pnl_b as u128 } else { 0 };
-    assert!(engine.pnl_pos_tot == pos_a + pos_b);
+    assert!(engine.pnl_pos_tot.get() == pos_a + pos_b);
 }
 
 #[kani::proof]
@@ -251,7 +251,7 @@ fn prop_pnl_pos_tot_agrees_with_recompute() {
     let pos_b: u128 = if pnl_b > 0 { pnl_b as u128 } else { 0 };
     let expected = pos_a + pos_b;
 
-    assert!(engine.pnl_pos_tot == expected);
+    assert!(engine.pnl_pos_tot.get() == expected);
 }
 
 #[kani::proof]
@@ -314,14 +314,14 @@ fn proof_set_pnl_maintains_pnl_pos_tot() {
     engine.set_pnl(idx as usize, pnl1 as i128);
 
     let expected1 = if pnl1 > 0 { pnl1 as u128 } else { 0u128 };
-    assert!(engine.pnl_pos_tot == expected1);
+    assert!(engine.pnl_pos_tot.get() == expected1);
 
     let pnl2: i32 = kani::any();
     kani::assume(pnl2 > i32::MIN);
     engine.set_pnl(idx as usize, pnl2 as i128);
 
     let expected2 = if pnl2 > 0 { pnl2 as u128 } else { 0u128 };
-    assert!(engine.pnl_pos_tot == expected2);
+    assert!(engine.pnl_pos_tot.get() == expected2);
 }
 
 #[kani::proof]
@@ -332,13 +332,13 @@ fn proof_set_pnl_underflow_safety() {
     let idx = engine.add_user(0).unwrap();
 
     engine.set_pnl(idx as usize, 1000i128);
-    assert!(engine.pnl_pos_tot == 1000u128);
+    assert!(engine.pnl_pos_tot.get() == 1000u128);
 
     engine.set_pnl(idx as usize, -500i128);
-    assert!(engine.pnl_pos_tot == 0u128);
+    assert!(engine.pnl_pos_tot.get() == 0u128);
 
     engine.set_pnl(idx as usize, 0i128);
-    assert!(engine.pnl_pos_tot == 0u128);
+    assert!(engine.pnl_pos_tot.get() == 0u128);
 }
 
 #[kani::proof]
@@ -351,22 +351,22 @@ fn proof_set_pnl_clamps_reserved_pnl() {
     // set_pnl routes through ImmediateRelease: positive increase goes to matured,
     // not to reserve. So reserved_pnl stays 0 after set_pnl.
     engine.set_pnl(idx as usize, 5000i128);
-    assert!(engine.accounts[idx as usize].reserved_pnl == 0u128,
+    assert!(engine.accounts[idx as usize].reserved_pnl.get() == 0u128,
         "ImmediateRelease: positive PnL goes to matured, not reserve");
 
     // Use UseHLock to test reserve clamping
     engine.set_pnl_with_reserve(idx as usize, 0i128, ReserveMode::ImmediateRelease).unwrap();
     engine.set_pnl_with_reserve(idx as usize, 5000i128, ReserveMode::UseHLock(10)).unwrap();
-    assert!(engine.accounts[idx as usize].reserved_pnl == 5000u128,
+    assert!(engine.accounts[idx as usize].reserved_pnl.get() == 5000u128,
         "UseHLock: positive PnL goes to reserve");
 
     // Decrease PNL: reserve loss applied via newest-first
     engine.set_pnl(idx as usize, 3000i128);
-    assert!(engine.accounts[idx as usize].reserved_pnl <= 3000u128);
+    assert!(engine.accounts[idx as usize].reserved_pnl.get() <= 3000u128);
 
     // Decrease PNL to -100 → reserve clamped to 0
     engine.set_pnl(idx as usize, -100i128);
-    assert!(engine.accounts[idx as usize].reserved_pnl == 0u128);
+    assert!(engine.accounts[idx as usize].reserved_pnl.get() == 0u128);
 }
 
 #[kani::proof]
@@ -420,8 +420,8 @@ fn proof_haircut_ratio_no_division_by_zero() {
     assert!(den == 1u128);
 
     // Set pnl_matured_pos_tot (v12.14.0 uses this as denominator, not pnl_pos_tot)
-    engine.pnl_pos_tot = 1000u128;
-    engine.pnl_matured_pos_tot = 1000u128;
+    engine.pnl_pos_tot = U128::new(1000u128);
+    engine.pnl_matured_pos_tot = U128::new(1000u128);
     engine.vault = U128::new(2000);
     engine.c_tot = U128::new(500);
     engine.insurance_fund.balance = U128::new(300);
@@ -535,7 +535,7 @@ fn proof_account_equity_net_nonnegative() {
     // Set pnl_matured_pos_tot to exercise h < 1 in haircut_ratio (v12.14.0)
     let matured: u16 = kani::any();
     kani::assume(matured <= 20_000);
-    engine.pnl_matured_pos_tot = core::cmp::min(matured as u128, engine.pnl_pos_tot);
+    engine.pnl_matured_pos_tot = U128::new(core::cmp::min(matured as u128, engine.pnl_pos_tot.get()));
 
     // Exercise both positive PnL (haircut path) and negative PnL
     let eq = engine.account_equity_net(&engine.accounts[a as usize], DEFAULT_ORACLE);
@@ -550,8 +550,8 @@ fn proof_effective_pos_q_epoch_mismatch_returns_zero() {
     let mut engine = RiskEngine::new(zero_fee_params());
     let idx = engine.add_user(0).unwrap();
 
-    engine.accounts[idx as usize].position_basis_q = POS_SCALE as i128;
-    engine.accounts[idx as usize].adl_a_basis = ADL_ONE;
+    engine.accounts[idx as usize].position_basis_q = I128::new(POS_SCALE as i128);
+    engine.accounts[idx as usize].adl_a_basis = U128::new(ADL_ONE);
     engine.accounts[idx as usize].adl_epoch_snap = 0;
     engine.stored_pos_count_long = 1;
 
@@ -559,7 +559,7 @@ fn proof_effective_pos_q_epoch_mismatch_returns_zero() {
     let eff = engine.effective_pos_q(idx as usize);
     assert!(eff == 0);
 
-    engine.accounts[idx as usize].position_basis_q = -(POS_SCALE as i128);
+    engine.accounts[idx as usize].position_basis_q = I128::new(-(POS_SCALE as i128));
     engine.accounts[idx as usize].adl_epoch_snap = 0;
     engine.adl_epoch_short = 1;
     let eff2 = engine.effective_pos_q(idx as usize);
@@ -573,7 +573,7 @@ fn proof_effective_pos_q_flat_is_zero() {
     let mut engine = RiskEngine::new(zero_fee_params());
     let idx = engine.add_user(0).unwrap();
 
-    assert!(engine.accounts[idx as usize].position_basis_q == 0);
+    assert!(engine.accounts[idx as usize].position_basis_q.get() == 0);
     let eff = engine.effective_pos_q(idx as usize);
     assert!(eff == 0);
 }

--- a/tests/proofs_lazy_ak.rs
+++ b/tests/proofs_lazy_ak.rs
@@ -269,11 +269,11 @@ fn t3_14_epoch_mismatch_forces_terminal_close() {
     let pos_mul: u8 = kani::any();
     kani::assume(pos_mul > 0);
     let pos = (POS_SCALE * (pos_mul as u128)) as i128;
-    engine.accounts[idx as usize].position_basis_q = pos;
-    engine.accounts[idx as usize].adl_a_basis = ADL_ONE;
+    engine.accounts[idx as usize].position_basis_q = I128::new(pos);
+    engine.accounts[idx as usize].adl_a_basis = U128::new(ADL_ONE);
     let k_snap_val: i8 = kani::any();
     let k_snap = k_snap_val as i128;
-    engine.accounts[idx as usize].adl_k_snap = k_snap;
+    engine.accounts[idx as usize].adl_k_snap = I128::new(k_snap);
     engine.accounts[idx as usize].adl_epoch_snap = 0;
     engine.stored_pos_count_long = 1;
 
@@ -282,7 +282,7 @@ fn t3_14_epoch_mismatch_forces_terminal_close() {
     let k_epoch_start = k_start_val as i128;
 
     engine.adl_epoch_long = 1;
-    engine.adl_epoch_start_k_long = k_epoch_start;
+    engine.adl_epoch_start_k_long = I128::new(k_epoch_start);
     engine.side_mode_long = SideMode::ResetPending;
     engine.stale_account_count_long = 1;
 
@@ -291,7 +291,7 @@ fn t3_14_epoch_mismatch_forces_terminal_close() {
     let result = engine.settle_side_effects_with_h_lock(idx as usize, 0);
     assert!(result.is_ok());
 
-    assert!(engine.accounts[idx as usize].position_basis_q == 0);
+    assert!(engine.accounts[idx as usize].position_basis_q.get() == 0);
     assert!(engine.stale_account_count_long == 0);
     // Canonical zero-position defaults: epoch_snap = 0 (spec §2.4)
     assert!(engine.accounts[idx as usize].adl_epoch_snap == 0);
@@ -313,14 +313,14 @@ fn t3_14b_epoch_mismatch_with_nonzero_k_diff() {
     engine.deposit(idx, 10_000_000, 100, 0).unwrap();
 
     let pos = POS_SCALE as i128;
-    engine.accounts[idx as usize].position_basis_q = pos;
-    engine.accounts[idx as usize].adl_a_basis = ADL_ONE;
+    engine.accounts[idx as usize].position_basis_q = I128::new(pos);
+    engine.accounts[idx as usize].adl_a_basis = U128::new(ADL_ONE);
     engine.accounts[idx as usize].adl_epoch_snap = 0;
     engine.stored_pos_count_long = 1;
 
     let k_snap_val: i8 = kani::any();
     let k_snap = k_snap_val as i128;
-    engine.accounts[idx as usize].adl_k_snap = k_snap;
+    engine.accounts[idx as usize].adl_k_snap = I128::new(k_snap);
 
     let k_diff_val: i8 = kani::any();
     kani::assume(k_diff_val != 0);
@@ -328,9 +328,9 @@ fn t3_14b_epoch_mismatch_with_nonzero_k_diff() {
     kani::assume(k_epoch_start_val >= -120 && k_epoch_start_val <= 120);
     let k_epoch_start = k_epoch_start_val as i128;
 
-    engine.adl_coeff_long = 0i128;
+    engine.adl_coeff_long = I128::ZERO;
     engine.adl_epoch_long = 1;
-    engine.adl_epoch_start_k_long = k_epoch_start;
+    engine.adl_epoch_start_k_long = I128::new(k_epoch_start);
     engine.side_mode_long = SideMode::ResetPending;
     engine.stale_account_count_long = 1;
 
@@ -339,7 +339,7 @@ fn t3_14b_epoch_mismatch_with_nonzero_k_diff() {
     let result = engine.settle_side_effects_with_h_lock(idx as usize, 0);
     assert!(result.is_ok());
 
-    assert!(engine.accounts[idx as usize].position_basis_q == 0);
+    assert!(engine.accounts[idx as usize].position_basis_q.get() == 0);
     assert!(engine.stale_account_count_long == 0);
     // Canonical zero-position defaults: epoch_snap = 0 (spec §2.4)
     assert!(engine.accounts[idx as usize].adl_epoch_snap == 0);
@@ -527,29 +527,29 @@ fn t6_26_full_drain_reset_regression() {
     kani::assume(k_start_val != k_snap_val);
     let k_epoch_start = k_start_val as i128;
 
-    engine.accounts[idx as usize].position_basis_q = (POS_SCALE * (pos_mul as u128)) as i128;
-    engine.accounts[idx as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[idx as usize].adl_k_snap = k_snap;
+    engine.accounts[idx as usize].position_basis_q = I128::new((POS_SCALE * (pos_mul as u128)) as i128);
+    engine.accounts[idx as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[idx as usize].adl_k_snap = I128::new(k_snap);
     engine.accounts[idx as usize].adl_epoch_snap = 0;
     engine.stored_pos_count_long = 1;
 
     // Set adl_coeff_long to k_epoch_start so begin_full_drain_reset captures it
-    engine.adl_coeff_long = k_epoch_start;
+    engine.adl_coeff_long = I128::new(k_epoch_start);
 
-    engine.oi_eff_long_q = 0u128;
+    engine.oi_eff_long_q = U128::ZERO;
     engine.begin_full_drain_reset(Side::Long);
 
     assert!(engine.side_mode_long == SideMode::ResetPending);
     assert!(engine.adl_epoch_long == 1);
     assert!(engine.stale_account_count_long == 1);
-    assert!(engine.adl_epoch_start_k_long == k_epoch_start);
+    assert!(engine.adl_epoch_start_k_long == I128::new(k_epoch_start));
 
     let pnl_before = engine.accounts[idx as usize].pnl;
 
     let result = engine.settle_side_effects_with_h_lock(idx as usize, 0);
     assert!(result.is_ok());
 
-    assert!(engine.accounts[idx as usize].position_basis_q == 0);
+    assert!(engine.accounts[idx as usize].position_basis_q.get() == 0);
     assert!(engine.stale_account_count_long == 0);
 
     // PnL assertion: settlement must credit the correct amount
@@ -584,16 +584,16 @@ fn proof_property_43_k_pair_chronology_correctness() {
 
     // Set up a long position with k_snap = 100
     let pos = 10 * POS_SCALE as i128;
-    engine.accounts[idx as usize].position_basis_q = pos;
-    engine.accounts[idx as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[idx as usize].adl_k_snap = 100;
+    engine.accounts[idx as usize].position_basis_q = I128::new(pos);
+    engine.accounts[idx as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[idx as usize].adl_k_snap = I128::new(100);
     engine.accounts[idx as usize].adl_epoch_snap = 0;
     engine.stored_pos_count_long = 1;
-    engine.oi_eff_long_q = 10 * POS_SCALE;
-    engine.oi_eff_short_q = 10 * POS_SCALE;
+    engine.oi_eff_long_q = U128::new(10 * POS_SCALE);
+    engine.oi_eff_short_q = U128::new(10 * POS_SCALE);
 
     // Set k_side > k_snap (price moved up => long should profit)
-    engine.adl_coeff_long = 500;
+    engine.adl_coeff_long = I128::new(500);
 
     let pnl_before = engine.accounts[idx as usize].pnl;
 

--- a/tests/proofs_liveness.rs
+++ b/tests/proofs_liveness.rs
@@ -18,12 +18,12 @@ fn t11_43_end_instruction_auto_finalizes_ready_side() {
     let mut engine = RiskEngine::new(zero_fee_params());
 
     engine.side_mode_long = SideMode::ResetPending;
-    engine.oi_eff_long_q = 0u128;
+    engine.oi_eff_long_q = U128::ZERO;
     engine.stale_account_count_long = 0;
     engine.stored_pos_count_long = 0;
 
     engine.side_mode_short = SideMode::ResetPending;
-    engine.oi_eff_short_q = 0u128;
+    engine.oi_eff_short_q = U128::ZERO;
     engine.stale_account_count_short = 1;
     engine.stored_pos_count_short = 0;
 
@@ -51,8 +51,8 @@ fn t11_44_trade_path_reopens_ready_reset_side() {
     engine.deposit(b, 10_000_000, 100, 0).unwrap();
 
     engine.side_mode_long = SideMode::ResetPending;
-    engine.oi_eff_long_q = 0u128;
-    engine.oi_eff_short_q = 0u128;
+    engine.oi_eff_long_q = U128::ZERO;
+    engine.oi_eff_short_q = U128::ZERO;
     engine.stale_account_count_long = 0;
     engine.stored_pos_count_long = 0;
 
@@ -87,10 +87,10 @@ fn t11_46_enqueue_adl_k_add_overflow_still_routes_quantity() {
     let mut engine = RiskEngine::new(zero_fee_params());
     let mut ctx = InstructionContext::new();
 
-    engine.adl_coeff_long = i128::MIN + 1;
-    engine.adl_mult_long = POS_SCALE;
-    engine.oi_eff_long_q = 4 * POS_SCALE;
-    engine.oi_eff_short_q = 4 * POS_SCALE;
+    engine.adl_coeff_long = I128::new(i128::MIN + 1);
+    engine.adl_mult_long = U128::new(POS_SCALE);
+    engine.oi_eff_long_q = U128::new(4 * POS_SCALE);
+    engine.oi_eff_short_q = U128::new(4 * POS_SCALE);
     engine.insurance_fund.balance = U128::new(10_000_000);
     engine.stored_pos_count_long = 1;
 
@@ -110,7 +110,7 @@ fn t11_46_enqueue_adl_k_add_overflow_still_routes_quantity() {
     // A must shrink (quantity was still routed)
     assert!(engine.adl_mult_long < a_before, "A must shrink on K overflow");
     // OI must decrease by q_close
-    assert!(engine.oi_eff_long_q == 2 * POS_SCALE);
+    assert!(engine.oi_eff_long_q.get() == 2 * POS_SCALE);
     // Insurance fund must decrease by D (absorb_protocol_loss was invoked)
     assert!(engine.insurance_fund.balance.get() < ins_before,
         "insurance fund must decrease — absorb_protocol_loss must be invoked");
@@ -126,10 +126,10 @@ fn t11_47_precision_exhaustion_terminal_drain() {
     let mut engine = RiskEngine::new(zero_fee_params());
     let mut ctx = InstructionContext::new();
 
-    engine.adl_mult_long = 1;
-    engine.adl_coeff_long = 0i128;
-    engine.oi_eff_long_q = 3 * POS_SCALE;
-    engine.oi_eff_short_q = 3 * POS_SCALE;
+    engine.adl_mult_long = U128::new(1);
+    engine.adl_coeff_long = I128::ZERO;
+    engine.oi_eff_long_q = U128::new(3 * POS_SCALE);
+    engine.oi_eff_short_q = U128::new(3 * POS_SCALE);
     engine.stored_pos_count_long = 1;
 
     let q_close = POS_SCALE;
@@ -140,8 +140,8 @@ fn t11_47_precision_exhaustion_terminal_drain() {
 
     assert!(ctx.pending_reset_long);
     assert!(ctx.pending_reset_short);
-    assert!(engine.oi_eff_long_q == 0);
-    assert!(engine.oi_eff_short_q == 0);
+    assert!(engine.oi_eff_long_q.get() == 0);
+    assert!(engine.oi_eff_short_q.get() == 0);
 }
 
 // ============================================================================
@@ -154,10 +154,10 @@ fn t11_48_bankruptcy_liquidation_routes_q_when_D_zero() {
     let mut engine = RiskEngine::new(zero_fee_params());
     let mut ctx = InstructionContext::new();
 
-    engine.adl_mult_long = POS_SCALE;
-    engine.adl_coeff_long = 42i128;
-    engine.oi_eff_long_q = 4 * POS_SCALE;
-    engine.oi_eff_short_q = 4 * POS_SCALE;
+    engine.adl_mult_long = U128::new(POS_SCALE);
+    engine.adl_coeff_long = I128::new(42i128);
+    engine.oi_eff_long_q = U128::new(4 * POS_SCALE);
+    engine.oi_eff_short_q = U128::new(4 * POS_SCALE);
     engine.stored_pos_count_long = 1;
 
     let k_before = engine.adl_coeff_long;
@@ -171,7 +171,7 @@ fn t11_48_bankruptcy_liquidation_routes_q_when_D_zero() {
 
     assert!(engine.adl_coeff_long == k_before, "K must be unchanged when D == 0");
     assert!(engine.adl_mult_long < a_before, "A must shrink");
-    assert!(engine.oi_eff_long_q == 3 * POS_SCALE);
+    assert!(engine.oi_eff_long_q.get() == 3 * POS_SCALE);
 }
 
 // ============================================================================
@@ -184,10 +184,10 @@ fn t11_49_pure_pnl_bankruptcy_path() {
     let mut engine = RiskEngine::new(zero_fee_params());
     let mut ctx = InstructionContext::new();
 
-    engine.adl_mult_long = POS_SCALE;
-    engine.adl_coeff_long = 0i128;
-    engine.oi_eff_long_q = 2 * POS_SCALE;
-    engine.oi_eff_short_q = 2 * POS_SCALE;
+    engine.adl_mult_long = U128::new(POS_SCALE);
+    engine.adl_coeff_long = I128::ZERO;
+    engine.oi_eff_long_q = U128::new(2 * POS_SCALE);
+    engine.oi_eff_short_q = U128::new(2 * POS_SCALE);
     engine.stored_pos_count_long = 1;
 
     let a_before = engine.adl_mult_long;
@@ -201,7 +201,7 @@ fn t11_49_pure_pnl_bankruptcy_path() {
 
     assert!(engine.adl_mult_long == a_before, "A must be unchanged for pure PnL bankruptcy");
     assert!(engine.adl_coeff_long != k_before, "K must change when D > 0");
-    assert!(engine.oi_eff_long_q == 2 * POS_SCALE);
+    assert!(engine.oi_eff_long_q.get() == 2 * POS_SCALE);
 }
 
 // ============================================================================
@@ -215,8 +215,8 @@ fn t11_53_keeper_crank_quiesces_after_pending_reset() {
 
     engine.last_oracle_price = 100;
     engine.last_market_slot = 0;
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
     engine.adl_epoch_long = 0;
     engine.adl_epoch_short = 0;
 
@@ -226,16 +226,16 @@ fn t11_53_keeper_crank_quiesces_after_pending_reset() {
 
     // a: long POS_SCALE (entire long side OI), tiny capital → deeply underwater
     engine.deposit(a, 1, 100, 0).unwrap();
-    engine.accounts[a as usize].position_basis_q = POS_SCALE as i128;
-    engine.accounts[a as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[a as usize].adl_k_snap = 0i128;
+    engine.accounts[a as usize].position_basis_q = I128::new(POS_SCALE as i128);
+    engine.accounts[a as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[a as usize].adl_k_snap = I128::ZERO;
     engine.accounts[a as usize].adl_epoch_snap = 0;
 
     // b: short POS_SCALE, well-funded
     engine.deposit(b, 10_000_000, 100, 0).unwrap();
-    engine.accounts[b as usize].position_basis_q = -(POS_SCALE as i128);
-    engine.accounts[b as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[b as usize].adl_k_snap = 0i128;
+    engine.accounts[b as usize].position_basis_q = I128::new(-(POS_SCALE as i128));
+    engine.accounts[b as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[b as usize].adl_k_snap = I128::ZERO;
     engine.accounts[b as usize].adl_epoch_snap = 0;
 
     // c: NO position, just capital (should NOT be touched after pending reset)
@@ -244,11 +244,11 @@ fn t11_53_keeper_crank_quiesces_after_pending_reset() {
     // BALANCED OI: 1 long (a) = PS, 1 short (b) = PS
     engine.stored_pos_count_long = 1;
     engine.stored_pos_count_short = 1;
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
 
     // Set K_long very negative → account a is deeply underwater
-    engine.adl_coeff_long = -((ADL_ONE as i128) * 1000);
+    engine.adl_coeff_long = I128::new(-((ADL_ONE as i128) * 1000));
 
     let c_cap_before = engine.accounts[c as usize].capital.get();
     let c_pnl_before = engine.accounts[c as usize].pnl;
@@ -275,8 +275,8 @@ fn proof_drain_only_to_reset_progress() {
 
     // Long side: DrainOnly, OI = 0
     engine.side_mode_long = SideMode::DrainOnly;
-    engine.oi_eff_long_q = 0u128;
-    engine.oi_eff_short_q = 0u128;
+    engine.oi_eff_long_q = U128::ZERO;
+    engine.oi_eff_short_q = U128::ZERO;
     engine.stored_pos_count_long = 0;
     // Short side still has stored positions → §5.7.A (bilateral-empty) does NOT fire
     engine.stored_pos_count_short = 1;
@@ -302,8 +302,8 @@ fn proof_keeper_reset_lifecycle_last_stale_triggers_finalize() {
 
     engine.last_oracle_price = 100;
     engine.last_market_slot = 0;
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
     engine.adl_epoch_long = 1;   // new epoch (post-reset)
     engine.adl_epoch_short = 0;
 
@@ -312,22 +312,22 @@ fn proof_keeper_reset_lifecycle_last_stale_triggers_finalize() {
 
     // a: the last stale long account — has a position from epoch 0 (stale)
     engine.deposit(a, 10_000_000, 100, 0).unwrap();
-    engine.accounts[a as usize].position_basis_q = POS_SCALE as i128;
-    engine.accounts[a as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[a as usize].adl_k_snap = 0i128;
+    engine.accounts[a as usize].position_basis_q = I128::new(POS_SCALE as i128);
+    engine.accounts[a as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[a as usize].adl_k_snap = I128::ZERO;
     engine.accounts[a as usize].adl_epoch_snap = 0;  // mismatches adl_epoch_long=1
 
     // b: a short account (non-stale, current epoch)
     engine.deposit(b, 10_000_000, 100, 0).unwrap();
-    engine.accounts[b as usize].position_basis_q = 0i128;
-    engine.accounts[b as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[b as usize].adl_k_snap = 0i128;
+    engine.accounts[b as usize].position_basis_q = I128::ZERO;
+    engine.accounts[b as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[b as usize].adl_k_snap = I128::ZERO;
     engine.accounts[b as usize].adl_epoch_snap = 0;
 
     // Long side: ResetPending, 1 stale account remaining, OI=0
     engine.side_mode_long = SideMode::ResetPending;
-    engine.oi_eff_long_q = 0u128;
-    engine.oi_eff_short_q = 0u128;
+    engine.oi_eff_long_q = U128::ZERO;
+    engine.oi_eff_short_q = U128::ZERO;
     engine.stale_account_count_long = 1;
     engine.stored_pos_count_long = 1;
 
@@ -360,8 +360,8 @@ fn proof_unilateral_empty_orphan_dust_clearance() {
     // Phantom dust: OI == dust bound (should clear)
     let dust = 42u128;
     engine.phantom_dust_bound_long_q = dust;
-    engine.oi_eff_long_q = dust;   // OI <= dust bound
-    engine.oi_eff_short_q = dust;  // balanced (required by spec)
+    engine.oi_eff_long_q = U128::new(dust);   // OI <= dust bound
+    engine.oi_eff_short_q = U128::new(dust);  // balanced (required by spec)
 
     let result = engine.schedule_end_of_instruction_resets(&mut ctx);
     assert!(result.is_ok());
@@ -372,9 +372,9 @@ fn proof_unilateral_empty_orphan_dust_clearance() {
     assert!(ctx.pending_reset_short,
         "opposite side must also get reset for bilateral consistency (§5.7.B)");
     // OI must be zeroed
-    assert!(engine.oi_eff_long_q == 0,
+    assert!(engine.oi_eff_long_q.get() == 0,
         "OI must be zeroed after dust clearance");
-    assert!(engine.oi_eff_short_q == 0,
+    assert!(engine.oi_eff_short_q.get() == 0,
         "OI must be zeroed after dust clearance");
 }
 

--- a/tests/proofs_safety.rs
+++ b/tests/proofs_safety.rs
@@ -100,8 +100,8 @@ fn bounded_haircut_ratio_bounded() {
     engine.vault = U128::new(vault_val as u128);
     engine.c_tot = U128::new(c_tot_val as u128);
     engine.insurance_fund.balance = U128::new(ins_val as u128);
-    engine.pnl_pos_tot = ppt_val as u128;
-    engine.pnl_matured_pos_tot = matured_val as u128; // v12.14.0: haircut denominator
+    engine.pnl_pos_tot = U128::new(ppt_val as u128);
+    engine.pnl_matured_pos_tot = U128::new(matured_val as u128); // v12.14.0: haircut denominator
 
     let (h_num, h_den) = engine.haircut_ratio();
 
@@ -139,7 +139,7 @@ fn bounded_equity_nonneg_flat() {
     kani::assume(pnl_val > i16::MIN);
     engine.set_pnl(idx as usize, pnl_val as i128);
 
-    assert!(engine.accounts[idx as usize].position_basis_q == 0);
+    assert!(engine.accounts[idx as usize].position_basis_q.get() == 0);
 
     let raw = engine.account_equity_maint_raw(&engine.accounts[idx as usize]);
 
@@ -317,8 +317,8 @@ fn proof_trade_pnl_is_zero_sum_algebraic() {
     assert!(result.is_ok(), "trade must succeed with sufficient margin");
 
     // After a trade, PnL must be zero-sum across the two counterparties
-    let pnl_a = engine.accounts[a as usize].pnl;
-    let pnl_b = engine.accounts[b as usize].pnl;
+    let pnl_a = engine.accounts[a as usize].pnl.get();
+    let pnl_b = engine.accounts[b as usize].pnl.get();
     assert!(pnl_a + pnl_b == 0, "trade PnL must be zero-sum");
 }
 
@@ -344,7 +344,7 @@ fn proof_flat_negative_resolves_through_insurance() {
         engine.finalize_touched_accounts_post_live(&ctx);
     }
 
-    assert!(engine.accounts[idx as usize].pnl == 0i128);
+    assert!(engine.accounts[idx as usize].pnl.get() == 0i128);
     assert!(engine.insurance_fund.balance.get() <= ins_before);
 }
 
@@ -391,10 +391,10 @@ fn t4_18_precision_exhaustion_both_sides_reset() {
 
     // A_mult = 2, OI = 3*PS. Closing 2*PS leaves OI_post = 1*PS.
     // A_candidate = floor(2 * 1 / 3) = 0 → precision exhaustion.
-    engine.adl_mult_long = 2;
-    engine.adl_coeff_long = 0i128;
-    engine.oi_eff_long_q = 3 * POS_SCALE;
-    engine.oi_eff_short_q = 3 * POS_SCALE;
+    engine.adl_mult_long = U128::new(2);
+    engine.adl_coeff_long = I128::ZERO;
+    engine.oi_eff_long_q = U128::new(3 * POS_SCALE);
+    engine.oi_eff_short_q = U128::new(3 * POS_SCALE);
     engine.stored_pos_count_long = 1;
 
     let q_close = 2 * POS_SCALE;
@@ -402,8 +402,8 @@ fn t4_18_precision_exhaustion_both_sides_reset() {
     assert!(result.is_ok());
 
     // Both sides' OI must be zeroed (precision exhaustion terminal drain)
-    assert!(engine.oi_eff_long_q == 0, "opposing OI must be zeroed");
-    assert!(engine.oi_eff_short_q == 0, "liquidated OI must be zeroed");
+    assert!(engine.oi_eff_long_q.get() == 0, "opposing OI must be zeroed");
+    assert!(engine.oi_eff_short_q.get() == 0, "liquidated OI must be zeroed");
     assert!(ctx.pending_reset_long, "opposing side must be pending reset");
     assert!(ctx.pending_reset_short, "liquidated side must be pending reset");
 }
@@ -458,10 +458,10 @@ fn t4_21_precision_exhaustion_zeroes_both_sides() {
     let mut engine = RiskEngine::new(zero_fee_params());
     let mut ctx = InstructionContext::new();
 
-    engine.adl_mult_long = 1;
-    engine.oi_eff_long_q = 3 * POS_SCALE;
-    engine.oi_eff_short_q = 3 * POS_SCALE;
-    engine.adl_coeff_long = 0i128;
+    engine.adl_mult_long = U128::new(1);
+    engine.oi_eff_long_q = U128::new(3 * POS_SCALE);
+    engine.oi_eff_short_q = U128::new(3 * POS_SCALE);
+    engine.adl_coeff_long = I128::ZERO;
     engine.stored_pos_count_long = 1;
 
     let q_close = POS_SCALE;
@@ -470,8 +470,8 @@ fn t4_21_precision_exhaustion_zeroes_both_sides() {
     let result = engine.enqueue_adl(&mut ctx, Side::Short, q_close, d);
     assert!(result.is_ok());
 
-    assert!(engine.oi_eff_long_q == 0);
-    assert!(engine.oi_eff_short_q == 0);
+    assert!(engine.oi_eff_long_q.get() == 0);
+    assert!(engine.oi_eff_short_q.get() == 0);
     assert!(ctx.pending_reset_long);
     assert!(ctx.pending_reset_short);
 }
@@ -485,10 +485,10 @@ fn t4_22_k_overflow_routes_to_absorb() {
     let mut ctx = InstructionContext::new();
 
     // Set K near i128::MIN so delta_K addition underflows
-    engine.adl_coeff_long = i128::MIN + 1;
-    engine.adl_mult_long = POS_SCALE; // Use POS_SCALE (not ADL_ONE) to keep computation manageable
-    engine.oi_eff_long_q = 4 * POS_SCALE;
-    engine.oi_eff_short_q = 4 * POS_SCALE;
+    engine.adl_coeff_long = I128::new(i128::MIN + 1);
+    engine.adl_mult_long = U128::new(POS_SCALE); // Use POS_SCALE (not ADL_ONE) to keep computation manageable
+    engine.oi_eff_long_q = U128::new(4 * POS_SCALE);
+    engine.oi_eff_short_q = U128::new(4 * POS_SCALE);
     engine.stored_pos_count_long = 1;
     engine.insurance_fund.balance = U128::new(10_000_000);
 
@@ -509,7 +509,7 @@ fn t4_22_k_overflow_routes_to_absorb() {
     assert!(engine.insurance_fund.balance.get() < ins_before,
         "insurance must decrease when absorbing overflow deficit");
     // A must still shrink (quantity routing is independent of K overflow)
-    assert!(engine.adl_mult_long < POS_SCALE, "A must shrink even on K overflow");
+    assert!(engine.adl_mult_long.get() < POS_SCALE, "A must shrink even on K overflow");
 }
 
 /// D=0 ADL: K must be unchanged, A must decrease, OI updated.
@@ -521,10 +521,10 @@ fn t4_23_d_zero_routes_quantity_only() {
     let mut ctx = InstructionContext::new();
 
     let k_init: i8 = kani::any();
-    engine.adl_coeff_long = k_init as i128;
-    engine.adl_mult_long = ADL_ONE;
-    engine.oi_eff_long_q = 10 * POS_SCALE;
-    engine.oi_eff_short_q = 10 * POS_SCALE;
+    engine.adl_coeff_long = I128::new(k_init as i128);
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.oi_eff_long_q = U128::new(10 * POS_SCALE);
+    engine.oi_eff_short_q = U128::new(10 * POS_SCALE);
     engine.stored_pos_count_long = 1;
 
     let k_before = engine.adl_coeff_long;
@@ -540,8 +540,8 @@ fn t4_23_d_zero_routes_quantity_only() {
     // A must decrease
     assert!(engine.adl_mult_long < a_before, "A must decrease after quantity ADL");
     // OI must decrease by q_close on both sides
-    assert!(engine.oi_eff_long_q == 9 * POS_SCALE);
-    assert!(engine.oi_eff_short_q == 9 * POS_SCALE);
+    assert!(engine.oi_eff_long_q.get() == 9 * POS_SCALE);
+    assert!(engine.oi_eff_short_q.get() == 9 * POS_SCALE);
 }
 
 // ############################################################################
@@ -638,15 +638,15 @@ fn t5_23_dust_clearance_guard_safe() {
 fn t13_54_funding_no_mint_asymmetric_a() {
     let mut engine = RiskEngine::new(zero_fee_params());
 
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
 
     let a_long: u16 = kani::any();
     kani::assume(a_long >= 1 && a_long <= 10);
     let a_short: u16 = kani::any();
     kani::assume(a_short >= 1 && a_short <= 10);
-    engine.adl_mult_long = a_long as u128;
-    engine.adl_mult_short = a_short as u128;
+    engine.adl_mult_long = U128::new(a_long as u128);
+    engine.adl_mult_short = U128::new(a_short as u128);
 
     engine.last_oracle_price = 100;
     engine.last_market_slot = 0;
@@ -857,8 +857,8 @@ fn proof_gc_dust_preserves_fee_credits() {
     // Account has 0 capital, 0 position, but positive fee_credits (prepaid)
     engine.set_capital(a as usize, 0);
     engine.accounts[a as usize].fee_credits = I128::new(5_000);
-    engine.accounts[a as usize].position_basis_q = 0i128;
-    engine.accounts[a as usize].reserved_pnl = 0u128;
+    engine.accounts[a as usize].position_basis_q = I128::ZERO;
+    engine.accounts[a as usize].reserved_pnl = U128::ZERO;
     engine.set_pnl(a as usize, 0i128);
 
     assert!(engine.is_used(a as usize));
@@ -876,8 +876,8 @@ fn proof_gc_dust_preserves_fee_credits() {
     engine.deposit(b, 10_000, 100, 1).unwrap();
     engine.set_capital(b as usize, 0);
     engine.accounts[b as usize].fee_credits = I128::new(-3_000); // debt
-    engine.accounts[b as usize].position_basis_q = 0i128;
-    engine.accounts[b as usize].reserved_pnl = 0u128;
+    engine.accounts[b as usize].position_basis_q = I128::ZERO;
+    engine.accounts[b as usize].reserved_pnl = U128::ZERO;
     engine.set_pnl(b as usize, 0i128);
 
     assert!(engine.is_used(b as usize));
@@ -1074,9 +1074,9 @@ fn proof_phantom_dust_drain_no_revert() {
 
     // Set up opposing side with phantom OI but no stored positions.
     // OI is balanced (required invariant), stored_pos_count_opp = 0.
-    engine.adl_mult_long = ADL_ONE;
-    engine.oi_eff_long_q = POS_SCALE;   // phantom OI on long side (opp)
-    engine.oi_eff_short_q = POS_SCALE;  // matching OI on short side (liq)
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.oi_eff_long_q = U128::new(POS_SCALE);   // phantom OI on long side (opp)
+    engine.oi_eff_short_q = U128::new(POS_SCALE);  // matching OI on short side (liq)
     engine.stored_pos_count_long = 0;   // no stored positions on opposing side
     engine.stored_pos_count_short = 1;  // liq side has stored positions
 
@@ -1089,8 +1089,8 @@ fn proof_phantom_dust_drain_no_revert() {
 
     // After enqueue_adl: OI_eff_short was decremented by q_close in step 1 → 0
     // OI_eff_long was set to oi_post = OI - q_close = 0 in step 5
-    assert!(engine.oi_eff_long_q == 0, "opp OI must be 0");
-    assert!(engine.oi_eff_short_q == 0, "liq OI must be 0");
+    assert!(engine.oi_eff_long_q.get() == 0, "opp OI must be 0");
+    assert!(engine.oi_eff_short_q.get() == 0, "liq OI must be 0");
 
     // Both pending resets must be set
     assert!(ctx.pending_reset_long, "drained opp side must have pending reset");
@@ -1295,8 +1295,8 @@ fn proof_gc_reclaims_flat_dust_capital() {
 
     let cap = engine.accounts[idx as usize].capital.get();
     assert!(cap > 0 && cap < 10_000, "account must have dust capital");
-    assert!(engine.accounts[idx as usize].pnl == 0);
-    assert!(engine.accounts[idx as usize].position_basis_q == 0);
+    assert!(engine.accounts[idx as usize].pnl.get() == 0);
+    assert!(engine.accounts[idx as usize].position_basis_q.get() == 0);
     assert!(engine.is_used(idx as usize));
 
     let ins_before = engine.insurance_fund.balance.get();
@@ -1351,10 +1351,10 @@ fn proof_property_3_oracle_manipulation_haircut_safety() {
     engine.keeper_crank_not_atomic(slot2, spike_oracle, &[(a, None), (b, None)], 64, 0i128, h_lock).unwrap();
 
     // After touch, a has positive PnL but it's reserved (R_i > 0)
-    let pnl_a = engine.accounts[a as usize].pnl;
+    let pnl_a = engine.accounts[a as usize].pnl.get();
     assert!(pnl_a > 0, "account a must have positive PnL after oracle spike");
 
-    let r_a = engine.accounts[a as usize].reserved_pnl;
+    let r_a = engine.accounts[a as usize].reserved_pnl.get();
     assert!(r_a > 0, "fresh profit must be reserved (R_i > 0)");
 
     // (a) PNL_matured_pos_tot must not have increased from fresh reserved profit
@@ -1413,9 +1413,9 @@ fn proof_property_26_maintenance_vs_im_dual_equity() {
     engine.keeper_crank_not_atomic(slot2, new_oracle, &[(a, None), (b, None)], 64, 0i128, h_lock).unwrap();
 
     // a now has fresh PnL from price increase. This PnL is reserved.
-    let pnl_a = engine.accounts[a as usize].pnl;
+    let pnl_a = engine.accounts[a as usize].pnl.get();
     assert!(pnl_a > 0, "a must have positive PnL");
-    let r_a = engine.accounts[a as usize].reserved_pnl;
+    let r_a = engine.accounts[a as usize].reserved_pnl.get();
     assert!(r_a > 0, "fresh profit must be reserved");
 
     // Maintenance uses full PnL_i → should be healthy
@@ -1511,8 +1511,8 @@ fn proof_audit_fee_sweep_pnl_conservation() {
     engine.set_capital(a as usize, 0);
     engine.set_pnl(a as usize, 50i128);
     // Mark PnL as fully matured (no reserve)
-    engine.accounts[a as usize].reserved_pnl = 0;
-    engine.pnl_matured_pos_tot = 50;
+    engine.accounts[a as usize].reserved_pnl = U128::ZERO;
+    engine.pnl_matured_pos_tot = U128::new(50);
 
     // Set large fee debt — capital can't cover it
     engine.accounts[a as usize].fee_credits = I128::new(-50);
@@ -1560,10 +1560,10 @@ fn proof_audit_im_uses_exact_raw_equity() {
     engine.deposit(a, 100, DEFAULT_ORACLE, DEFAULT_SLOT).unwrap();
 
     // Set up a position with very negative PnL to make Eq_init_raw < 0
-    engine.accounts[a as usize].position_basis_q = (1 * POS_SCALE) as i128;
+    engine.accounts[a as usize].position_basis_q = I128::new((1 * POS_SCALE) as i128);
     engine.stored_pos_count_long = 1;
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
     engine.set_pnl(a as usize, -500i128);
 
     // Eq_init_raw = C(100) + min(PnL, 0)(-500) + eff_matured(0) - fee(0) = -400
@@ -1595,8 +1595,8 @@ fn proof_audit_empty_lp_gc_reclaimable() {
 
     // LP has zero capital, zero PnL, zero position — it's dead
     assert!(engine.accounts[lp as usize].capital.get() == 0);
-    assert!(engine.accounts[lp as usize].pnl == 0);
-    assert!(engine.accounts[lp as usize].position_basis_q == 0);
+    assert!(engine.accounts[lp as usize].pnl.get() == 0);
+    assert!(engine.accounts[lp as usize].position_basis_q.get() == 0);
 
     // GC should reclaim this empty LP slot
     let freed = engine.garbage_collect_dust();
@@ -1740,7 +1740,7 @@ fn proof_audit2_positive_overflow_equity_conservative() {
     // This bypasses MAX_VAULT_TVL but tests the overflow fallback path.
     let huge_capital = (i128::MAX as u128) + 1; // 2^127
     engine.accounts[a as usize].capital = U128::new(huge_capital);
-    engine.accounts[a as usize].pnl = 0i128;
+    engine.accounts[a as usize].pnl = I128::ZERO;
     engine.accounts[a as usize].fee_credits = I128::ZERO;
 
     // Eq_maint_raw = C + PnL - FeeDebt = huge_capital + 0 - 0 = huge_capital > i128::MAX
@@ -1774,10 +1774,10 @@ fn proof_audit2_positive_overflow_no_false_liquidation() {
     // Set up a position + huge capital
     let huge_capital = (i128::MAX as u128) + 1;
     engine.accounts[a as usize].capital = U128::new(huge_capital);
-    engine.accounts[a as usize].position_basis_q = (1 * POS_SCALE) as i128;
+    engine.accounts[a as usize].position_basis_q = I128::new((1 * POS_SCALE) as i128);
     engine.stored_pos_count_long = 1;
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
 
     let above_mm = engine.is_above_maintenance_margin(
         &engine.accounts[a as usize], a as usize, DEFAULT_ORACLE);
@@ -1877,35 +1877,35 @@ fn proof_audit4_init_in_place_canonical() {
     engine.vault = U128::new(999);
     engine.insurance_fund.balance = U128::new(777);
     engine.c_tot = U128::new(555);
-    engine.pnl_pos_tot = 333;
-    engine.pnl_matured_pos_tot = 222;
+    engine.pnl_pos_tot = U128::new(333);
+    engine.pnl_matured_pos_tot = U128::new(222);
     engine.current_slot = 42;
     engine.last_crank_slot = 77;
     engine.gc_cursor = 2;
-    engine.adl_mult_long = 42;
-    engine.adl_mult_short = 43;
-    engine.adl_coeff_long = 100;
-    engine.adl_coeff_short = 200;
+    engine.adl_mult_long = U128::new(42);
+    engine.adl_mult_short = U128::new(43);
+    engine.adl_coeff_long = I128::new(100);
+    engine.adl_coeff_short = I128::new(200);
     engine.adl_epoch_long = 7;
     engine.adl_epoch_short = 8;
-    engine.adl_epoch_start_k_long = 300;
-    engine.adl_epoch_start_k_short = 400;
-    engine.oi_eff_long_q = 1000;
-    engine.oi_eff_short_q = 2000;
+    engine.adl_epoch_start_k_long = I128::new(300);
+    engine.adl_epoch_start_k_short = I128::new(400);
+    engine.oi_eff_long_q = U128::new(1000);
+    engine.oi_eff_short_q = U128::new(2000);
     engine.side_mode_long = SideMode::DrainOnly;
     engine.side_mode_short = SideMode::ResetPending;
     engine.stored_pos_count_long = 10;
     engine.stored_pos_count_short = 11;
     engine.stale_account_count_long = 3;
     engine.stale_account_count_short = 4;
-    engine.phantom_dust_bound_long_q = 50;
-    engine.phantom_dust_bound_short_q = 60;
+    engine.phantom_dust_bound_long_q = U128::new(50);
+    engine.phantom_dust_bound_short_q = U128::new(60);
     engine.num_used_accounts = 10;
     engine.materialized_account_count = 5;
     engine.last_oracle_price = 9999;
     engine.last_market_slot = 55;
-    engine.f_long_num = 42;
-    engine.f_short_num = -42;
+    engine.f_long_num = I128::new(42);
+    engine.f_short_num = I128::new(-42);
     engine.params.insurance_floor = U128::new(12345);
     engine.free_head = u16::MAX; // break the freelist
 
@@ -1918,35 +1918,35 @@ fn proof_audit4_init_in_place_canonical() {
 
     // ---- Aggregates ----
     assert!(engine.c_tot.get() == 0);
-    assert!(engine.pnl_pos_tot == 0);
-    assert!(engine.pnl_matured_pos_tot == 0);
+    assert!(engine.pnl_pos_tot.get() == 0);
+    assert!(engine.pnl_matured_pos_tot.get() == 0);
 
     // ---- Slots / cursors ----
     assert!(engine.current_slot == 0);
     assert!(engine.last_crank_slot == 0);
     assert!(engine.gc_cursor == 0);
-    assert!(engine.f_long_num == 0);
-    assert!(engine.f_short_num == 0);
+    assert!(engine.f_long_num.get() == 0);
+    assert!(engine.f_short_num.get() == 0);
 
     // ---- ADL / side state ----
-    assert!(engine.adl_mult_long == ADL_ONE);
-    assert!(engine.adl_mult_short == ADL_ONE);
-    assert!(engine.adl_coeff_long == 0);
-    assert!(engine.adl_coeff_short == 0);
+    assert!(engine.adl_mult_long == U128::new(ADL_ONE));
+    assert!(engine.adl_mult_short == U128::new(ADL_ONE));
+    assert!(engine.adl_coeff_long.get() == 0);
+    assert!(engine.adl_coeff_short.get() == 0);
     assert!(engine.adl_epoch_long == 0);
     assert!(engine.adl_epoch_short == 0);
-    assert!(engine.adl_epoch_start_k_long == 0);
-    assert!(engine.adl_epoch_start_k_short == 0);
-    assert!(engine.oi_eff_long_q == 0);
-    assert!(engine.oi_eff_short_q == 0);
+    assert!(engine.adl_epoch_start_k_long.get() == 0);
+    assert!(engine.adl_epoch_start_k_short.get() == 0);
+    assert!(engine.oi_eff_long_q.get() == 0);
+    assert!(engine.oi_eff_short_q.get() == 0);
     assert!(engine.side_mode_long == SideMode::Normal);
     assert!(engine.side_mode_short == SideMode::Normal);
     assert!(engine.stored_pos_count_long == 0);
     assert!(engine.stored_pos_count_short == 0);
     assert!(engine.stale_account_count_long == 0);
     assert!(engine.stale_account_count_short == 0);
-    assert!(engine.phantom_dust_bound_long_q == 0);
-    assert!(engine.phantom_dust_bound_short_q == 0);
+    assert!(engine.phantom_dust_bound_long_q.get() == 0);
+    assert!(engine.phantom_dust_bound_short_q.get() == 0);
 
     // ---- Account tracking ----
     assert!(engine.num_used_accounts == 0);
@@ -2225,7 +2225,7 @@ fn proof_audit5_reclaim_rejects_open_position() {
     let idx = engine.add_user(0).unwrap();
 
     // Give the account a position
-    engine.accounts[idx as usize].position_basis_q = 100;
+    engine.accounts[idx as usize].position_basis_q = I128::new(100);
 
     let result = engine.reclaim_empty_account_not_atomic(idx, DEFAULT_SLOT);
     assert!(result.is_err(), "must reject account with open position");
@@ -2577,8 +2577,8 @@ fn proof_execute_trade_full_margin_enforcement() {
         engine.attach_effective_position(lp as usize, -old_pos_q);
         // Update OI to match
         let abs_q = old_pos_q.unsigned_abs();
-        engine.oi_eff_long_q = abs_q;
-        engine.oi_eff_short_q = abs_q;
+        engine.oi_eff_long_q = U128::new(abs_q);
+        engine.oi_eff_short_q = U128::new(abs_q);
     }
 
     let old_eff_user = engine.effective_pos_q(user as usize);
@@ -2686,7 +2686,7 @@ fn proof_convert_released_pnl_exercises_conversion() {
     engine.keeper_crank_not_atomic(slot2, high_oracle, &[(a, None), (b, None)], 64, 0i128, 0).unwrap();
 
     // Verify the account still has a position (not flat — won't early-return at step 4)
-    assert!(engine.accounts[a as usize].position_basis_q != 0,
+    assert!(engine.accounts[a as usize].position_basis_q.get() != 0,
         "account must have open position");
 
     let released = engine.released_pos(a as usize);

--- a/tests/proofs_v1131.rs
+++ b/tests/proofs_v1131.rs
@@ -57,10 +57,10 @@ fn proof_funding_rate_bound_rejected() {
 #[kani::solver(cadical)]
 fn proof_funding_sign_and_floor() {
     let mut engine = RiskEngine::new(zero_fee_params());
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
     engine.last_oracle_price = DEFAULT_ORACLE;
     engine.last_market_slot = 0;
 
@@ -100,10 +100,10 @@ fn proof_funding_sign_and_floor() {
 #[kani::solver(cadical)]
 fn proof_funding_floor_not_truncation() {
     let mut engine = RiskEngine::new(zero_fee_params());
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
     engine.last_oracle_price = DEFAULT_ORACLE;
     engine.last_market_slot = 0;
 
@@ -134,13 +134,13 @@ fn proof_funding_floor_not_truncation() {
 #[kani::solver(cadical)]
 fn proof_funding_skip_zero_oi_short() {
     let mut engine = RiskEngine::new(zero_fee_params());
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
     engine.last_oracle_price = DEFAULT_ORACLE;
     engine.last_market_slot = 0;
 
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = 0;
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::ZERO;
 
     let k_long_before = engine.adl_coeff_long;
     let k_short_before = engine.adl_coeff_short;
@@ -160,13 +160,13 @@ fn proof_funding_skip_zero_oi_short() {
 #[kani::solver(cadical)]
 fn proof_funding_skip_zero_oi_long() {
     let mut engine = RiskEngine::new(zero_fee_params());
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
     engine.last_oracle_price = DEFAULT_ORACLE;
     engine.last_market_slot = 0;
 
-    engine.oi_eff_long_q = 0;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.oi_eff_long_q = U128::ZERO;
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
 
     let k_long_before = engine.adl_coeff_long;
     let k_short_before = engine.adl_coeff_short;
@@ -186,13 +186,13 @@ fn proof_funding_skip_zero_oi_long() {
 #[kani::solver(cadical)]
 fn proof_funding_skip_zero_oi_both() {
     let mut engine = RiskEngine::new(zero_fee_params());
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
     engine.last_oracle_price = DEFAULT_ORACLE;
     engine.last_market_slot = 0;
 
-    engine.oi_eff_long_q = 0;
-    engine.oi_eff_short_q = 0;
+    engine.oi_eff_long_q = U128::ZERO;
+    engine.oi_eff_short_q = U128::ZERO;
 
     let k_long_before = engine.adl_coeff_long;
     let k_short_before = engine.adl_coeff_short;
@@ -217,10 +217,10 @@ fn proof_funding_skip_zero_oi_both() {
 #[kani::solver(cadical)]
 fn proof_funding_substep_large_dt() {
     let mut engine = RiskEngine::new(zero_fee_params());
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
     engine.last_oracle_price = DEFAULT_ORACLE;
     engine.last_market_slot = 0;
 
@@ -234,9 +234,9 @@ fn proof_funding_substep_large_dt() {
     // sub-step 2: fund_num = 1000 * 100 * 1 = 100_000; fund_term = floor(100_000/1e9) = 0
     // total fund_term effect = 6 * ADL_ONE = 6_000_000
     let expected_delta: i128 = 6i128 * (ADL_ONE as i128);
-    assert_eq!(engine.adl_coeff_long, -expected_delta,
+    assert_eq!(engine.adl_coeff_long, I128::new(-expected_delta),
         "K_long must reflect sum of sub-step funding deltas");
-    assert_eq!(engine.adl_coeff_short, expected_delta,
+    assert_eq!(engine.adl_coeff_short, I128::new(expected_delta),
         "K_short must reflect sum of sub-step funding deltas");
 }
 
@@ -251,10 +251,10 @@ fn proof_funding_substep_large_dt() {
 #[kani::solver(cadical)]
 fn proof_funding_price_basis_timing() {
     let mut engine = RiskEngine::new(zero_fee_params());
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
     engine.last_oracle_price = 500; // old price (also used as fund_px_0 in v12.16.4)
     engine.last_market_slot = 0;
 
@@ -270,7 +270,7 @@ fn proof_funding_price_basis_timing() {
     // K_long += ADL_ONE * 1000 = 1_000_000_000 (mark)
     // K_long -= ADL_ONE * 50 = 50_000_000 (funding)
     // Net K_long = 1_000_000_000 - 50_000_000 = 950_000_000
-    let expected_k_long = 1_000_000_000i128 - 50_000_000i128;
+    let expected_k_long = I128::new(1_000_000_000i128 - 50_000_000i128);
     assert_eq!(engine.adl_coeff_long, expected_k_long,
         "funding must use fund_px_0=500, not oracle=1500");
 
@@ -289,10 +289,10 @@ fn proof_funding_price_basis_timing() {
 #[kani::solver(cadical)]
 fn proof_accrue_no_funding_when_rate_zero() {
     let mut engine = RiskEngine::new(zero_fee_params());
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
     engine.last_oracle_price = DEFAULT_ORACLE;
     engine.last_market_slot = 0;
 
@@ -316,10 +316,10 @@ fn proof_accrue_no_funding_when_rate_zero() {
 fn proof_accrue_mark_still_works() {
     let mut engine = RiskEngine::new(zero_fee_params());
 
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
     engine.last_oracle_price = DEFAULT_ORACLE;
     engine.last_market_slot = 0;
 
@@ -377,7 +377,7 @@ fn proof_deposit_no_insurance_draw() {
         "deposit must never decrement I");
 
     // PNL must still be negative (settle_losses paid from capital but couldn't cover all)
-    assert!(engine.accounts[idx as usize].pnl < 0,
+    assert!(engine.accounts[idx as usize].pnl.get() < 0,
         "negative PNL must survive deposit — resolve_flat_negative not called");
 }
 
@@ -416,7 +416,7 @@ fn proof_deposit_sweep_pnl_guard() {
     // PNL is still very negative, so sweep must NOT happen
     assert!(engine.accounts[idx as usize].fee_credits.get() == fc_before,
         "deposit must not sweep when PNL < 0 after settle_losses");
-    assert!(engine.accounts[idx as usize].pnl < 0,
+    assert!(engine.accounts[idx as usize].pnl.get() < 0,
         "PNL must still be negative — settle_losses can't cover full loss");
 }
 
@@ -438,7 +438,7 @@ fn proof_deposit_sweep_when_pnl_nonneg() {
     engine.accounts[idx as usize].fee_credits = I128::new(-5000);
 
     // PNL = 0 (flat position, no losses)
-    assert!(engine.accounts[idx as usize].pnl == 0);
+    assert!(engine.accounts[idx as usize].pnl.get() == 0);
 
     // Symbolic deposit amount
     let dep: u32 = kani::any();
@@ -524,7 +524,7 @@ fn proof_positive_conversion_denominator() {
     // released_pos = pnl_matured_pos_tot contribution from this account.
     // In a flat account, after warmup, the released portion is positive.
     // We directly verify the haircut ratio:
-    engine.pnl_matured_pos_tot = pnl_val as u128;
+    engine.pnl_matured_pos_tot = U128::new(pnl_val as u128);
 
     let (h_num, h_den) = engine.haircut_ratio();
     // When pnl_matured_pos_tot > 0, h_den == pnl_matured_pos_tot > 0
@@ -583,9 +583,9 @@ fn proof_bilateral_oi_decomposition() {
         let expected_short = if eff_a < 0 { eff_a.unsigned_abs() } else { 0 }
             + if eff_b < 0 { eff_b.unsigned_abs() } else { 0 };
 
-        assert!(engine.oi_eff_long_q == expected_long,
+        assert!(engine.oi_eff_long_q.get() == expected_long,
             "OI_long must match bilateral decomposition");
-        assert!(engine.oi_eff_short_q == expected_short,
+        assert!(engine.oi_eff_short_q.get() == expected_short,
             "OI_short must match bilateral decomposition");
 
         // OI balance: must be equal

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -19,8 +19,8 @@ fn default_params() -> RiskParams {
         liquidation_fee_cap: U128::new(1_000_000),
         min_liquidation_abs: U128::new(0),
         min_initial_deposit: U128::new(1000),
-        min_nonzero_mm_req: 1,
-        min_nonzero_im_req: 2,
+        min_nonzero_mm_req: U128::new(1),
+        min_nonzero_im_req: U128::new(2),
         insurance_floor: U128::ZERO,
         h_min: 0,
         h_max: 100,
@@ -228,7 +228,7 @@ fn test_basic_trade() {
     let eff_b = engine.effective_pos_q(b as usize);
     assert_eq!(eff_a, make_size_q(100), "account a must be long 100 units");
     assert_eq!(eff_b, make_size_q(-100), "account b must be short 100 units");
-    assert!(engine.oi_eff_long_q > 0, "open interest must be nonzero after trade");
+    assert!(engine.oi_eff_long_q.get() > 0, "open interest must be nonzero after trade");
     assert!(engine.check_conservation());
 }
 
@@ -276,7 +276,7 @@ fn test_trade_with_different_exec_price() {
 
     // Account a (long) bought at exec=990 vs oracle=1000, so should have positive PnL
     // trade_pnl = floor(100 * POS_SCALE * (1000 - 990) / POS_SCALE) = 1000
-    assert!(engine.accounts[a as usize].pnl > 0,
+    assert!(engine.accounts[a as usize].pnl.get() > 0,
         "long PnL must be positive when exec < oracle: pnl={}",
         engine.accounts[a as usize].pnl);
 
@@ -450,8 +450,8 @@ fn test_cohort_reserve_set_on_new_profit() {
     }
 
     // If PnL is positive, reserved_pnl should be nonzero (cohort-based warmup with h_lock>0)
-    if engine.accounts[a as usize].pnl > 0 {
-        assert!(engine.accounts[a as usize].reserved_pnl > 0,
+    if engine.accounts[a as usize].pnl.get() > 0 {
+        assert!(engine.accounts[a as usize].reserved_pnl.get() > 0,
             "reserved_pnl should be nonzero for positive PnL (cohort warmup with h_lock>0)");
     }
 }
@@ -752,12 +752,12 @@ fn test_adl_epoch_changes() {
     let epoch_long_before = engine.adl_epoch_long;
 
     // Begin a full drain reset on long side (requires OI=0)
-    assert!(engine.oi_eff_long_q == 0);
+    assert!(engine.oi_eff_long_q.get() == 0);
     engine.begin_full_drain_reset(Side::Long);
 
     assert_eq!(engine.adl_epoch_long, epoch_long_before + 1);
     assert_eq!(engine.side_mode_long, SideMode::ResetPending);
-    assert_eq!(engine.adl_mult_long, ADL_ONE);
+    assert_eq!(engine.adl_mult_long.get(), ADL_ONE);
 }
 
 #[test]
@@ -923,7 +923,7 @@ fn test_close_account_after_trade_and_unwind() {
 
     // PnL should be zero or converted by now
     let pnl = engine.accounts[a as usize].pnl;
-    if pnl == 0 {
+    if pnl.get() == 0 {
         let cap = engine.close_account_not_atomic(a, slot2, oracle, 0i128, 0).expect("close account");
         assert!(cap > 0);
         assert!(!engine.is_used(a as usize));
@@ -1216,11 +1216,11 @@ fn test_keeper_crank_propagates_corruption() {
 
     // Set up a corrupt state: a_basis = 0 triggers CorruptState error
     // in settle_side_effects (called by touch_account_full_not_atomic)
-    engine.accounts[a as usize].position_basis_q = POS_SCALE as i128;
-    engine.accounts[a as usize].adl_a_basis = 0; // CORRUPT: a_basis must be > 0
+    engine.accounts[a as usize].position_basis_q = I128::new(POS_SCALE as i128);
+    engine.accounts[a as usize].adl_a_basis = U128::ZERO; // CORRUPT: a_basis must be > 0
     engine.stored_pos_count_long = 1;
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
 
     // keeper_crank_not_atomic must propagate the CorruptState error, not swallow it
     let result = engine.keeper_crank_not_atomic(2, oracle, &[(a, None)], 64, 0i128, 0);
@@ -1259,10 +1259,10 @@ fn test_same_slot_price_change_applies_mark() {
     engine.current_slot = slot;
     engine.last_oracle_price = oracle;
     engine.last_market_slot = slot; // same slot
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
 
     let k_long_before = engine.adl_coeff_long;
     let k_short_before = engine.adl_coeff_short;
@@ -1301,8 +1301,8 @@ fn test_schedule_reset_error_propagated_in_withdraw() {
     // This makes schedule_end_of_instruction_resets return CorruptState.
     engine.stored_pos_count_long = 0;
     engine.stored_pos_count_short = 0;
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE * 2; // unequal OI
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE * 2); // unequal OI
 
     let result = engine.withdraw_not_atomic(a, 1, oracle, slot, 0i128, 0);
     assert!(result.is_err(), "withdraw_not_atomic must propagate reset error on corrupt state");
@@ -1394,10 +1394,10 @@ fn test_accrue_market_to_multi_substep_large_dt() {
     let mut engine = RiskEngine::new(default_params());
     engine.last_oracle_price = 1000;
     engine.last_market_slot = 0;
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
 
     // High funding rate, large time gap requiring multiple sub-steps
     let large_dt = MAX_FUNDING_DT * 3 + 100; // triggers 4 sub-steps
@@ -1416,10 +1416,10 @@ fn test_accrue_market_funding_rate_zero_no_funding_applied() {
     let mut engine = RiskEngine::new(default_params());
     engine.last_oracle_price = 1000;
     engine.last_market_slot = 0;
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
 
     let k_long_before = engine.adl_coeff_long;
     let k_short_before = engine.adl_coeff_short;
@@ -1439,10 +1439,10 @@ fn test_accrue_market_applies_funding_transfer() {
     let mut engine = RiskEngine::new(default_params());
     engine.last_oracle_price = 1000;
     engine.last_market_slot = 0;
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
 
     let f_long_before = engine.f_long_num;
     let f_short_before = engine.f_short_num;
@@ -1470,10 +1470,10 @@ fn test_accrue_market_no_funding_when_rate_zero() {
     let mut engine = RiskEngine::new(default_params());
     engine.last_oracle_price = 1000;
     engine.last_market_slot = 0;
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
 
     let k_long_before = engine.adl_coeff_long;
     let k_short_before = engine.adl_coeff_short;
@@ -1641,17 +1641,17 @@ fn test_charge_fee_safe_rejects_pnl_at_i256_min() {
     // Liquidation fee would push PnL to exactly i128::MIN — must return Err
     // We test via the public liquidate path, but first set up the conditions
     // for an underwater account with a position.
-    engine.accounts[a as usize].position_basis_q = POS_SCALE as i128;
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
+    engine.accounts[a as usize].position_basis_q = I128::new(POS_SCALE as i128);
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
     engine.adl_epoch_long = 0;
     engine.adl_epoch_short = 0;
-    engine.accounts[a as usize].adl_a_basis = ADL_ONE;
-    engine.accounts[a as usize].adl_k_snap = 0i128;
+    engine.accounts[a as usize].adl_a_basis = U128::new(ADL_ONE);
+    engine.accounts[a as usize].adl_k_snap = I128::new(0i128);
     engine.accounts[a as usize].adl_epoch_snap = 0;
     engine.stored_pos_count_long = 1;
-    engine.oi_eff_long_q = POS_SCALE;
-    engine.oi_eff_short_q = POS_SCALE;
+    engine.oi_eff_long_q = U128::new(POS_SCALE);
+    engine.oi_eff_short_q = U128::new(POS_SCALE);
     engine.last_oracle_price = oracle;
     engine.last_market_slot = slot;
     engine.last_crank_slot = slot;
@@ -1660,7 +1660,7 @@ fn test_charge_fee_safe_rejects_pnl_at_i256_min() {
     let result = engine.liquidate_at_oracle_not_atomic(a, slot, oracle, LiquidationPolicy::FullClose, 0i128, 0);
     // Either it errors out or it succeeds but PnL is not i128::MIN
     if result.is_ok() {
-        assert!(engine.accounts[a as usize].pnl != i128::MIN,
+        assert!(engine.accounts[a as usize].pnl.get() != i128::MIN,
             "PnL must never reach i128::MIN");
     }
 }
@@ -1700,8 +1700,8 @@ fn test_oracle_price_max_accepted() {
     let mut engine = RiskEngine::new(default_params());
     engine.last_oracle_price = 1000;
     engine.last_market_slot = 0;
-    engine.adl_mult_long = ADL_ONE;
-    engine.adl_mult_short = ADL_ONE;
+    engine.adl_mult_long = U128::new(ADL_ONE);
+    engine.adl_mult_short = U128::new(ADL_ONE);
 
     let result = engine.accrue_market_to(1, MAX_ORACLE_PRICE, 0);
     assert!(result.is_ok(), "MAX_ORACLE_PRICE must be accepted");
@@ -1835,7 +1835,7 @@ fn test_gc_dust_preserves_fee_credits() {
 
     // Set up dust-like state: 0 capital, 0 position, but positive fee_credits
     engine.set_capital(a as usize, 0);
-    engine.accounts[a as usize].position_basis_q = 0i128;
+    engine.accounts[a as usize].position_basis_q = I128::new(0i128);
     engine.set_pnl(a as usize, 0i128);
     engine.accounts[a as usize].fee_credits = I128::new(5_000);
 
@@ -1867,7 +1867,7 @@ fn test_gc_collects_dead_account_with_negative_fee_credits() {
 
     // Simulate abandoned account: zero everything, inject negative fee_credits
     engine.set_capital(a as usize, 0);
-    engine.accounts[a as usize].position_basis_q = 0i128;
+    engine.accounts[a as usize].position_basis_q = I128::new(0i128);
     engine.set_pnl(a as usize, 0i128);
     engine.accounts[a as usize].fee_credits = I128::new(-500);
 
@@ -1894,7 +1894,7 @@ fn test_gc_still_protects_positive_fee_credits() {
     engine.keeper_crank_not_atomic(slot, oracle, &[] as &[(u16, Option<LiquidationPolicy>)], 64, 0i128, 0).unwrap();
 
     engine.set_capital(a as usize, 0);
-    engine.accounts[a as usize].position_basis_q = 0i128;
+    engine.accounts[a as usize].position_basis_q = I128::new(0i128);
     engine.set_pnl(a as usize, 0i128);
     // Large positive prepaid credits
     engine.accounts[a as usize].fee_credits = I128::new(1_000_000);
@@ -2025,15 +2025,15 @@ fn test_property_49_consume_released_pnl_preserves_reserve() {
     // After set_pnl, the increase goes to reserved_pnl; simulate warmup completion
     {
         let old_r = engine.accounts[idx].reserved_pnl;
-        engine.accounts[idx].reserved_pnl = 0;
-        engine.pnl_matured_pos_tot += old_r;
+        engine.accounts[idx].reserved_pnl = U128::new(0);
+        engine.pnl_matured_pos_tot = U128::new(engine.pnl_matured_pos_tot.get() + old_r.get());
     }
 
     let r_before = engine.accounts[idx].reserved_pnl;
     let ppt_before = engine.pnl_pos_tot;
     let pmpt_before = engine.pnl_matured_pos_tot;
 
-    assert_eq!(r_before, 0, "all profit should be released");
+    assert_eq!(r_before.get(), 0, "all profit should be released");
 
     let x = 2_000u128;
     engine.consume_released_pnl(idx, x);
@@ -2044,7 +2044,7 @@ fn test_property_49_consume_released_pnl_preserves_reserve() {
         "pnl_pos_tot must decrease by x");
     assert_eq!(engine.pnl_matured_pos_tot, pmpt_before - x,
         "pnl_matured_pos_tot must decrease by x");
-    assert_eq!(engine.accounts[idx].pnl, 3_000i128,
+    assert_eq!(engine.accounts[idx].pnl.get(), 3_000i128,
         "PNL_i must decrease by x");
 }
 
@@ -2078,8 +2078,8 @@ fn test_property_50_flat_only_auto_conversion() {
     engine.set_pnl(idx_a, 10_000);
     {
         let old_r = engine.accounts[idx_a].reserved_pnl;
-        engine.accounts[idx_a].reserved_pnl = 0;
-        engine.pnl_matured_pos_tot += old_r;
+        engine.accounts[idx_a].reserved_pnl = U128::new(0);
+        engine.pnl_matured_pos_tot = U128::new(engine.pnl_matured_pos_tot.get() + old_r.get());
     }
     engine.vault = U128::new(engine.vault.get() + 10_000); // fund the PnL
 
@@ -2093,7 +2093,7 @@ fn test_property_50_flat_only_auto_conversion() {
     }
 
     let pnl_after = engine.accounts[idx_a].pnl;
-    assert!(pnl_after > 0, "open-position touch must not zero out released profit via auto-convert");
+    assert!(pnl_after.get() > 0, "open-position touch must not zero out released profit via auto-convert");
 
     // Now test flat account: close the position first
     engine.execute_trade_not_atomic(b, a, oracle, slot + 1, size_q, oracle, 0i128, 0).unwrap();
@@ -2102,8 +2102,8 @@ fn test_property_50_flat_only_auto_conversion() {
     engine.set_pnl(idx_a, 5_000);
     {
         let old_r = engine.accounts[idx_a].reserved_pnl;
-        engine.accounts[idx_a].reserved_pnl = 0;
-        engine.pnl_matured_pos_tot += old_r;
+        engine.accounts[idx_a].reserved_pnl = U128::new(0);
+        engine.pnl_matured_pos_tot = U128::new(engine.pnl_matured_pos_tot.get() + old_r.get());
     }
     engine.vault = U128::new(engine.vault.get() + 5_000);
 
@@ -2119,7 +2119,7 @@ fn test_property_50_flat_only_auto_conversion() {
     // After flat touch, released profit should have been converted to capital
     let pnl_after_flat = engine.accounts[idx_a].pnl;
     let cap_after_flat = engine.accounts[idx_a].capital.get();
-    assert_eq!(pnl_after_flat, 0, "flat touch must convert released profit (PNL → 0)");
+    assert_eq!(pnl_after_flat.get(), 0, "flat touch must convert released profit (PNL → 0)");
     assert!(cap_after_flat > cap_before_flat, "flat touch must increase capital from conversion");
 }
 
@@ -2187,12 +2187,12 @@ fn test_property_52_convert_released_pnl_explicit() {
     // Set released matured profit: use UseHLock(10) so PnL goes to reserve queue
     let idx = a as usize;
     engine.set_pnl_with_reserve(idx, 10_000, ReserveMode::UseHLock(10)).unwrap();
-    assert_eq!(engine.accounts[idx].reserved_pnl, 10_000, "all goes to reserve with h_lock>0");
+    assert_eq!(engine.accounts[idx].reserved_pnl.get(), 10_000, "all goes to reserve with h_lock>0");
     // Advance past horizon to mature cohorts, releasing 7000 (keep 3000 reserved)
     engine.current_slot = slot + 20; // well past h_lock=10
     engine.advance_profit_warmup(idx);
     // All 10000 is now matured; manually set reserved to 3000 to simulate partial release
-    engine.accounts[idx].reserved_pnl = 3_000;
+    engine.accounts[idx].reserved_pnl = U128::new(3_000);
     // Adjust matured for the re-reservation
     engine.pnl_matured_pos_tot = engine.pnl_matured_pos_tot.saturating_sub(3_000);
 
@@ -2210,8 +2210,8 @@ fn test_property_52_convert_released_pnl_explicit() {
     // Requesting more than released must fail
     let released_now = {
         let pnl = engine.accounts[idx].pnl;
-        let pos = if pnl > 0 { pnl as u128 } else { 0u128 };
-        pos.saturating_sub(engine.accounts[idx].reserved_pnl)
+        let pos = if pnl.get() > 0 { pnl.get() as u128 } else { 0u128 };
+        pos.saturating_sub(engine.accounts[idx].reserved_pnl.get())
     };
     let result2 = engine.convert_released_pnl_not_atomic(a, released_now + 1, oracle, slot3, 0i128, 0);
     assert!(result2.is_err(), "requesting more than released must fail");
@@ -2247,7 +2247,7 @@ fn test_property_53_phantom_dust_adl_ordering() {
 
     // Verify balanced OI before crash
     assert_eq!(engine.oi_eff_long_q, engine.oi_eff_short_q, "OI must be balanced");
-    assert!(engine.oi_eff_long_q > 0, "OI must be nonzero");
+    assert!(engine.oi_eff_long_q.get() > 0, "OI must be nonzero");
     assert!(engine.stored_pos_count_long > 0, "should have stored long positions");
 
     // Crash the price to make 'a' (long) deeply underwater, triggering
@@ -2308,7 +2308,7 @@ fn test_property_54_unilateral_exact_drain_reset() {
     assert!(engine.check_conservation(), "conservation must hold after exact-drain scenario");
 
     // If long OI went to 0, the side should have a reset scheduled or already finalized
-    if engine.oi_eff_long_q == 0 && engine.stored_pos_count_long == 0 {
+    if engine.oi_eff_long_q.get() == 0 && engine.stored_pos_count_long == 0 {
         // Side was fully drained — mode should transition appropriately
         assert!(engine.side_mode_long != SideMode::Normal
                 || engine.stored_pos_count_short == 0,
@@ -2476,7 +2476,7 @@ fn test_force_close_combined_convenience() {
 
     // First call on positive-PnL account: reconciles, may be Deferred
     let a_result = engine.force_close_resolved_not_atomic(a, 200).unwrap();
-    if engine.accounts[a as usize].pnl > 0 && a_result.is_progress_only() {
+    if engine.accounts[a as usize].pnl.get() > 0 && a_result.is_progress_only() {
         assert!(engine.is_used(a as usize), "account stays open when deferred");
     }
 
@@ -2657,8 +2657,8 @@ fn test_force_close_multiple_sequential_no_aggregate_drift() {
     }
 
     assert_eq!(engine.c_tot.get(), 0);
-    assert_eq!(engine.pnl_pos_tot, 0);
-    assert_eq!(engine.pnl_matured_pos_tot, 0);
+    assert_eq!(engine.pnl_pos_tot.get(), 0);
+    assert_eq!(engine.pnl_matured_pos_tot.get(), 0);
     assert_eq!(engine.stored_pos_count_long, 0);
     assert_eq!(engine.stored_pos_count_short, 0);
     assert_eq!(engine.num_used_accounts, 0);
@@ -2679,7 +2679,7 @@ fn test_force_close_decrements_positions() {
 
     // resolve_market zeroes OI; force_close zeroes positions
     engine.resolve_market(1000, 1000, 100, 0).unwrap();
-    assert_eq!(engine.oi_eff_long_q, 0, "resolve_market zeroes OI");
+    assert_eq!(engine.oi_eff_long_q.get(), 0, "resolve_market zeroes OI");
 
     // Close both sides — position counts go to 0
     engine.force_close_resolved_not_atomic(a, 100).unwrap().expect_closed("force_close");
@@ -2723,7 +2723,7 @@ fn test_force_close_rejects_corrupt_a_basis() {
     // Manufacture corrupt state: nonzero position with a_basis = 0
     engine.set_position_basis_q(a as usize, (10 * POS_SCALE) as i128);
     engine.stored_pos_count_long = 1;
-    engine.accounts[a as usize].adl_a_basis = 0;
+    engine.accounts[a as usize].adl_a_basis = U128::ZERO;
 
     engine.market_mode = MarketMode::Resolved;
     let result = engine.force_close_resolved_not_atomic(a, 100);
@@ -2759,7 +2759,7 @@ fn test_property_31_fullclose_liquidation_zeros_position() {
     assert_eq!(engine.effective_pos_q(a as usize), 0,
         "FullClose liquidation must zero the effective position");
     // Position basis must also be zero
-    assert_eq!(engine.accounts[a as usize].position_basis_q, 0,
+    assert_eq!(engine.accounts[a as usize].position_basis_q.get(), 0,
         "FullClose liquidation must zero position_basis_q");
     assert!(engine.check_conservation());
 }
@@ -2774,17 +2774,17 @@ fn test_append_reserve_creates_sched_bucket() {
     let idx = engine.add_user(1000).unwrap();
     engine.deposit(idx, 100_000, 1000, 100).unwrap();
     // Simulate positive PnL increase that would create a reserve
-    engine.accounts[idx as usize].pnl = 10_000;
-    engine.accounts[idx as usize].reserved_pnl = 0;
+    engine.accounts[idx as usize].pnl = I128::new(10_000);
+    engine.accounts[idx as usize].reserved_pnl = U128::new(0);
     engine.current_slot = 100;
 
     engine.append_or_route_new_reserve(idx as usize, 10_000, 100, 50);
 
     assert_eq!(engine.accounts[idx as usize].sched_present, 1);
-    assert_eq!(engine.accounts[idx as usize].sched_remaining_q, 10_000);
+    assert_eq!(engine.accounts[idx as usize].sched_remaining_q.get(), 10_000);
     assert_eq!(engine.accounts[idx as usize].sched_horizon, 50);
     assert_eq!(engine.accounts[idx as usize].sched_start_slot, 100);
-    assert_eq!(engine.accounts[idx as usize].reserved_pnl, 10_000);
+    assert_eq!(engine.accounts[idx as usize].reserved_pnl.get(), 10_000);
 }
 
 #[test]
@@ -2799,10 +2799,10 @@ fn test_append_reserve_merges_same_slot_horizon() {
 
     // Should merge into one scheduled bucket
     assert_eq!(engine.accounts[idx as usize].sched_present, 1);
-    assert_eq!(engine.accounts[idx as usize].sched_remaining_q, 8_000);
-    assert_eq!(engine.accounts[idx as usize].sched_anchor_q, 8_000);
+    assert_eq!(engine.accounts[idx as usize].sched_remaining_q.get(), 8_000);
+    assert_eq!(engine.accounts[idx as usize].sched_anchor_q.get(), 8_000);
     assert_eq!(engine.accounts[idx as usize].pending_present, 0);
-    assert_eq!(engine.accounts[idx as usize].reserved_pnl, 8_000);
+    assert_eq!(engine.accounts[idx as usize].reserved_pnl.get(), 8_000);
 }
 
 #[test]
@@ -2818,8 +2818,8 @@ fn test_append_reserve_different_horizon_creates_pending() {
     // First goes to sched, second to pending (different horizon, so no merge)
     assert_eq!(engine.accounts[idx as usize].sched_present, 1);
     assert_eq!(engine.accounts[idx as usize].pending_present, 1);
-    assert_eq!(engine.accounts[idx as usize].pending_remaining_q, 3_000);
-    assert_eq!(engine.accounts[idx as usize].reserved_pnl, 8_000);
+    assert_eq!(engine.accounts[idx as usize].pending_remaining_q.get(), 3_000);
+    assert_eq!(engine.accounts[idx as usize].reserved_pnl.get(), 8_000);
 }
 
 #[test]
@@ -2838,8 +2838,8 @@ fn test_apply_reserve_loss_newest_first() {
 
     assert_eq!(engine.accounts[idx as usize].pending_present, 0); // pending removed
     assert_eq!(engine.accounts[idx as usize].sched_present, 1);
-    assert_eq!(engine.accounts[idx as usize].sched_remaining_q, 4_000); // sched had 5k - 1k = 4k
-    assert_eq!(engine.accounts[idx as usize].reserved_pnl, 4_000);
+    assert_eq!(engine.accounts[idx as usize].sched_remaining_q.get(), 4_000); // sched had 5k - 1k = 4k
+    assert_eq!(engine.accounts[idx as usize].reserved_pnl.get(), 4_000);
 }
 
 #[test]
@@ -2850,11 +2850,11 @@ fn test_prepare_account_for_resolved_touch() {
     engine.current_slot = 100;
 
     engine.append_or_route_new_reserve(idx as usize, 10_000, 100, 50);
-    assert_eq!(engine.accounts[idx as usize].reserved_pnl, 10_000);
+    assert_eq!(engine.accounts[idx as usize].reserved_pnl.get(), 10_000);
 
     engine.prepare_account_for_resolved_touch(idx as usize);
 
-    assert_eq!(engine.accounts[idx as usize].reserved_pnl, 0);
+    assert_eq!(engine.accounts[idx as usize].reserved_pnl.get(), 0);
     assert_eq!(engine.accounts[idx as usize].sched_present, 0);
     assert_eq!(engine.accounts[idx as usize].pending_present, 0);
 }
@@ -2868,25 +2868,25 @@ fn test_advance_profit_warmup_sched_maturity() {
     engine.current_slot = 100;
 
     // Create a scheduled bucket: 10_000 reserve, horizon 100 slots, starting at slot 100
-    engine.accounts[idx as usize].pnl = 10_000;
-    engine.pnl_pos_tot = 10_000;
+    engine.accounts[idx as usize].pnl = I128::new(10_000);
+    engine.pnl_pos_tot = U128::new(10_000);
     engine.append_or_route_new_reserve(idx as usize, 10_000, 100, 100);
-    assert_eq!(engine.accounts[idx as usize].reserved_pnl, 10_000);
+    assert_eq!(engine.accounts[idx as usize].reserved_pnl.get(), 10_000);
 
     // Advance 50 slots -> should release floor(10_000 * 50 / 100) = 5_000
     engine.current_slot = 150;
     let matured_before = engine.pnl_matured_pos_tot;
     engine.advance_profit_warmup(idx as usize);
 
-    let released = engine.pnl_matured_pos_tot - matured_before;
+    let released = (engine.pnl_matured_pos_tot - matured_before).get();
     assert_eq!(released, 5_000, "50% of horizon should release 50% of reserve");
-    assert_eq!(engine.accounts[idx as usize].reserved_pnl, 5_000);
+    assert_eq!(engine.accounts[idx as usize].reserved_pnl.get(), 5_000);
 
     // Advance to full maturity (slot 200)
     engine.current_slot = 200;
     engine.advance_profit_warmup(idx as usize);
 
-    assert_eq!(engine.accounts[idx as usize].reserved_pnl, 0, "fully matured");
+    assert_eq!(engine.accounts[idx as usize].reserved_pnl.get(), 0, "fully matured");
     assert_eq!(engine.accounts[idx as usize].sched_present, 0, "empty bucket cleared");
 }
 
@@ -2898,24 +2898,24 @@ fn test_advance_profit_warmup_sched_then_pending_promotion() {
     engine.current_slot = 100;
 
     // Two buckets: sched (10k, h=100) then pending (5k, h=200)
-    engine.accounts[idx as usize].pnl = 15_000;
-    engine.pnl_pos_tot = 15_000;
+    engine.accounts[idx as usize].pnl = I128::new(15_000);
+    engine.pnl_pos_tot = U128::new(15_000);
     engine.append_or_route_new_reserve(idx as usize, 10_000, 100, 100); // sched: 100-slot horizon
     engine.append_or_route_new_reserve(idx as usize, 5_000, 100, 200);  // pending: 200-slot horizon
 
     assert_eq!(engine.accounts[idx as usize].sched_present, 1);
     assert_eq!(engine.accounts[idx as usize].pending_present, 1);
-    assert_eq!(engine.accounts[idx as usize].reserved_pnl, 15_000);
+    assert_eq!(engine.accounts[idx as usize].reserved_pnl.get(), 15_000);
 
     // At slot 200: sched fully matured -> clears + promotes pending to sched
     engine.current_slot = 200;
     engine.advance_profit_warmup(idx as usize);
 
     // sched 10_000 fully released, pending promoted to sched (starts at slot 200)
-    assert_eq!(engine.accounts[idx as usize].reserved_pnl, 5_000);
+    assert_eq!(engine.accounts[idx as usize].reserved_pnl.get(), 5_000);
     assert_eq!(engine.accounts[idx as usize].sched_present, 1, "pending promoted to sched");
     assert_eq!(engine.accounts[idx as usize].pending_present, 0);
-    assert_eq!(engine.accounts[idx as usize].sched_remaining_q, 5_000);
+    assert_eq!(engine.accounts[idx as usize].sched_remaining_q.get(), 5_000);
     assert_eq!(engine.accounts[idx as usize].sched_start_slot, 200);
 }
 
@@ -2929,12 +2929,12 @@ fn test_set_pnl_with_reserve_positive_increase_creates_cohort() {
     // Set PnL from 0 to 10_000 with H_lock=50
     engine.set_pnl_with_reserve(idx as usize, 10_000, ReserveMode::UseHLock(50)).unwrap();
 
-    assert_eq!(engine.accounts[idx as usize].pnl, 10_000);
-    assert_eq!(engine.accounts[idx as usize].reserved_pnl, 10_000);
+    assert_eq!(engine.accounts[idx as usize].pnl.get(), 10_000);
+    assert_eq!(engine.accounts[idx as usize].reserved_pnl.get(), 10_000);
     assert_eq!(engine.accounts[idx as usize].sched_present, 1);
-    assert_eq!(engine.pnl_pos_tot, 10_000);
+    assert_eq!(engine.pnl_pos_tot.get(), 10_000);
     // Matured should NOT increase (reserve not yet matured)
-    assert_eq!(engine.pnl_matured_pos_tot, 0);
+    assert_eq!(engine.pnl_matured_pos_tot.get(), 0);
 }
 
 #[test]
@@ -2945,9 +2945,9 @@ fn test_set_pnl_with_reserve_immediate_release() {
 
     engine.set_pnl_with_reserve(idx as usize, 10_000, ReserveMode::ImmediateRelease).unwrap();
 
-    assert_eq!(engine.accounts[idx as usize].pnl, 10_000);
-    assert_eq!(engine.accounts[idx as usize].reserved_pnl, 0); // no reserve
-    assert_eq!(engine.pnl_matured_pos_tot, 10_000); // immediately matured
+    assert_eq!(engine.accounts[idx as usize].pnl.get(), 10_000);
+    assert_eq!(engine.accounts[idx as usize].reserved_pnl.get(), 0); // no reserve
+    assert_eq!(engine.pnl_matured_pos_tot.get(), 10_000); // immediately matured
 }
 
 #[test]
@@ -2959,14 +2959,14 @@ fn test_set_pnl_with_reserve_negative_lifo_loss() {
 
     // Start with 10_000 reserved
     engine.set_pnl_with_reserve(idx as usize, 10_000, ReserveMode::UseHLock(50)).unwrap();
-    assert_eq!(engine.accounts[idx as usize].reserved_pnl, 10_000);
+    assert_eq!(engine.accounts[idx as usize].reserved_pnl.get(), 10_000);
 
     // PnL drops to 3_000 → loss of 7_000 from positive, consumed from reserve LIFO
     engine.set_pnl_with_reserve(idx as usize, 3_000, ReserveMode::NoPositiveIncreaseAllowed).unwrap();
 
-    assert_eq!(engine.accounts[idx as usize].pnl, 3_000);
-    assert_eq!(engine.accounts[idx as usize].reserved_pnl, 3_000); // 10_000 - 7_000
-    assert_eq!(engine.pnl_pos_tot, 3_000);
+    assert_eq!(engine.accounts[idx as usize].pnl.get(), 3_000);
+    assert_eq!(engine.accounts[idx as usize].reserved_pnl.get(), 3_000); // 10_000 - 7_000
+    assert_eq!(engine.pnl_pos_tot.get(), 3_000);
 }
 
 #[test]
@@ -2978,8 +2978,8 @@ fn test_set_pnl_with_reserve_h_lock_zero_immediate() {
     // H_lock = 0 means immediate release (no cohort)
     engine.set_pnl_with_reserve(idx as usize, 5_000, ReserveMode::UseHLock(0)).unwrap();
 
-    assert_eq!(engine.accounts[idx as usize].reserved_pnl, 0);
-    assert_eq!(engine.pnl_matured_pos_tot, 5_000);
+    assert_eq!(engine.accounts[idx as usize].reserved_pnl.get(), 0);
+    assert_eq!(engine.pnl_matured_pos_tot.get(), 5_000);
 }
 
 // ============================================================================
@@ -2995,7 +2995,7 @@ fn test_touch_live_local_does_not_auto_convert() {
 
     // Give account positive PnL (flat, released)
     engine.set_pnl(idx as usize, 10_000);
-    engine.pnl_matured_pos_tot = 10_000;
+    engine.pnl_matured_pos_tot = U128::new(10_000);
 
     let cap_before = engine.accounts[idx as usize].capital.get();
     engine.last_market_slot = 100;
@@ -3082,8 +3082,8 @@ fn test_resolve_market_basic() {
     assert!(result.is_ok());
     assert!(engine.market_mode == MarketMode::Resolved);
     assert_eq!(engine.resolved_price, 1000);
-    assert_eq!(engine.oi_eff_long_q, 0);
-    assert_eq!(engine.oi_eff_short_q, 0);
+    assert_eq!(engine.oi_eff_long_q.get(), 0);
+    assert_eq!(engine.oi_eff_short_q.get(), 0);
     assert_eq!(engine.pnl_matured_pos_tot, engine.pnl_pos_tot);
 }
 
@@ -3137,8 +3137,8 @@ fn test_blocker1_trade_open_must_not_use_unreleased_pnl() {
     engine.touch_account_live_local(a as usize, &mut ctx).unwrap();
 
     // a now has reserved positive PnL (not yet released due to h_lock=50)
-    assert!(engine.accounts[a as usize].pnl > 0, "a must have positive PnL");
-    assert!(engine.accounts[a as usize].reserved_pnl > 0, "PnL must be reserved");
+    assert!(engine.accounts[a as usize].pnl.get() > 0, "a must have positive PnL");
+    assert!(engine.accounts[a as usize].reserved_pnl.get() > 0, "PnL must be reserved");
 
     // Compute trade-open equity and init equity
     let eq_trade = engine.account_equity_trade_open_raw(
@@ -3212,10 +3212,10 @@ fn audit_2_trade_open_must_use_all_pos_pnl_via_g() {
     engine.deposit(a, 100, 1000, 100).unwrap();
 
     // Inject positive PnL, ALL in reserve (unreleased)
-    engine.accounts[a as usize].pnl = 100;
-    engine.accounts[a as usize].reserved_pnl = 100;
-    engine.pnl_pos_tot = 100;
-    engine.pnl_matured_pos_tot = 0;
+    engine.accounts[a as usize].pnl = I128::new(100);
+    engine.accounts[a as usize].reserved_pnl = U128::new(100);
+    engine.pnl_pos_tot = U128::new(100);
+    engine.pnl_matured_pos_tot = U128::new(0);
     // Vault fully backs positive PnL: g = 1
     engine.vault = U128::new(engine.vault.get() + 100);
 
@@ -3327,7 +3327,7 @@ fn audit_9_pending_merge_uses_max_horizon() {
     engine.accounts[idx].pnl += 1000;
     engine.pnl_pos_tot += 1000;
     engine.append_or_route_new_reserve(idx, 1000, 102, 100);
-    assert_eq!(engine.accounts[idx].pending_remaining_q, 2000);
+    assert_eq!(engine.accounts[idx].pending_remaining_q.get(), 2000);
     assert_eq!(engine.accounts[idx].pending_horizon, 100,
         "pending horizon must be max of all merged horizons");
 }
@@ -3520,7 +3520,7 @@ fn funding_new_entrant_must_not_inherit_old_fraction() {
     let d_pnl = engine.accounts[d as usize].pnl;
     // With per-side F indices and f_snap, the new pair sees exactly
     // F(slot+2) - F(slot+1) funding, not the accumulated fraction.
-    assert!(c_pnl.abs() <= 1 && d_pnl.abs() <= 1,
+    assert!(c_pnl.get().abs() <= 1 && d_pnl.get().abs() <= 1,
         "new entrant must not inherit old fractional funding: c_pnl={}, d_pnl={}", c_pnl, d_pnl);
 }
 
@@ -3564,7 +3564,7 @@ fn funding_basic_sign_convention() {
     let b_cap = engine.accounts[b as usize].capital.get();
     assert!(a_cap < 500_000,
         "positive rate: long must lose capital, got cap={}", a_cap);
-    assert!(b_cap > 500_000 || engine.accounts[b as usize].pnl > 0,
+    assert!(b_cap > 500_000 || engine.accounts[b as usize].pnl.get() > 0,
         "positive rate: short must gain, cap={} pnl={}", b_cap, engine.accounts[b as usize].pnl);
     assert!(engine.check_conservation());
 }
@@ -3620,8 +3620,8 @@ fn test_kf_combined_floor_negative_boundary() {
     let f_before = engine.f_long_num;
 
     // Set K_diff = -1, F_diff = -FUNDING_DEN through accrue manipulation
-    engine.adl_coeff_long = engine.accounts[idx].adl_k_snap - 1;
-    engine.f_long_num = engine.accounts[idx].f_snap - (FUNDING_DEN as i128);
+    engine.adl_coeff_long = I128::new(engine.accounts[idx].adl_k_snap.get() - 1);
+    engine.f_long_num = I128::new(engine.accounts[idx].f_snap.get() - (FUNDING_DEN as i128));
 
     let pnl_before = engine.accounts[idx].pnl;
 
@@ -3641,7 +3641,7 @@ fn test_kf_combined_floor_negative_boundary() {
     // reasonable K_diff. Need larger abs_basis.
 
     // Let me use a direct approach: verify pnl_delta is not double-counted
-    assert!(pnl_delta >= -1,
+    assert!(pnl_delta.get() >= -1,
         "KF settlement must not double-floor: pnl_delta={}", pnl_delta);
 }
 
@@ -3696,10 +3696,10 @@ fn test_reclaim_rejects_nonempty_queue_metadata() {
 
     let idx = a as usize;
     // Corrupt state: reserved_pnl = 0 but bucket metadata not empty
-    engine.accounts[idx].reserved_pnl = 0;
+    engine.accounts[idx].reserved_pnl = U128::new(0);
     engine.accounts[idx].sched_present = 1; // orphaned metadata
-    engine.accounts[idx].pnl = 0;
-    engine.accounts[idx].position_basis_q = 0;
+    engine.accounts[idx].pnl = I128::new(0);
+    engine.accounts[idx].position_basis_q = I128::new(0);
     // Make capital dust (below min_initial_deposit)
     engine.set_capital(idx, 1);
 
@@ -3768,8 +3768,8 @@ fn test_funding_partition_invariance() {
 
     // K may differ between paths (different chunking → different integer parts).
     // But K*FUNDING_DEN + F must be the same (exact total funding).
-    let total_a = (k_a as i128) * (FUNDING_DEN as i128) + f_a;
-    let total_b = (k_b as i128) * (FUNDING_DEN as i128) + f_b;
+    let total_a = k_a.get() * (FUNDING_DEN as i128) + f_a.get();
+    let total_b = k_b.get() * (FUNDING_DEN as i128) + f_b.get();
     assert_eq!(total_a, total_b,
         "K*DEN + F must be partition-invariant: A=({},{}) B=({},{})", k_a, f_a, k_b, f_b);
 
@@ -3912,7 +3912,7 @@ fn test_settle_flat_negative_pnl() {
     engine.settle_flat_negative_pnl_not_atomic(a, 101).unwrap();
 
     // PnL should be zeroed, insurance should have absorbed the loss
-    assert_eq!(engine.accounts[a as usize].pnl, 0,
+    assert_eq!(engine.accounts[a as usize].pnl.get(), 0,
         "flat negative PnL must be zeroed");
     assert!(engine.check_conservation());
 }


### PR DESCRIPTION
## Summary

- All `#[repr(C)]` structs (`Account`, `RiskParams`, `RiskEngine`) used raw `i128`/`u128` for **30 fields** while only 2 fields used the safe `I128`/`U128` wrappers
- Rust 1.77+ changed `i128`/`u128` alignment from 8 to 16 bytes on x86_64, while BPF/SBF retains 8-byte alignment
- `#[repr(C)]` inserts different padding on each platform, producing **different struct layouts** for the same definition
- Any off-chain zero-copy deserialization (indexers, SDKs, test harnesses) on Rust 1.77+ x86_64 reads **corrupted field values** from on-chain BPF-serialized data — every field after the first misaligned `i128`/`u128` is at a wrong byte offset

## Changes

Replaced all 30 raw `i128`/`u128` struct fields with `I128`/`U128` wrappers (`[u64; 2]` internals, 8-byte aligned on all platforms) and updated all usage sites:

| Struct | Fields Changed | Details |
|--------|---------------|---------|
| `Account` | 10 | `pnl`, `reserved_pnl`, `position_basis_q`, `adl_a_basis`, `adl_k_snap`, `f_snap`, `sched_remaining_q`, `sched_anchor_q`, `sched_release_q`, `pending_remaining_q` |
| `RiskParams` | 2 | `min_nonzero_mm_req`, `min_nonzero_im_req` |
| `RiskEngine` | 18 | `resolved_payout_h_num/den`, `pnl_pos_tot`, `pnl_matured_pos_tot`, `adl_mult/coeff/epoch_start_k` for long/short, `oi_eff_long/short_q`, `phantom_dust_bound_long/short_q`, `f_long/short_num`, `f_epoch_start_long/short_num` |

**Usage site changes:**
- Reads: `.get()` to extract primitive `i128`/`u128`
- Writes: `I128::new(val)` / `U128::new(val)` for construction
- Zero initialization: `I128::ZERO` / `U128::ZERO`
- Local variables and function signatures remain as raw primitives — only persisted struct fields wrapped

**No behavioral changes** — the wrapper types produce identical arithmetic results. This is a pure layout-safety fix.

## Files modified

- `src/percolator.rs` — 30 field declarations + ~300 usage sites
- `tests/unit_tests.rs` — Test field access and initialization updated
- `tests/amm_tests.rs` — Test field access updated

## Test plan

- [x] `cargo check` — zero compilation errors
- [x] `cargo test --lib` — 49/49 library tests pass
- [x] `cargo check --tests` — all test targets compile cleanly
- [ ] Kani proofs (behind `#[cfg(kani)]`) may need similar `.get()`/`.new()` updates
- [ ] Verify `size_of::<Account>()` and `size_of::<RiskEngine>()` match expected BPF sizes via sizecheck examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)