### PR TITLE
Harden red-team findings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ overflow-checks = true
 inherits = "release"
 panic = "abort"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
+
 [workspace.metadata.kani]
 flags = { tests = true }
 unstable = { stubbing = true }

--- a/README.md
+++ b/README.md
@@ -171,6 +171,20 @@ PnL admission for untrusted public flows, sync recurring fees when enabled, and
 reject extraction-sensitive actions while raw oracle target and effective engine
 price diverge.
 
+### Wrapper Security Boundary
+
+Do not expose core primitives directly as permissionless public instructions:
+
+- `set_owner`, live/resolved insurance withdrawals, and insurance-to-account
+  credits require wrapper authentication and policy limits.
+- `ResolveMode::Degenerate` is a privileged recovery branch. Public resolution
+  flows should use ordinary resolution unless an authenticated recovery path
+  explicitly authorizes the degenerate branch.
+- Account-free `accrue_market_to` must not be a public heartbeat on exposed
+  markets when price or funding would move account equity. Public catch-up
+  should use an account-touching keeper/liquidation path or a wrapper proof that
+  the accrual is not equity-active.
+
 ---
 
 ## Open Source

--- a/src/wide_math.rs
+++ b/src/wide_math.rs
@@ -650,9 +650,7 @@ impl I256 {
         if neg {
             // Result must be <= 2^255 (magnitude of MIN)
             // 2^255 as U256: hi limb has bit 127 set (for [u128;2]) or bit 63 of limb[3] (for [u64;4])
-            let min_mag = U256::from_u128(0)
-                .checked_add(U256::from_u128(1u128 << 127))
-                .unwrap_or(U256::MAX);
+            let min_mag = U256::new(0, 1u128 << 127);
             // For exactly 2^255, result is MIN
             if product == min_mag {
                 return Some(I256::MIN);
@@ -873,9 +871,7 @@ impl I256 {
         if neg {
             // Result must be <= 2^255 (magnitude of MIN)
             // 2^255 as U256: hi limb has bit 127 set (for [u128;2]) or bit 63 of limb[3] (for [u64;4])
-            let min_mag = U256::from_u128(0)
-                .checked_add(U256::from_u128(1u128 << 127))
-                .unwrap_or(U256::MAX);
+            let min_mag = U256::new(0, 1u128 << 127);
             // For exactly 2^255, result is MIN
             if product == min_mag {
                 return Some(I256::MIN);
@@ -1921,6 +1917,20 @@ mod tests {
         let v = I256::from_i128(-100);
         let a = v.abs_u256();
         assert_eq!(a, U256::from_u128(100));
+    }
+
+    #[test]
+    fn test_i256_mul_negative_above_i128_magnitude() {
+        let a = I256::from_u128(1u128 << 127);
+        let b = I256::from_i128(-2);
+
+        let product = a
+            .checked_mul_i256(b)
+            .expect("-2^128 fits in signed 256-bit range");
+
+        assert!(product.is_negative());
+        assert_eq!(product.try_into_i128(), None);
+        assert_eq!(product.abs_u256(), U256::new(0, 1));
     }
 
     // --- I256 comparison ---

--- a/tests/proofs_audit.rs
+++ b/tests/proofs_audit.rs
@@ -46,14 +46,14 @@ fn proof_epoch_snap_zero_on_position_zeroout() {
     // Use set_position_basis_q to correctly track stored_pos_count.
     // Set epoch mismatch to skip the phantom dust U256 path
     // (irrelevant to the epoch_snap fix).
-    engine.set_position_basis_q(idx, signed_basis);
+    engine.set_position_basis_q(idx, signed_basis).unwrap();
     engine.accounts[idx].adl_a_basis = ADL_ONE;
     engine.accounts[idx].adl_k_snap = 0;
     // Epoch mismatch: snap=0 != epoch_long=5 / epoch_short=7
     engine.accounts[idx].adl_epoch_snap = 0;
 
     // Zero out the position
-    engine.attach_effective_position(idx, 0);
+    engine.attach_effective_position(idx, 0).unwrap();
 
     // Spec §2.4: all canonical zero-position defaults
     assert!(
@@ -97,7 +97,7 @@ fn proof_epoch_snap_correct_on_nonzero_attach() {
         -(basis as i128)
     };
 
-    engine.attach_effective_position(idx, new_eff);
+    engine.attach_effective_position(idx, new_eff).unwrap();
 
     if side_long {
         assert!(engine.accounts[idx].adl_epoch_snap == engine.adl_epoch_long);
@@ -285,7 +285,7 @@ fn proof_fee_debt_sweep_checked_arithmetic() {
     let fc_before = engine.accounts[idx].fee_credits.get();
     let ins_before = engine.insurance_fund.balance.get();
 
-    engine.fee_debt_sweep(idx);
+    engine.fee_debt_sweep(idx).unwrap();
 
     let cap_after = engine.accounts[idx].capital.get();
     let fc_after = engine.accounts[idx].fee_credits.get();
@@ -468,10 +468,9 @@ fn proof_close_account_pnl_check_before_fee_forgive() {
     let idx = add_user_test(&mut engine, 0).unwrap();
 
     // Set up consistent state: flat, PnL > 0 (fully reserved), capital = 0, fee debt
-    // Use set_pnl to keep pnl_pos_tot in sync
-    engine.set_pnl(idx as usize, 5000i128);
-    // All PnL is reserved (warmup not complete)
-    engine.accounts[idx as usize].reserved_pnl = 5000;
+    // Use the live-compatible helper to keep PnL aggregates and reserve
+    // buckets in sync.
+    set_pnl_test(&mut engine, idx as usize, 5000i128).unwrap();
     // Zero capital — fee_debt_sweep will be a no-op
     // (capital is already 0 from add_user with fee=0)
 
@@ -791,7 +790,7 @@ fn proof_reclaim_rejects_negative_pnl() {
     let idx = add_user_test(&mut engine, 0).unwrap();
     engine.deposit_not_atomic(idx, 1, DEFAULT_SLOT).unwrap();
 
-    engine.set_pnl(idx as usize, -100i128);
+    engine.set_pnl(idx as usize, -100i128).unwrap();
 
     let ins_before = engine.insurance_fund.balance.get();
 

--- a/tests/proofs_instructions.rs
+++ b/tests/proofs_instructions.rs
@@ -39,7 +39,7 @@ fn t3_16_reset_pending_counter_invariant() {
     engine.adl_coeff_long = k;
 
     engine.oi_eff_long_q = 0u128;
-    engine.begin_full_drain_reset(Side::Long);
+    engine.begin_full_drain_reset(Side::Long).unwrap();
 
     assert!(engine.side_mode_long == SideMode::ResetPending);
     assert!(engine.stale_account_count_long == 2);
@@ -86,7 +86,7 @@ fn t3_16b_reset_counter_with_nonzero_k_diff() {
     engine.adl_coeff_long = k_long;
 
     engine.oi_eff_long_q = 0u128;
-    engine.begin_full_drain_reset(Side::Long);
+    engine.begin_full_drain_reset(Side::Long).unwrap();
 
     assert!(engine.adl_epoch_start_k_long == k_long);
     assert!(engine.stale_account_count_long == 2);
@@ -133,7 +133,7 @@ fn t3_18_dust_bound_reset_in_begin_full_drain() {
     engine.phantom_dust_bound_long_q = 5u128;
     engine.oi_eff_long_q = 0u128;
 
-    engine.begin_full_drain_reset(Side::Long);
+    engine.begin_full_drain_reset(Side::Long).unwrap();
 
     assert!(
         engine.phantom_dust_bound_long_q == 0,
@@ -182,7 +182,7 @@ fn t6_26b_full_drain_reset_nonzero_k_diff() {
     engine.adl_coeff_long = 500i128;
 
     engine.oi_eff_long_q = 0u128;
-    engine.begin_full_drain_reset(Side::Long);
+    engine.begin_full_drain_reset(Side::Long).unwrap();
 
     assert!(engine.adl_epoch_start_k_long == 500i128);
     assert!(engine.adl_epoch_long == 1);
@@ -824,7 +824,7 @@ fn proof_begin_full_drain_reset() {
 
     assert!(engine.oi_eff_long_q == 0);
 
-    engine.begin_full_drain_reset(Side::Long);
+    engine.begin_full_drain_reset(Side::Long).unwrap();
 
     assert!(engine.adl_epoch_long == epoch_before + 1);
     assert!(engine.adl_mult_long == ADL_ONE);
@@ -1206,7 +1206,7 @@ fn t14_64_dust_bound_full_drain_reset_zeroes() {
     engine.stored_pos_count_long = 0;
     engine.adl_epoch_long = 0;
 
-    engine.begin_full_drain_reset(Side::Long);
+    engine.begin_full_drain_reset(Side::Long).unwrap();
 
     assert!(engine.phantom_dust_bound_long_q == 0u128);
     assert!(engine.oi_eff_long_q == 0u128);

--- a/tests/proofs_invariants.rs
+++ b/tests/proofs_invariants.rs
@@ -145,7 +145,7 @@ fn inductive_set_capital_decrease_preserves_accounting() {
 
     let new_cap: u32 = kani::any();
     kani::assume(new_cap <= dep);
-    engine.set_capital(idx as usize, new_cap as u128);
+    engine.set_capital(idx as usize, new_cap as u128).unwrap();
     assert!(engine.check_conservation());
 }
 

--- a/tests/proofs_lazy_ak.rs
+++ b/tests/proofs_lazy_ak.rs
@@ -601,7 +601,7 @@ fn t6_26_full_drain_reset_regression() {
     engine.adl_coeff_long = k_epoch_start;
 
     engine.oi_eff_long_q = 0u128;
-    engine.begin_full_drain_reset(Side::Long);
+    engine.begin_full_drain_reset(Side::Long).unwrap();
 
     assert!(engine.side_mode_long == SideMode::ResetPending);
     assert!(engine.adl_epoch_long == 1);


### PR DESCRIPTION
Summary:
- Fix signed 256-bit multiplication negative product bounds above i128 magnitude.
- Document the wrapper security boundary for privileged core primitives found during red-team review.
- Declare cfg(kani) as an expected cfg and tighten selected proof setup Result handling.

Validation:
- cargo fmt --all -- --check
- git diff --check
- cargo test test_i256_mul_negative_above_i128_magnitude --all-features
- cargo test
- cargo test --all-features
- cargo clippy --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings fails on existing lint debt: unused doc comments around macro-generated items, API/style clippy lints, and existing unused Result warnings in tests.