### PR TITLE
fix: set_capital returns Result (consistent with set_position_basis_q)

### DIFF
--- a/src/percolator.rs
+++ b/src/percolator.rs
@@ -1156,18 +1156,19 @@ impl RiskEngine {
 
     /// set_capital (spec §4.2): checked signed-delta update of C_tot
     test_visible! {
-    fn set_capital(&mut self, idx: usize, new_capital: u128) {
+    fn set_capital(&mut self, idx: usize, new_capital: u128) -> Result<()> {
         let old = self.accounts[idx].capital.get();
         if new_capital >= old {
             let delta = new_capital - old;
             self.c_tot = U128::new(self.c_tot.get().checked_add(delta)
-                .expect("set_capital: c_tot overflow"));
+                .ok_or(RiskError::Overflow)?);
         } else {
             let delta = old - new_capital;
             self.c_tot = U128::new(self.c_tot.get().checked_sub(delta)
-                .expect("set_capital: c_tot underflow"));
+                .ok_or(RiskError::CorruptState)?);
         }
         self.accounts[idx].capital = U128::new(new_capital);
+        Ok(())
     }
     }
 
@@ -2672,7 +2673,7 @@ impl RiskEngine {
         let cap = self.accounts[idx].capital.get();
         let pay = core::cmp::min(need, cap);
         if pay > 0 {
-            self.set_capital(idx, cap - pay);
+            self.set_capital(idx, cap - pay)?;
             let pay_i128 = pay as i128; // pay <= need = |pnl| <= i128::MAX, safe
             let new_pnl = pnl.checked_add(pay_i128)
                 .ok_or(RiskError::CorruptState)?;
@@ -2700,16 +2701,16 @@ impl RiskEngine {
 
     /// fee_debt_sweep (spec §7.5): after any capital increase, sweep fee debt
     test_visible! {
-    fn fee_debt_sweep(&mut self, idx: usize) {
+    fn fee_debt_sweep(&mut self, idx: usize) -> Result<()> {
         let fc = self.accounts[idx].fee_credits.get();
         let debt = fee_debt_u128_checked(fc);
         if debt == 0 {
-            return;
+            return Ok(());
         }
         let cap = self.accounts[idx].capital.get();
         let pay = core::cmp::min(debt, cap);
         if pay > 0 {
-            self.set_capital(idx, cap - pay);
+            self.set_capital(idx, cap - pay)?;
             // pay <= debt = |fee_credits|, so fee_credits + pay <= 0: no overflow
             let pay_i128 = core::cmp::min(pay, i128::MAX as u128) as i128;
             self.accounts[idx].fee_credits = I128::new(self.accounts[idx].fee_credits.get()
@@ -2721,6 +2722,7 @@ impl RiskEngine {
         // Per spec §7.5: unpaid fee debt remains as local fee_credits until
         // physical capital becomes available or manual profit conversion occurs.
         // MUST NOT consume junior PnL claims to mint senior insurance capital.
+        Ok(())
     }
     }
 
@@ -2800,12 +2802,12 @@ impl RiskEngine {
                 if released > 0 {
                     self.consume_released_pnl(idx, released)?;
                     let new_cap = add_u128(self.accounts[idx].capital.get(), released);
-                    self.set_capital(idx, new_cap);
+                    self.set_capital(idx, new_cap)?;
                 }
             }
 
             // Fee-debt sweep
-            self.fee_debt_sweep(idx);
+            self.fee_debt_sweep(idx)?;
         }
         Ok(())
     }
@@ -2999,7 +3001,7 @@ impl RiskEngine {
 
         // Step 6: set_capital(i, C_i + capital_amount)
         let new_cap = add_u128(self.accounts[idx as usize].capital.get(), capital_amount);
-        self.set_capital(idx as usize, new_cap);
+        self.set_capital(idx as usize, new_cap)?;
 
         // Step 7: settle_losses_from_principal
         self.settle_losses(idx as usize)?;
@@ -3015,7 +3017,7 @@ impl RiskEngine {
         if self.accounts[idx as usize].position_basis_q == 0
             && self.accounts[idx as usize].pnl >= 0
         {
-            self.fee_debt_sweep(idx as usize);
+            self.fee_debt_sweep(idx as usize)?;
         }
 
         Ok(())
@@ -3097,7 +3099,7 @@ impl RiskEngine {
         }
 
         // Step 7: commit withdrawal
-        self.set_capital(idx as usize, self.accounts[idx as usize].capital.get() - amount);
+        self.set_capital(idx as usize, self.accounts[idx as usize].capital.get() - amount)?;
         self.vault = U128::new(sub_u128(self.vault.get(), amount));
 
         // Steps 8-9: end-of-instruction resets
@@ -3391,7 +3393,7 @@ impl RiskEngine {
         let cap = self.accounts[idx].capital.get();
         let fee_paid = core::cmp::min(fee, cap);
         if fee_paid > 0 {
-            self.set_capital(idx, cap - fee_paid);
+            self.set_capital(idx, cap - fee_paid)?;
             self.insurance_fund.balance = self.insurance_fund.balance + fee_paid;
         }
         let fee_shortfall = fee - fee_paid;
@@ -4039,10 +4041,10 @@ impl RiskEngine {
 
         // Step 8: set_capital(i, C_i + y)
         let new_cap = add_u128(self.accounts[idx as usize].capital.get(), y);
-        self.set_capital(idx as usize, new_cap);
+        self.set_capital(idx as usize, new_cap)?;
 
         // Step 9: sweep fee debt
-        self.fee_debt_sweep(idx as usize);
+        self.fee_debt_sweep(idx as usize)?;
 
         // Step 10: post-conversion health check
         let eff = self.effective_pos_q(idx as usize);
@@ -4120,7 +4122,7 @@ impl RiskEngine {
             return Err(RiskError::InsufficientBalance);
         }
         self.vault = self.vault - capital;
-        self.set_capital(idx as usize, 0);
+        self.set_capital(idx as usize, 0)?;
 
         // End-of-instruction resets before freeing
         self.schedule_end_of_instruction_resets(&mut ctx)?;
@@ -4429,17 +4431,17 @@ impl RiskEngine {
                     self.resolved_payout_h_num, self.resolved_payout_h_den);
                 self.consume_released_pnl(i, released)?;
                 let new_cap = add_u128(self.accounts[i].capital.get(), y);
-                self.set_capital(i, new_cap);
+                self.set_capital(i, new_cap)?;
             }
         }
-        self.fee_debt_sweep(i);
+        self.fee_debt_sweep(i)?;
         if self.accounts[i].fee_credits.get() < 0 {
             self.accounts[i].fee_credits = I128::ZERO;
         }
         let capital = self.accounts[i].capital;
         if capital > self.vault { return Err(RiskError::InsufficientBalance); }
         self.vault = self.vault - capital;
-        self.set_capital(i, 0);
+        self.set_capital(i, 0)?;
         self.free_slot(idx)?;
         Ok(capital.get())
     }
@@ -4497,7 +4499,7 @@ impl RiskEngine {
         // Step 7: reclamation effects (spec §2.6)
         let dust_cap = self.accounts[idx as usize].capital.get();
         if dust_cap > 0 {
-            self.set_capital(idx as usize, 0);
+            self.set_capital(idx as usize, 0)?;
             self.insurance_fund.balance = self.insurance_fund.balance + dust_cap;
         }
 
@@ -4566,7 +4568,7 @@ impl RiskEngine {
             // Sweep dust capital into insurance (spec §2.6)
             let dust_cap = self.accounts[idx].capital.get();
             if dust_cap > 0 {
-                self.set_capital(idx, 0);
+                self.set_capital(idx, 0)?;
                 self.insurance_fund.balance = self.insurance_fund.balance + dust_cap;
             }
 


### PR DESCRIPTION
## Summary
- Convert `set_capital` from `expect`/panic to `Result` return, matching the `set_position_basis_q` conversion in 788ddf8
- Also converts `fee_debt_sweep` (only internal caller that returned `()`)
- Propagates `?` at all 13 call sites across deposit, withdraw, trade, liquidation, conversion, GC, and close paths
- Last remaining aggregate-tracking helper that panics on public-reachable paths

## Test plan
- [x] `cargo test --features test` — 167/167 pass
- [x] `cargo clippy` — no new warnings introduced
- [x] All call sites already return `Result<()>` — mechanical `?` propagation