### PR TITLE
Fix group-wide loss_stale_active masking (issue percolator-prog#106)

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -7455,7 +7455,29 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.set_asset_state(asset_index, asset)?;
         self.header.current_slot = V16PodU64::new(now_slot);
         self.header.slot_last = V16PodU64::new(asset.slot_last);
-        self.header.loss_stale_active = encode_bool(asset.slot_last < now_slot);
+        // Fix (issue #106): loss_stale_active is a GROUP-WIDE flag consumed
+        // by drain-detection, trade preflight, withdrawal, and several other
+        // gates. It must reflect the union of per-asset staleness across all
+        // accruable assets — not the freshness of the single asset cranked
+        // here. Setting it from one asset's slot_last allowed an attacker
+        // who controlled (or could nudge) any Active|DrainOnly asset to clear
+        // the bit on behalf of the whole group, defeating the gate even when
+        // other assets were stale.
+        let configured = self.header.config.max_market_slots.get() as usize;
+        let n_markets = core::cmp::min(configured, self.markets.len());
+        let mut any_loss_stale = false;
+        let mut k = 0usize;
+        while k < n_markets {
+            let lc = decode_asset_lifecycle(self.markets[k].engine.asset.lifecycle)?;
+            if matches!(lc, AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly)
+                && self.markets[k].engine.asset.slot_last.get() < now_slot
+            {
+                any_loss_stale = true;
+                break;
+            }
+            k += 1;
+        }
+        self.header.loss_stale_active = encode_bool(any_loss_stale);
         if activity.price_move_active {
             self.header.oracle_epoch = V16PodU64::new(
                 self.header
@@ -14413,7 +14435,22 @@ impl MarketGroupV16 {
             .ok_or(V16Error::ArithmeticOverflow)?;
         self.current_slot = now_slot;
         self.slot_last = asset.slot_last;
-        self.loss_stale_active = asset.slot_last < now_slot;
+        // Fix (issue #106): mirror of the zero-copy fix above. See the comment
+        // in the zero-copy `accrue_asset_to_not_atomic` for full rationale.
+        let n_markets = self.config.max_market_slots as usize;
+        let mut any_loss_stale = false;
+        let mut k = 0usize;
+        while k < n_markets {
+            let lc = self.assets[k].lifecycle;
+            if matches!(lc, AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly)
+                && self.assets[k].slot_last < now_slot
+            {
+                any_loss_stale = true;
+                break;
+            }
+            k += 1;
+        }
+        self.loss_stale_active = any_loss_stale;
         if price_move_active {
             self.oracle_epoch = self
                 .oracle_epoch
@@ -14432,7 +14469,9 @@ impl MarketGroupV16 {
             price_move_active,
             funding_active,
             equity_active,
-            loss_stale_after: self.loss_stale_active,
+            // The per-asset return value remains per-asset (matches zero-copy
+            // path); the group-wide flag is the one we widened.
+            loss_stale_after: self.assets[asset_index].slot_last < now_slot,
         })
     }
 

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -14437,7 +14437,11 @@ impl MarketGroupV16 {
         self.slot_last = asset.slot_last;
         // Fix (issue #106): mirror of the zero-copy fix above. See the comment
         // in the zero-copy `accrue_asset_to_not_atomic` for full rationale.
-        let n_markets = self.config.max_market_slots as usize;
+        // `self.assets.len()` is invariant-equal to `self.config.max_market_slots`
+        // after construction, but the `min` is a defensive bound for parity with
+        // the zero-copy path's `min(configured, self.markets.len())`.
+        let configured = self.config.max_market_slots as usize;
+        let n_markets = core::cmp::min(configured, self.assets.len());
         let mut any_loss_stale = false;
         let mut k = 0usize;
         while k < n_markets {

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -11565,3 +11565,125 @@ fn proof_v16_resolved_active_position_close_returns_progress_without_payout() {
     assert_eq!(group.vault, before_vault);
     assert_eq!(group.c_tot, before_c_tot);
 }
+
+// =========================================================================
+// Issue #106 — regression proof for `header.loss_stale_active`
+// =========================================================================
+//
+// The bug: prior to the fix, `accrue_asset_to_not_atomic` set the group-wide
+// `loss_stale_active` flag from a single asset's freshness:
+//
+//     self.loss_stale_active = asset.slot_last < now_slot;
+//
+// On a multi-asset group, cranking any one Active|DrainOnly asset to
+// `now_slot` cleared the bit even when other accruable assets were still
+// stale. Seven downstream gates (drain detection, trade preflight,
+// withdrawal, …) consume the flag — so a single permissionless crank
+// disabled them all.
+//
+// The fix replaces the single-asset comparison with the union across all
+// accruable assets. These proofs assert the invariant directly.
+
+/// Direct invariant: after `accrue_asset_to_not_atomic`, the group-wide
+/// `loss_stale_active` flag equals `∃k. lifecycle(k) ∈ {Active, DrainOnly}
+/// ∧ slot_last(k) < now_slot`. Symbolic over `accrue_asset_index` so the
+/// proof covers cranking *any* asset (including the previously-stale one).
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_106_loss_stale_active_reflects_group_wide_union() {
+    let (market, _account_id, _owner) = symbolic_ids();
+    let mut config = V16Config::public_user_fund(2, 0, 1);
+    // Allow full catch-up in one segment so the cranked asset can become
+    // fresh, exposing the bug's masking behaviour.
+    config.max_accrual_dt_slots = 10;
+    config.min_funding_lifetime_slots = 10;
+    let mut group = MarketGroupV16::new(market, config).unwrap();
+
+    // Both assets start at slot_last = 0, lifecycle = Active (defaults).
+    let now_slot: u64 = 1;
+    let accrue_asset_index: usize = kani::any();
+    kani::assume(accrue_asset_index < 2);
+
+    let _ = group.accrue_asset_to_not_atomic(accrue_asset_index, now_slot, 1, 0, true);
+
+    // Compute the expected value: an oracle implementation of the invariant.
+    let other = 1 - accrue_asset_index;
+    let other_stale = matches!(
+        group.assets[other].lifecycle,
+        AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
+    ) && group.assets[other].slot_last < now_slot;
+    let cranked_stale = matches!(
+        group.assets[accrue_asset_index].lifecycle,
+        AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
+    ) && group.assets[accrue_asset_index].slot_last < now_slot;
+    let expected = other_stale || cranked_stale;
+
+    // Under the bug, when `accrue_asset_index` becomes fresh and `other`
+    // stays stale (slot_last=0 < now_slot=1), the flag was cleared but
+    // `expected` is true → assert fails.
+    assert_eq!(group.loss_stale_active, expected);
+}
+
+/// Coverage proof: the buggy scenario IS reachable — cranking one asset
+/// fresh while the other stays stale. This guards against the invariant
+/// proof being vacuously satisfied by an over-constrained model.
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_106_buggy_scenario_is_reachable_under_fixed_semantics() {
+    let (market, _account_id, _owner) = symbolic_ids();
+    let mut config = V16Config::public_user_fund(2, 0, 1);
+    config.max_accrual_dt_slots = 10;
+    config.min_funding_lifetime_slots = 10;
+    let mut group = MarketGroupV16::new(market, config).unwrap();
+
+    let now_slot: u64 = 1;
+    group.accrue_asset_to_not_atomic(0, now_slot, 1, 0, true).unwrap();
+
+    // Asset 0 is now fresh (slot_last == now_slot == 1).
+    kani::cover!(
+        group.assets[0].slot_last == now_slot,
+        "v16 #106 cranked asset becomes fresh"
+    );
+    // Asset 1 stayed stale (slot_last == 0 < now_slot == 1).
+    kani::cover!(
+        group.assets[1].slot_last < now_slot,
+        "v16 #106 untouched asset remains stale"
+    );
+    // The fix correctly keeps `loss_stale_active` set because asset 1 is stale.
+    assert!(group.loss_stale_active);
+}
+
+/// Non-accruable lifecycles must not contribute to the group-wide flag.
+/// If every asset except `accrue_asset_index` is Disabled/Retired/Recovery
+/// or PendingActivation, cranking that asset to `now_slot` must clear the
+/// flag — because no other asset is accruable in a way that would matter
+/// to the gates that read `loss_stale_active`.
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_106_only_accruable_lifecycles_contribute() {
+    let (market, _account_id, _owner) = symbolic_ids();
+    let mut config = V16Config::public_user_fund(2, 0, 1);
+    config.max_accrual_dt_slots = 10;
+    config.min_funding_lifetime_slots = 10;
+    let mut group = MarketGroupV16::new(market, config).unwrap();
+
+    // Asset 1 transitions to a non-accruable lifecycle.
+    group.assets[1].lifecycle = symbolic_non_active_lifecycle();
+    // We only care about the engine-rejected lifecycles for accrual.
+    kani::assume(!matches!(
+        group.assets[1].lifecycle,
+        AssetLifecycleV16::DrainOnly
+    ));
+
+    let now_slot: u64 = 1;
+    group.accrue_asset_to_not_atomic(0, now_slot, 1, 0, true).unwrap();
+
+    // Asset 1 is non-accruable (Disabled / PendingActivation / Retired /
+    // Recovery), so the union is exactly `asset_0.slot_last < now_slot`
+    // restricted to {Active, DrainOnly}. After the crank, asset 0 is fresh
+    // → the flag must be cleared.
+    assert!(!group.loss_stale_active);
+}

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -11593,11 +11593,13 @@ fn proof_v16_resolved_active_position_close_returns_progress_without_payout() {
 #[kani::solver(cadical)]
 fn proof_v16_106_loss_stale_active_reflects_group_wide_union() {
     let (market, _account_id, _owner) = symbolic_ids();
-    let mut config = V16Config::public_user_fund(2, 0, 1);
-    // Allow full catch-up in one segment so the cranked asset can become
-    // fresh, exposing the bug's masking behaviour.
-    config.max_accrual_dt_slots = 10;
-    config.min_funding_lifetime_slots = 10;
+    // Default `public_user_fund` config: `max_accrual_dt_slots = 1`, which
+    // is the minimum dt that still triggers the bug — at `now_slot = 1`,
+    // accruing one asset from `slot_last = 0` advances it to `slot_last = 1`
+    // (full catch-up in a single segment), making it fresh while the other
+    // asset stays at `slot_last = 0`. Increasing `max_accrual_dt_slots`
+    // would re-trigger `validate_exact_solvency_envelope`'s shape check.
+    let config = V16Config::public_user_fund(2, 0, 1);
     let mut group = MarketGroupV16::new(market, config).unwrap();
 
     // Both assets start at slot_last = 0, lifecycle = Active (defaults).
@@ -11633,13 +11635,13 @@ fn proof_v16_106_loss_stale_active_reflects_group_wide_union() {
 #[kani::solver(cadical)]
 fn proof_v16_106_buggy_scenario_is_reachable_under_fixed_semantics() {
     let (market, _account_id, _owner) = symbolic_ids();
-    let mut config = V16Config::public_user_fund(2, 0, 1);
-    config.max_accrual_dt_slots = 10;
-    config.min_funding_lifetime_slots = 10;
+    let config = V16Config::public_user_fund(2, 0, 1);
     let mut group = MarketGroupV16::new(market, config).unwrap();
 
     let now_slot: u64 = 1;
-    group.accrue_asset_to_not_atomic(0, now_slot, 1, 0, true).unwrap();
+    // The accrue may not always succeed under symbolic preconditions, but
+    // we only care about the cover/assert when it does.
+    let _ = group.accrue_asset_to_not_atomic(0, now_slot, 1, 0, true);
 
     // Asset 0 is now fresh (slot_last == now_slot == 1).
     kani::cover!(
@@ -11665,25 +11667,27 @@ fn proof_v16_106_buggy_scenario_is_reachable_under_fixed_semantics() {
 #[kani::solver(cadical)]
 fn proof_v16_106_only_accruable_lifecycles_contribute() {
     let (market, _account_id, _owner) = symbolic_ids();
-    let mut config = V16Config::public_user_fund(2, 0, 1);
-    config.max_accrual_dt_slots = 10;
-    config.min_funding_lifetime_slots = 10;
+    let config = V16Config::public_user_fund(2, 0, 1);
     let mut group = MarketGroupV16::new(market, config).unwrap();
 
-    // Asset 1 transitions to a non-accruable lifecycle.
+    // Asset 1 transitions to a non-accruable lifecycle. Setting `lifecycle`
+    // alone is not enough to keep `assert_public_invariants` happy for all
+    // states (Retired requires `retired_slot != 0`, etc.), so the accrue
+    // may legitimately fail — we only care about the loss_stale_active
+    // value when it succeeds, which is what the conditional assertion below
+    // captures.
     group.assets[1].lifecycle = symbolic_non_active_lifecycle();
-    // We only care about the engine-rejected lifecycles for accrual.
     kani::assume(!matches!(
         group.assets[1].lifecycle,
         AssetLifecycleV16::DrainOnly
     ));
 
     let now_slot: u64 = 1;
-    group.accrue_asset_to_not_atomic(0, now_slot, 1, 0, true).unwrap();
-
-    // Asset 1 is non-accruable (Disabled / PendingActivation / Retired /
-    // Recovery), so the union is exactly `asset_0.slot_last < now_slot`
-    // restricted to {Active, DrainOnly}. After the crank, asset 0 is fresh
-    // → the flag must be cleared.
-    assert!(!group.loss_stale_active);
+    if group.accrue_asset_to_not_atomic(0, now_slot, 1, 0, true).is_ok() {
+        // Asset 1 is non-accruable (Disabled / PendingActivation / Retired /
+        // Recovery), so the union restricted to {Active, DrainOnly} is
+        // exactly `asset_0.slot_last < now_slot`. After the crank, asset 0
+        // is fresh → the flag must be cleared.
+        assert!(!group.loss_stale_active);
+    }
 }

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1384,7 +1384,17 @@ fn v16_expired_fresh_backing_requires_refresh_before_source_credit_conversion() 
 
     let prices = [1; V16_MAX_PORTFOLIO_ASSETS_N];
     g.full_account_refresh(&mut a, &prices).unwrap();
-    g.accrue_asset_to_not_atomic(0, 1, 1, 0, true).unwrap();
+    // Issue #106: `header.loss_stale_active` is now a group-wide flag, so
+    // every accruable asset must be cranked to slot 1 to clear it. Cranking
+    // only asset 0 leaves assets 1..N stale and the bit set, which would
+    // mask this test's account-level Stale check behind a group-level
+    // LockActive error.
+    let n_assets = g.config.max_market_slots as usize;
+    let mut i = 0usize;
+    while i < n_assets {
+        g.accrue_asset_to_not_atomic(i, 1, 1, 0, true).unwrap();
+        i += 1;
+    }
     assert_eq!(g.current_slot, 1);
     assert!(a.health_cert.valid);
     assert_eq!(a.health_cert.cert_oracle_epoch, g.oracle_epoch);
@@ -4052,7 +4062,18 @@ fn v16_health_certificate_is_bound_to_market_epochs_and_prices() {
     );
     g.asset_set_epoch -= 1;
 
+    // Issue #106: crank every accruable asset so `header.loss_stale_active`
+    // remains clear. Only asset 0 advances oracle_epoch (price 1 → 2); the
+    // others stay flat. This isolates the test's intent — that the bumped
+    // oracle_epoch makes `long`'s health_cert stale — from the unrelated
+    // group-level loss-stale gate.
     g.accrue_asset_to_not_atomic(0, 1, 2, 0, true).unwrap();
+    let n_assets = g.config.max_market_slots as usize;
+    let mut i = 1usize;
+    while i < n_assets {
+        g.accrue_asset_to_not_atomic(i, 1, 1, 0, true).unwrap();
+        i += 1;
+    }
     assert_eq!(
         g.ensure_favorable_action_allowed(&long),
         Err(V16Error::Stale)
@@ -6488,6 +6509,14 @@ fn v16_e2e_trade_mark_close_convert_withdraw_conserves() {
         &px2,
     )
     .unwrap();
+    // Issue #106: crank the remaining accruable assets so the group-wide
+    // `loss_stale_active` flag is cleared. Only asset 0 has OI in this test.
+    let n_assets = g.config.max_market_slots as usize;
+    let mut i = 1usize;
+    while i < n_assets {
+        g.accrue_asset_to_not_atomic(i, 1, 1, 0, true).unwrap();
+        i += 1;
+    }
     g.full_account_refresh(&mut alice, &px2).unwrap();
     g.full_account_refresh(&mut bob, &px2).unwrap();
     assert!(
@@ -9688,3 +9717,68 @@ fn v16_rebalance_rejects_missing_or_zero_progress() {
         Err(V16Error::InvalidConfig)
     );
 }
+
+// =========================================================================
+// Issue #106 — regression test for `header.loss_stale_active`
+// =========================================================================
+//
+// Prior to the fix, `accrue_asset_to_not_atomic` set the group-wide
+// `loss_stale_active` flag from a single asset's freshness. This let a
+// crank of any one Active|DrainOnly asset clear the bit even when other
+// accruable assets remained stale, defeating seven downstream gates.
+
+#[test]
+fn v16_106_loss_stale_active_remains_set_when_other_assets_stale() {
+    let (market, _, _) = ids();
+    let cfg = V16Config::public_user_fund(2, 0, 1);
+    let mut g = MarketGroupV16::new(market, cfg).unwrap();
+
+    // Both assets start at slot_last = 0, lifecycle = Active.
+    assert_eq!(g.assets[0].slot_last, 0);
+    assert_eq!(g.assets[1].slot_last, 0);
+
+    // Crank asset 0 only to now_slot = 1.
+    let now_slot = 1u64;
+    let out = g
+        .accrue_asset_to_not_atomic(0, now_slot, 1, 0, true)
+        .unwrap();
+
+    // Asset 0 should be fresh; asset 1 should still be stale.
+    assert_eq!(g.assets[0].slot_last, now_slot);
+    assert_eq!(g.assets[1].slot_last, 0);
+    assert!(g.assets[1].slot_last < now_slot);
+
+    // The per-asset return value is per-asset and unchanged.
+    assert!(!out.loss_stale_after);
+
+    // The group-wide flag must reflect that asset 1 is still stale.
+    // Under the bug, this assertion fails: the flag is cleared.
+    assert!(
+        g.loss_stale_active,
+        "header.loss_stale_active must remain TRUE while asset 1 is still stale; \
+         see issue #106 for the bug this regression test guards against"
+    );
+}
+
+#[test]
+fn v16_106_loss_stale_active_clears_only_when_all_accruable_assets_fresh() {
+    let (market, _, _) = ids();
+    let cfg = V16Config::public_user_fund(2, 0, 1);
+    let mut g = MarketGroupV16::new(market, cfg).unwrap();
+
+    let now_slot = 1u64;
+    // Crank asset 0 → flag must remain set (asset 1 still stale).
+    g.accrue_asset_to_not_atomic(0, now_slot, 1, 0, true)
+        .unwrap();
+    assert!(g.loss_stale_active);
+
+    // Crank asset 1 → both assets fresh, flag clears.
+    g.accrue_asset_to_not_atomic(1, now_slot, 1, 0, true)
+        .unwrap();
+    assert!(!g.loss_stale_active);
+}
+
+// Note: the non-accruable-lifecycle filter is covered by the Kani harness
+// `proof_v16_106_only_accruable_lifecycles_contribute` in proofs_v16.rs;
+// reproducing it as a runtime test requires assembling the full invariant
+// preconditions for a Retired asset (retired_slot, OI residuals, etc.).


### PR DESCRIPTION
# PR description — `fix/loss-stale-active-group-wide`

**Target:** `aeyakovenko/percolator` (master)
**Head:** `LGopus/percolator:fix/loss-stale-active-group-wide`
**Commits:**
- `b75a09e` Fix group-wide loss_stale_active masking (issue #106)
- `ce96782` Fix Kani harness construction for v16_106 proofs
- `215bcac` Mirror defensive min bound in Vec runtime accrue path

**Refs:** [percolator-prog#106](https://github.com/aeyakovenko/percolator-prog/issues/106)

---

## Summary

Fix the bug at `v16.rs:7458` (and its runtime mirror at `v16.rs:14416`) where
`accrue_asset_to_not_atomic` writes the group-wide `loss_stale_active` flag
from the freshness of a single asset. (Line numbers are on the current master
HEAD `9d9b0ff`; the same code appears at `:7429` on the pinned engine rev
`23de295` that the deployed BPF and the wrapper's `Cargo.lock` use, which is
the form referenced in [percolator-prog#106](https://github.com/aeyakovenko/percolator-prog/issues/106).)

```rust
self.loss_stale_active = asset.slot_last < now_slot;   // BUG
```

The flag is consumed by **seven downstream sites** (four in the wrapper,
three in the engine) — all of which interpret it as *"any accruable asset
in this group is stale"*:

- **wrapper** — `live_domain_withdraw_health_or_shutdown_view` (gates
  insurance-domain withdrawal, top-up backing, junior PnL claim),
  `handle_withdraw_insurance_limited` (gates user insurance withdrawal),
  `require_asset_active_for_oracle_reconfiguration_view` and
  `group_has_position_or_loss_state_view` (both gate oracle reconfiguration);
- **engine** — `validate_trade_position_preflight` (engine-side trade
  preflight), `h_lock_lane` (favorable-action lock used by
  `ensure_favorable_action_allowed`), and `validate_shape` (group-shape
  audit decode).

On a multi-asset group, cranking any one Active|DrainOnly asset to
`now_slot` cleared the bit for the entire group, even when other accruable
assets remained stale. Issue [percolator-prog#106](https://github.com/aeyakovenko/percolator-prog/issues/106)
contains the end-to-end empirical drain construction against the wrapper at
`7f7cefc`.

This PR replaces the single-asset comparison with the union across all
accruable (`Active|DrainOnly`) assets in both the zero-copy
(`MarketGroupV16ViewMut::accrue_asset_to_not_atomic`) and Vec runtime
(`MarketGroupV16::accrue_asset_to_not_atomic`) paths.

## Test plan

- [x] All **346 pre-existing engine tests** pass with the fix (50 unit +
  296 spec). Total after the PR: **348 tests** (the 2 new regression tests
  below)
- [x] Two new regression tests (`v16_106_loss_stale_active_*` in
  `tests/v16_spec_tests.rs`) fail on the unpatched code with a descriptive
  assertion message and pass on the fix
- [x] Three Kani proofs (`proof_v16_106_*` in `tests/proofs_v16.rs`) assert
  the invariant directly — direct, reachability (coverage), and
  non-accruable-lifecycle filter. All three verified locally with
  `cargo kani --features fuzz`:
  - `proof_v16_106_loss_stale_active_reflects_group_wide_union` — `0 / 2878` failed
  - `proof_v16_106_buggy_scenario_is_reachable_under_fixed_semantics` — `0 / 2865` failed, `2 / 2` cover satisfied
  - `proof_v16_106_only_accruable_lifecycles_contribute` — `0 / 2873` failed
- [x] Three pre-existing tests that depended on the bug
  (`v16_health_certificate_is_bound_to_market_epochs_and_prices`,
  `v16_e2e_trade_mark_close_convert_withdraw_conserves`,
  `v16_expired_fresh_backing_requires_refresh_before_source_credit_conversion`)
  are updated to crank every accruable asset, isolating their intended
  account-level assertions from the group-level gate
- [x] `cargo build --release` clean
- [x] `cargo check --features test --tests` clean

## Invariant proven

After `accrue_asset_to_not_atomic`, the group-wide flag must equal:

```
loss_stale_active ⟺ ∃k. lifecycle(k) ∈ {Active, DrainOnly}
                       ∧ slot_last(k) < now_slot
```

Both the zero-copy and Vec runtime paths now compute this directly.

## Files touched

| File | + | - | Notes |
|---|---|---|---|
| `src/v16.rs` | 42 | 3 | Zero-copy + Vec runtime fix + comments |
| `tests/proofs_v16.rs` | 122 | 0 | Three Kani proofs (direct invariant, coverage, lifecycle filter) |
| `tests/v16_spec_tests.rs` | 96 | 4 | Two new regression tests + 3 pre-existing tests updated to crank all assets |

## Notes on the per-asset `loss_stale_after` return value

`AccrueAssetOutcomeV16::loss_stale_after` is left **per-asset** (matching the
zero-copy path's existing semantic). Only the group-wide
`header.loss_stale_active` / `self.loss_stale_active` write is widened. This
preserves the existing contract for callers that depended on the per-call
return value reflecting only the cranked asset.

## Out of scope for this PR

`v16.rs:7457` (`self.header.slot_last = V16PodU64::new(asset.slot_last);`)
has the same per-asset-write-of-group-wide-field shape. The impact appears
limited to a fee-anchor mis-calibration in `sync_account_fee_to_slot`
(charges accounts for slots when assets were stale), not a drain primitive.
The empirical PoC harness in percolator-prog#106 isolates the
`loss_stale_active` bit as the single causal variable for the demonstrated
drain. Filing the `slot_last` review separately keeps this fix minimal and
focused.