### PR TITLE
v16: detach solvent active legs in close_resolved_account_not_atomic (fixes #61)

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -15342,6 +15342,15 @@ impl MarketGroupV16 {
         if account.pnl < 0 {
             self.settle_resolved_bankruptcy_negative_pnl(account)?;
         }
+        // Detach solvent active legs after K/F/B settlement so the close
+        // can complete. Mirrors v12 `reconcile_resolved_not_atomic`'s
+        // `clear_position_basis_q` step (legacy `src/percolator.rs:9948`)
+        // ported forward to v16's multi-leg portfolio. Bankrupt accounts
+        // (pnl < 0 or active close ledger with residual) take the
+        // `settle_resolved_bankruptcy_negative_pnl` /
+        // `apply_quantity_adl_after_residual_for_account_not_atomic` path
+        // instead; this helper is a no-op for them.
+        self.detach_solvent_active_legs_for_resolved_close(account)?;
         if !active_bitmap_is_empty(account.active_bitmap)
             || account.pnl < 0
             || account.b_stale_state
@@ -15399,6 +15408,84 @@ impl MarketGroupV16 {
         .validate()?;
         self.assert_public_invariants()?;
         Ok(ResolvedCloseOutcomeV16::Closed { payout })
+    }
+
+    /// Detach all active legs for a solvent account after K/F/B settlement on a
+    /// Resolved market. Called from `close_resolved_account_not_atomic` to
+    /// release the `stored_pos_count_*` / `loss_weight_sum_*` / `oi_eff_*`
+    /// accounting that `resolved_positive_payout_ready` depends on.
+    ///
+    /// Direct parity with v12's `reconcile_resolved_not_atomic` →
+    /// `clear_position_basis_q(i)` step (legacy `src/percolator.rs:9948`).
+    /// Without this call, solvent users with active legs at resolve time
+    /// cannot detach through any wrapper-callable instruction; see
+    /// `https://github.com/aeyakovenko/percolator/issues/61` for the spec
+    /// references (§12 lines 1381 and 1413) and the regression vs v12.
+    ///
+    /// Semantics:
+    ///
+    /// * The caller MUST have already run
+    ///   `settle_account_side_effects_not_atomic` to `AccountCurrent` so that
+    ///   `k_target == k_snap` / `f_target == f_snap` / `b_target == b_snap`
+    ///   and `account.b_stale_state` is cleared.
+    /// * If the account is bankrupt (`pnl < 0`) or has an active close
+    ///   ledger with pending residual, this helper is a no-op; the
+    ///   bankruptcy resolution path (`settle_resolved_bankruptcy_negative_pnl`
+    ///   + `apply_quantity_adl_after_residual_for_account_not_atomic`) handles
+    ///   detach for those accounts via `clear_leg_after_quantity_adl`.
+    /// * If any active leg fails a `clear_leg` precondition that can clear
+    ///   on a retry (e.g. a pending domain loss barrier whose owning
+    ///   counterparty still needs to settle), this helper is a no-op so that
+    ///   the existing `active_bitmap_is_empty` gate in
+    ///   `close_resolved_account_not_atomic` returns `ProgressOnly`.
+    ///   Hard failures (corrupt epoch shape, etc.) still propagate as `Err`.
+    /// * When the leg's side is in `ResetPending` after a full-drain ADL,
+    ///   `clear_leg` internally skips the `oi_eff_*` / `loss_weight_sum_*`
+    ///   decrements (the side's accounting was zeroed by
+    ///   `apply_quantity_adl_after_residual_internal` /
+    ///   `begin_full_drain_reset_inner`) and only decrements
+    ///   `stored_pos_count_*`. This helper inherits that behavior.
+    fn detach_solvent_active_legs_for_resolved_close(
+        &mut self,
+        account: &mut PortfolioAccountV16,
+    ) -> V16Result<()> {
+        if account.pnl < 0 || account.close_progress.has_pending_residual() {
+            return Ok(());
+        }
+        // Pre-check every active leg against `clear_leg`'s clearable shape.
+        // If any leg fails on a transient condition, fall through unchanged
+        // so the existing `active_bitmap_is_empty` gate returns ProgressOnly.
+        for slot in 0..V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg = account.legs[slot];
+            if !leg.active {
+                continue;
+            }
+            if leg.b_stale || leg.stale {
+                return Ok(());
+            }
+            let asset_index = leg.asset_index as usize;
+            if asset_index >= self.config.max_market_slots as usize {
+                return Err(V16Error::InvalidLeg);
+            }
+            if self.has_pending_domain_loss_barrier(asset_index, leg.side)? {
+                return Ok(());
+            }
+            let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;
+            if k_target != leg.k_snap || f_target != leg.f_snap {
+                return Ok(());
+            }
+            if self.b_target_for_leg(asset_index, leg)? != leg.b_snap {
+                return Ok(());
+            }
+        }
+        // All clearable: detach in slot order.
+        for slot in 0..V16_MAX_PORTFOLIO_ASSETS_N {
+            if account.legs[slot].active {
+                let asset_index = account.legs[slot].asset_index as usize;
+                self.clear_leg(account, asset_index)?;
+            }
+        }
+        Ok(())
     }
 
     pub fn claim_resolved_payout_topup_not_atomic(

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -10822,6 +10822,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if account.header.pnl.get() < 0 {
             self.settle_resolved_bankruptcy_negative_pnl(account)?;
         }
+        // Detach solvent active legs after K/F/B settlement so the close
+        // can complete. Same semantics as the Vec runtime variant — see
+        // `MarketGroupV16::detach_solvent_active_legs_for_resolved_close`
+        // (defined later in this file, around line 15275 after rebase) for
+        // the full rationale, v12 parity references, and the
+        // bankrupt-account no-op condition. This is the zero-copy mirror
+        // for the wrapper-callable production path.
+        self.detach_solvent_active_legs_for_resolved_close(account)?;
         if !active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get))
             || account.header.pnl.get() < 0
             || decode_bool(account.header.b_stale_state)?
