### PR TITLE
fix: cap total_dt at MAX_FUNDING_DT in accrue_market_to

### DIFF
--- a/src/percolator.rs
+++ b/src/percolator.rs
@@ -1690,7 +1690,8 @@ impl RiskEngine {
         let long_live = self.oi_eff_long_q != 0;
         let short_live = self.oi_eff_short_q != 0;
 
-        let total_dt = now_slot.saturating_sub(self.last_market_slot);
+        let total_dt = now_slot.saturating_sub(self.last_market_slot)
+            .min(MAX_FUNDING_DT);
         if total_dt == 0 && self.last_oracle_price == oracle_price {
             // Step 5: no change — set current_slot and return (spec §5.4)
             self.current_slot = now_slot;

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -3965,3 +3965,47 @@ fn test_resolved_context_getter() {
     assert_eq!(price, oracle);
     assert_eq!(rslot, slot);
 }
+
+// ============================================================================
+// SP-3 regression: MAX_FUNDING_DT cap prevents overflow in accrue_market_to
+// ============================================================================
+
+#[test]
+fn accrue_large_dt_does_not_overflow() {
+    // Before the MAX_FUNDING_DT cap, a large dt with high funding rate
+    // could overflow i128 in the funding product. The cap clips dt to
+    // 65535 so the computation stays within bounds.
+    let (mut engine, a, b) = setup_two_users(500_000, 500_000);
+    let oracle = 1000u64;
+    let slot = 2u64;
+    let size = make_size_q(100);
+
+    // Create positions so funding has counterparties
+    engine.execute_trade_not_atomic(a, b, oracle, slot, size, oracle, 0i128, 0).unwrap();
+
+    // Accrue with a very large dt gap (100,000 slots) and max funding rate.
+    // Without the cap, this would overflow. With the cap, dt is clipped to 65535.
+    let large_slot = slot + 100_000;
+    let max_funding = MAX_ABS_FUNDING_E9_PER_SLOT;
+    let result = engine.accrue_market_to(large_slot, oracle, max_funding);
+    assert!(result.is_ok(), "Large dt should succeed with MAX_FUNDING_DT cap: {:?}", result);
+
+    // Verify slot advanced to the actual requested slot (not clipped)
+    assert_eq!(engine.current_slot, large_slot);
+    assert_eq!(engine.last_market_slot, large_slot);
+}
+
+#[test]
+fn accrue_dt_at_cap_boundary() {
+    // Verify dt = MAX_FUNDING_DT exactly works
+    let (mut engine, a, b) = setup_two_users(500_000, 500_000);
+    let oracle = 1000u64;
+    let slot = 2u64;
+    let size = make_size_q(100);
+    engine.execute_trade_not_atomic(a, b, oracle, slot, size, oracle, 0i128, 0).unwrap();
+
+    // Exactly at the cap
+    let cap_slot = slot + MAX_FUNDING_DT;
+    let result = engine.accrue_market_to(cap_slot, oracle, MAX_ABS_FUNDING_E9_PER_SLOT);
+    assert!(result.is_ok(), "dt=MAX_FUNDING_DT should succeed: {:?}", result);
+}


### PR DESCRIPTION
## Summary
- `MAX_FUNDING_DT` (65535) is defined per spec §1.4 but never enforced in `accrue_market_to`
- The I256 funding product `fund_px * rate * dt` can overflow i128 at `try_into_i128()` when dt is large and parameters are near their maximums, making the market temporarily uncrank-able
- Caps `total_dt` at `MAX_FUNDING_DT` before the funding computation — mark-to-market is unaffected (uses `delta_p`, not `dt`)
- `current_slot` and `last_market_slot` still advance to the real slot

## Test plan
- [x] `cargo test --features test` — 221/221 pass
- [x] New test `accrue_large_dt_does_not_overflow` — verifies 100k slot gap with max funding rate succeeds
- [x] New test `accrue_dt_at_cap_boundary` — verifies dt=65535 exactly works
- [x] Verified mark-to-market path unaffected (uses delta_p, not total_dt)