@@ -10890,6 +10898,66 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.validate_shape()?;
         account.validate_with_market(&self.as_view())?;
         Ok(ResolvedCloseOutcomeV16::Closed { payout })
+    }
+
+    /// Zero-copy mirror of `MarketGroupV16::detach_solvent_active_legs_for_resolved_close`.
+    /// See that function's doc comment for the full semantics — same
+    /// preconditions, same per-leg pre-check loop, same slot-order detach.
+    /// Translates each `account.<field>` Vec-runtime access to
+    /// `account.header.<field>.get()` / `.try_to_runtime()?` and walks the
+    /// wire-format leg array. All four helper methods
+    /// (`has_pending_domain_loss_barrier`, `kf_target_for_leg`,
+    /// `b_target_for_leg`, `clear_leg`) have matching signatures on this
+    /// `MarketGroupV16ViewMut` impl block, so the logic carries 1:1.
+    fn detach_solvent_active_legs_for_resolved_close(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+    ) -> V16Result<()> {
+        if account.header.pnl.get() < 0
+            || account
+                .header
+                .close_progress
+                .try_to_runtime()?
+                .has_pending_residual()
+        {
+            return Ok(());
+        }
+        // Pre-check every active leg against `clear_leg`'s clearable shape.
+        // If any leg fails on a transient condition, fall through unchanged
+        // so the existing `active_bitmap_is_empty` gate returns ProgressOnly.
+        let configured_max = self.header.config.max_market_slots.get() as usize;
+        for slot in 0..V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg = account.header.legs[slot].try_to_runtime()?;
+            if !leg.active {
+                continue;
+            }
+            if leg.b_stale || leg.stale {
+                return Ok(());
+            }
+            let asset_index = leg.asset_index as usize;
+            if asset_index >= configured_max {
+                return Err(V16Error::InvalidLeg);
+            }
+            if self.has_pending_domain_loss_barrier(asset_index, leg.side)? {
+                return Ok(());
+            }
+            let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;
+            if k_target != leg.k_snap || f_target != leg.f_snap {
+                return Ok(());
+            }
+            if self.b_target_for_leg(asset_index, leg)? != leg.b_snap {
+                return Ok(());
+            }
+        }
+        // All clearable: detach in slot order.
+        for slot in 0..V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg = account.header.legs[slot].try_to_runtime()?;
+            if leg.active {
+                let asset_index = leg.asset_index as usize;
+                self.clear_leg(account, asset_index)?;
+            }
+        }
+        Ok(())
     }
 
     pub fn deposit_not_atomic(

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -11837,7 +11837,7 @@ fn proof_v16_liquidation_fee_floor_shortfall_charges_available_capital_only() {
 #[kani::proof]
 #[kani::unwind(130)]
 #[kani::solver(cadical)]
-fn proof_v16_resolved_active_position_close_returns_progress_without_payout() {
+fn proof_v16_resolved_active_position_close_detaches_leg_and_pays_capital() {
     let (market, account_id, owner) = concrete_ids();
     let mut group = MarketGroupV16::new(market, V16Config::public_user_fund(1, 0, 1)).unwrap();
     let mut account =
@@ -11845,14 +11845,18 @@ fn proof_v16_resolved_active_position_close_returns_progress_without_payout() {
     group.deposit_not_atomic(&mut account, 7).unwrap();
     group.attach_leg(&mut account, 0, SideV16::Long, 1).unwrap();
     group.resolve_market_not_atomic(1).unwrap();
-    let before_vault = group.vault;
-    let before_c_tot = group.c_tot;
 
     let outcome = group.close_resolved_account_not_atomic(&mut account, 0);
 
-    assert_eq!(outcome, Ok(ResolvedCloseOutcomeV16::ProgressOnly));
-    assert!(!percolator::active_bitmap_is_empty(account.active_bitmap));
-    assert_eq!(account.capital, 7);
-    assert_eq!(group.vault, before_vault);
-    assert_eq!(group.c_tot, before_c_tot);
+    // Parity with v12 `reconcile_resolved_not_atomic` ->
+    // `clear_position_basis_q`: a solvent active leg on a Resolved market is
+    // detached inside `close_resolved_account_not_atomic` after K/F/B
+    // settlement, the bitmap clears, and capital is paid out.
+    assert_eq!(outcome, Ok(ResolvedCloseOutcomeV16::Closed { payout: 7 }));
+    assert!(percolator::active_bitmap_is_empty(account.active_bitmap));
+    assert_eq!(account.capital, 0);
+    assert_eq!(group.vault, 0);
+    assert_eq!(group.c_tot, 0);
+    assert_eq!(group.assets[0].stored_pos_count_long, 0);
+    assert_eq!(group.assert_public_invariants(), Ok(()));
 }

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -8822,23 +8822,92 @@ fn v16_resolved_profit_close_pays_from_snapshot_residual_and_clears_claim() {
 }
 
 #[test]
-fn v16_resolved_close_with_active_position_returns_progress_only() {
+fn v16_resolved_close_with_active_position_detaches_leg_and_pays_capital() {
     let mut g = group();
     let mut a = account();
     g.deposit_not_atomic(&mut a, 777).unwrap();
     g.attach_leg(&mut a, 0, SideV16::Long, POS_SCALE as i128)
         .unwrap();
     g.resolve_market_not_atomic(1).unwrap();
-    let before_vault = g.vault;
-    let before_c_tot = g.c_tot;
 
     let out = g.close_resolved_account_not_atomic(&mut a, 0).unwrap();
 
-    assert_eq!(out, ResolvedCloseOutcomeV16::ProgressOnly);
-    assert_eq!(a.capital, 777);
-    assert_ne!(a.active_bitmap, bitmap(&[]));
-    assert_eq!(g.vault, before_vault);
-    assert_eq!(g.c_tot, before_c_tot);
+    // Solvent active legs are detached inside close_resolved (parity with
+    // v12 `reconcile_resolved_not_atomic` -> `clear_position_basis_q`).
+    assert_eq!(out, ResolvedCloseOutcomeV16::Closed { payout: 777 });
+    assert_eq!(a.capital, 0);
+    assert_eq!(a.active_bitmap, bitmap(&[]));
+    assert_eq!(g.vault, 0);
+    assert_eq!(g.c_tot, 0);
+    assert_eq!(g.assets[0].stored_pos_count_long, 0);
+}
+
+#[test]
+fn v16_resolved_close_detaches_balanced_counterparties_paying_both() {
+    // Two solvent users on opposite sides of the same asset, both with zero
+    // mark-to-market PnL. After resolve, each can close in a single
+    // `close_resolved_account_not_atomic` call: the helper detaches their
+    // leg, the bitmap clears, capital is paid out from the vault.
+    let (market, _, owner) = ids();
+    let mut g = group();
+    let mut long_acct =
+        PortfolioAccountV16::empty(ProvenanceHeaderV16::new(market, [60; 32], owner));
+    let mut short_acct =
+        PortfolioAccountV16::empty(ProvenanceHeaderV16::new(market, [61; 32], owner));
+    g.deposit_not_atomic(&mut long_acct, 1_000).unwrap();
+    g.deposit_not_atomic(&mut short_acct, 1_000).unwrap();
+    g.attach_leg(&mut long_acct, 0, SideV16::Long, POS_SCALE as i128)
+        .unwrap();
+    g.attach_leg(&mut short_acct, 0, SideV16::Short, -(POS_SCALE as i128))
+        .unwrap();
+    g.resolve_market_not_atomic(1).unwrap();
+
+    let long_close = g.close_resolved_account_not_atomic(&mut long_acct, 0);
+    assert_eq!(
+        long_close,
+        Ok(ResolvedCloseOutcomeV16::Closed { payout: 1_000 })
+    );
+    assert_eq!(long_acct.capital, 0);
+    assert_eq!(long_acct.active_bitmap, bitmap(&[]));
+
+    let short_close = g.close_resolved_account_not_atomic(&mut short_acct, 0);
+    assert_eq!(
+        short_close,
+        Ok(ResolvedCloseOutcomeV16::Closed { payout: 1_000 })
+    );
+    assert_eq!(short_acct.capital, 0);
+    assert_eq!(short_acct.active_bitmap, bitmap(&[]));
+
+    assert_eq!(g.vault, 0);
+    assert_eq!(g.c_tot, 0);
+    assert_eq!(g.assets[0].stored_pos_count_long, 0);
+    assert_eq!(g.assets[0].stored_pos_count_short, 0);
+}
+
+#[test]
+fn v16_resolved_close_detaches_multi_asset_legs_in_single_call() {
+    // A solvent account with active legs across two different assets closes
+    // in one `close_resolved_account_not_atomic` call. Both legs are
+    // detached by the helper and both per-asset `stored_pos_count_long`
+    // counters reach zero.
+    let mut g = group();
+    let mut a = account();
+    g.deposit_not_atomic(&mut a, 500).unwrap();
+    g.attach_leg(&mut a, 0, SideV16::Long, POS_SCALE as i128)
+        .unwrap();
+    g.attach_leg(&mut a, 1, SideV16::Long, POS_SCALE as i128)
+        .unwrap();
+    g.resolve_market_not_atomic(1).unwrap();
+
+    let out = g.close_resolved_account_not_atomic(&mut a, 0).unwrap();
+
+    assert_eq!(out, ResolvedCloseOutcomeV16::Closed { payout: 500 });
+    assert_eq!(a.capital, 0);
+    assert_eq!(a.active_bitmap, bitmap(&[]));
+    assert_eq!(g.vault, 0);
+    assert_eq!(g.c_tot, 0);
+    assert_eq!(g.assets[0].stored_pos_count_long, 0);
+    assert_eq!(g.assets[1].stored_pos_count_long, 0);
 }
 
 #[test]
@@ -8960,15 +9029,23 @@ fn v16_resolved_bankrupt_active_negative_consumes_insurance_then_unblocks_winner
     g.attach_leg(&mut bankrupt, 0, SideV16::Long, 1).unwrap();
     g.resolve_market_not_atomic(1).unwrap();
 
-    let bankrupt_progress = g.close_resolved_account_not_atomic(&mut bankrupt, 0);
+    let bankrupt_close = g.close_resolved_account_not_atomic(&mut bankrupt, 0);
 
-    assert_eq!(bankrupt_progress, Ok(ResolvedCloseOutcomeV16::ProgressOnly));
+    // Insurance covers the bankrupt's residual, the close ledger finalizes
+    // with `residual_remaining == 0`, and the bankrupt's leg is detached
+    // by `close_resolved_account_not_atomic` in the same call (parity with
+    // v12 `reconcile_resolved_not_atomic` -> `clear_position_basis_q`).
+    assert_eq!(
+        bankrupt_close,
+        Ok(ResolvedCloseOutcomeV16::Closed { payout: 0 })
+    );
     assert_eq!(bankrupt.pnl, 0);
+    assert_eq!(bankrupt.active_bitmap, bitmap(&[]));
     assert_eq!(g.negative_pnl_account_count, 0);
     assert_eq!(g.insurance, 0);
     assert_eq!(g.insurance_domain_spent[1], 5);
+    assert_eq!(g.assets[0].stored_pos_count_long, 0);
 
-    g.clear_leg(&mut bankrupt, 0).unwrap();
     let winner_close = g.close_resolved_account_not_atomic(&mut winner, 0);
 
     assert_eq!(
@@ -8994,18 +9071,27 @@ fn v16_resolved_bankrupt_active_negative_without_counterweight_clears_as_explici
     g.attach_leg(&mut bankrupt, 0, SideV16::Long, 1).unwrap();
     g.resolve_market_not_atomic(1).unwrap();
 
-    let bankrupt_progress = g.close_resolved_account_not_atomic(&mut bankrupt, 0);
+    let bankrupt_close = g.close_resolved_account_not_atomic(&mut bankrupt, 0);
 
-    assert_eq!(bankrupt_progress, Ok(ResolvedCloseOutcomeV16::ProgressOnly));
+    // Without a counterweight the residual is booked as explicit loss
+    // (`bankruptcy_hlock_active` set, `close_progress.finalized`), and the
+    // bankrupt's leg is detached by `close_resolved_account_not_atomic` in
+    // the same call (parity with v12 `reconcile_resolved_not_atomic` ->
+    // `clear_position_basis_q`).
+    assert_eq!(
+        bankrupt_close,
+        Ok(ResolvedCloseOutcomeV16::Closed { payout: 0 })
+    );
     assert_eq!(bankrupt.pnl, 0);
+    assert_eq!(bankrupt.active_bitmap, bitmap(&[]));
     assert_eq!(g.negative_pnl_account_count, 0);
     assert_eq!(g.recovery_reason, None);
     assert!(g.bankruptcy_hlock_active);
     assert_eq!(bankrupt.close_progress.explicit_loss_assigned, 5);
     assert_eq!(bankrupt.close_progress.residual_remaining, 0);
     assert!(bankrupt.close_progress.finalized);
+    assert_eq!(g.assets[0].stored_pos_count_long, 0);
 
-    g.clear_leg(&mut bankrupt, 0).unwrap();
     let winner_close = g.close_resolved_account_not_atomic(&mut winner, 0);
 
     assert_eq!(

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -8843,6 +8843,58 @@ fn v16_resolved_close_with_active_position_detaches_leg_and_pays_capital() {
 }
 
 #[test]
+fn v16_zero_copy_resolved_close_with_active_position_detaches_leg_and_pays_capital() {
+    // Mirror of the test above, exercised against the zero-copy
+    // `MarketGroupV16ViewMut::close_resolved_account_not_atomic` API path
+    // that the wrapper actually uses in production (`handle_close_resolved`
+    // -> `state::market_view_mut`). Without the corresponding zero-copy
+    // fix added in this PR, production close_resolved returns
+    // ProgressOnly for solvent users with active legs — same bug class
+    // as issue #61 but on the view path the wrapper invokes.
+    let mut g = group();
+    let mut a = account();
+    g.deposit_not_atomic(&mut a, 777).unwrap();
+    g.attach_leg(&mut a, 0, SideV16::Long, POS_SCALE as i128)
+        .unwrap();
+    g.resolve_market_not_atomic(1).unwrap();
+
+    let mut header =
+        MarketGroupV16HeaderAccount::from_runtime_with_capacity(&g, g.assets.len()).unwrap();
+    let mut markets = (0..g.assets.len())
+        .map(|i| Market {
+            wrapper: 0u64,
+            engine: EngineAssetSlotV16Account::from_runtime_group_slot(&g, i).unwrap(),
+        })
+        .collect::<Vec<_>>();
+    let mut account_header = PortfolioAccountV16Account::from_runtime(&a);
+    let mut source_domains = PortfolioAccountV16Account::source_domains_from_runtime(&a).unwrap();
+
+    let mut account_view =
+        percolator::v16::PortfolioV16ViewMut::new(&mut account_header, &mut source_domains);
+    let mut market_view = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+
+    let out = market_view
+        .close_resolved_account_not_atomic(&mut account_view, 0)
+        .unwrap();
+
+    assert_eq!(out, ResolvedCloseOutcomeV16::Closed { payout: 777 });
+    assert_eq!(account_view.header.capital.get(), 0);
+    assert!(percolator::active_bitmap_is_empty(
+        account_view.header.active_bitmap.map(V16PodU64::get)
+    ));
+    assert_eq!(market_view.header.vault.get(), 0);
+    assert_eq!(market_view.header.c_tot.get(), 0);
+    assert_eq!(
+        market_view.markets[0]
+            .engine
+            .asset
+            .stored_pos_count_long
+            .get(),
+        0
+    );
+}
+
+#[test]
 fn v16_resolved_close_detaches_balanced_counterparties_paying_both() {
     // Two solvent users on opposite sides of the same asset, both with zero
     // mark-to-market PnL. After resolve, each can close in a single


### PR DESCRIPTION
## Update 2026-05-26: rebased onto current master + zero-copy port

When this PR was originally filed (2026-05-21, base `10f9ffcd`), only one
`close_resolved_account_not_atomic` existed in the engine — in `impl MarketGroupV16`
(the Vec runtime path). The fix correctly patched it.

The next day, `eb75806` "Complete v16 zero-copy view port" landed on master
and added a PARALLEL implementation in `impl<'a, T> MarketGroupV16ViewMut<'a, T>`.
The wrapper now routes the production `handle_close_resolved` instruction
through the zero-copy variant via `state::market_view_mut`. PR #62's fix,
unmodified, leaves the zero-copy production path bugged after merge into
current master.

**This PR has been rebased onto current master `9bcf002b` and a second
commit (`048aa25` "Port detach to zero-copy MarketGroupV16ViewMut::close_resolved")
has been added.** The new commit:

- Adds a zero-copy mirror of the `detach_solvent_active_legs_for_resolved_close`
  helper to `impl<'a, T> MarketGroupV16ViewMut<'a, T>` (translation rules:
  `account.<field>` → `account.header.<field>.get()` / `.try_to_runtime()?`;
  `self.config.X` → `self.header.config.X.get()`).
- Wires it into the zero-copy `close_resolved_account_not_atomic` at the
  matching insertion point (after K/F/B settlement, before the
  active-bitmap gate).
- Adds a paired zero-copy regression test
  (`v16_zero_copy_resolved_close_with_active_position_detaches_leg_and_pays_capital`)
  that pair-verifies: fails on unpatched src/v16.rs with the exact bug
  shape (`ProgressOnly` instead of `Closed { payout: 777 }`) and passes
  on the patched code.

All four helper methods (`has_pending_domain_loss_barrier`,
`kf_target_for_leg`, `b_target_for_leg`, `clear_leg`) already exist on
`MarketGroupV16ViewMut` with matching signatures, so the port is a 1:1
textual transcription.

## Commits

- `469c00b` (rebase of original `dc76318`): v16: detach solvent active legs in `close_resolved_account_not_atomic`
- `048aa25` (rebase of `08ea957`): Port detach to zero-copy `MarketGroupV16ViewMut::close_resolved`

(Rebased onto current master `9bcf002b` 2026-05-26 evening after Toly's
loss-stale fix landed; no conflicts with that fix.)

## Tests run (against current master `9bcf002b`)

```
$ cargo test --features test
   lib tests:        50 passed (unit)
   v16 spec tests:  309 passed
```

Total: **359 tests pass**. Master baseline on `9bcf002b` is **356 tests**
(50 unit + 306 spec); this PR adds **3 new** tests (2 from the original
PR #62 — `..._detaches_balanced_counterparties_paying_both` and
`..._detaches_multi_asset_legs_in_single_call` — plus the zero-copy
mirror `v16_zero_copy_resolved_close_with_active_position_detaches_leg_and_pays_capital`).
The existing tests `v16_resolved_close_with_active_position_returns_progress_only`
and the two `4493538a` strengthening tests were renamed / had their
assertions flipped, not net-added, so they don't increase the count.

## Pair-verification (proves both paths catch the bug)

Vec runtime regression test (original PR #62):
- Reverting `src/v16.rs` changes from the rebased commit: test FAILS with
  `ProgressOnly` vs expected `Closed { payout: 777 }`.

Zero-copy regression test (new in `048aa25`):
- Same revert: test FAILS with the same shape, but exercised through
  `MarketGroupV16ViewMut::close_resolved_account_not_atomic` (the
  production code path).

With both fixes applied, both tests pass.

## Kani proof status (transparency)

The Vec-runtime Kani proof
(`proof_v16_resolved_active_position_close_detaches_leg_and_pays_capital`,
renamed + assertion-flipped from
`proof_v16_resolved_active_position_close_returns_progress_without_payout`)
is carried forward unchanged from the original commit. **Local
re-verification post-rebase did not converge** on the verification machine
(CBMC `--unwind 130 --sat-solver cadical` running > 8 hours wall-clock
with heavy host swap pressure; killed without producing a
`VERIFICATION:- SUCCESSFUL`/`FAILED` marker). The proof body and the
target code it covers are textually unchanged by this rebase or the
zero-copy extension. Recommend re-running locally on a machine with
more headroom, or in CI if one is configured.

The empirical pair-verification above is the primary correctness
evidence; the Kani proof is supplementary.

---

[Original PR description follows below]

Implements the wire-through described in #61. Direct port forward of v12's `reconcile_resolved_not_atomic` → `clear_position_basis_q(i)` step (legacy `src/percolator.rs:9948`) to v16's multi-leg `close_resolved_account_not_atomic`.

## Fix

In `close_resolved_account_not_atomic` (after `settle_resolved_bankruptcy_negative_pnl`, before the `active_bitmap_is_empty` gate), call new helper `detach_solvent_active_legs_for_resolved_close`. The helper iterates active legs and invokes `clear_leg` for each.

Gated to be a no-op when:

* `account.pnl < 0` or `account.close_progress.has_pending_residual()` — bankrupt accounts take the existing `apply_quantity_adl_after_residual_for_account_not_atomic` path, unchanged.
* Any active leg fails a `clear_leg` precondition that can clear on retry (pending domain loss barrier, K/F/B target lag, b_stale) — falls through unchanged so the existing `active_bitmap_is_empty` gate returns `ProgressOnly`. Preserves the historical UX for transient locks.

When a leg's side is in `ResetPending` after a full-drain ADL, `clear_leg`'s existing `prior_reset_epoch` branch (`src/v16.rs:5398-5435`) skips the `oi_eff_*` / `loss_weight_sum_*` decrements (those were already zeroed by `apply_quantity_adl_after_residual_internal` / `begin_full_drain_reset_inner`) and only decrements `stored_pos_count_*`. This helper inherits that behavior.

## Spec compliance

From engine `spec.md` section 12:

> Line 1381: "A public `CrankForward` market MUST expose permissionless terminal recovery for any state where bounded progress cannot continue, including [...] active close failure, [...] payout-lane conflict."

> Line 1413: "Dead-leg forfeit/detach is bounded and owner-callable for terminal/recovery/dead assets."

Before this PR, neither requirement was satisfiable for solvent users with active legs on a Resolved market (forfeit predicate all-disjuncts unreachable, declare_permissionless_recovery blocked from Resolved). After this PR, the close path itself provides the spec-mandated detach.

## Test updates (in the original commit)

* `v16_resolved_close_with_active_position_returns_progress_only` → `v16_resolved_close_with_active_position_detaches_leg_and_pays_capital` (renamed + assertion flipped).
* Two strengthening tests folded the previously-required follow-up `clear_leg(&mut bankrupt, 0)` into the same `close_resolved_account_not_atomic` call (parity with v12 single-call force-close-resolved semantics).
* Kani proof `proof_v16_resolved_active_position_close_returns_progress_without_payout` → `proof_v16_resolved_active_position_close_detaches_leg_and_pays_capital`.
* New regression tests:
  - `v16_resolved_close_detaches_balanced_counterparties_paying_both`
  - `v16_resolved_close_detaches_multi_asset_legs_in_single_call`

## Wrapper-repo follow-up

`aeyakovenko/percolator-prog` `tests/v16_wrapper.rs:11814` (`v16_wrapper_close_resolved_progress_only_does_not_pay_active_position`) asserts the prior lockup behavior via end-to-end wrapper instructions. After this engine PR lands, that test will need to flip to assert the new correct behavior (single-call close, capital paid out). Happy to file the wrapper PR as a follow-up if useful.

## Confidence + caveats

The fix is the minimal port of a v12-tested invariant to v16. Hot path is unchanged for bankrupt accounts; the new code only activates when `pnl >= 0 && !close_progress.has_pending_residual()`. The pre-check loop ensures any transient `clear_leg` precondition failure falls through to the existing ProgressOnly gate rather than surfacing as Err — preserving the v16 close UX. Happy to adjust placement, gating, or naming as preferred.

—LGopus