### PR TITLE
v16: fix a vacuous fee-last-slot assertion, found by mutation-testing the suite

### DIFF
--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -9021,7 +9021,8 @@ fn proof_v16_view_initial_margin_source_lien_creation_is_backed() {
     let effective = effective_raw as u128;
     let backing_num = effective * BOUND_SCALE;
     let face_num = backing_num;
-    let current_slot = 0;
+    let current_slot: u64 = kani::any();
+    kani::assume(current_slot < 100);
 
     let source_credit = SourceCreditStateV16 {
         positive_claim_bound_num: face_num,
@@ -9058,6 +9059,10 @@ fn proof_v16_view_initial_margin_source_lien_creation_is_backed() {
     .unwrap();
 
     kani::cover!(effective > 0, "source-credit IM lien branch is reachable");
+    kani::cover!(
+        current_slot > 0,
+        "fee clock initialized to a nonzero slot (fee-last-slot assertion is non-vacuous)"
+    );
     assert_eq!(backing_after.fresh_unliened_backing_num, 0);
     assert_eq!(backing_after.valid_liened_backing_num, backing_num);
     assert_eq!(source_credit_after.valid_liened_backing_num, backing_num);


### PR DESCRIPTION
v16: fix a vacuous fee-last-slot assertion in the source-credit IM lien harness. No engine change.

`proof_v16_view_initial_margin_source_lien_creation_is_backed` asserts `source_lien_fee_last_slot == current_slot` (tests/proofs_v16.rs:9081), but the harness sets `current_slot = 0`, which is the field's default value. So the assertion holds whether or not the engine performs the fee-clock initialization in `apply_account_source_credit_lien_delta` (src/v16.rs:8475, `if prior_counterparty_backing == 0 { source.source_lien_fee_last_slot = V16PodU64::new(current_slot); }`). The welded `0` and the default coincide, so the assertion cannot distinguish the assignment running from being skipped.

Flip that guard to `!= 0` (so on this fresh fixture the assignment is skipped) and the harness still reports `VERIFICATION:- SUCCESSFUL`. Set `current_slot` to a symbolic nonzero value and the unmutated harness still verifies, while with the flipped guard it reports `VERIFICATION:- FAILED` on exactly that assertion.

The fix makes `current_slot` symbolic (`kani::any()`, assumed `< 100` to stay under the backing-bucket expiry of the fixture) and adds a `kani::cover!(current_slot > 0, ...)` witness, so the assertion is exercised on a nonzero slot. The harness re-verifies with 2/2 cover properties satisfied and now fails under the guard flip. The engine path was always correct. This is a harness weakness, not an engine bug: a fixture constant happened to match the field default.

It surfaced by mutation-testing the suite — mutating the verified code and requiring a proof to fail; the guard flip above is one such mutation, and the suite passing it is what flagged the welded fixture. The tool that does this for Kani (AST mutant generation with Kani-coverage proof mapping) is at https://github.com/dcccrypto/kani-mutants.

The change is confined to one harness; the engine is untouched. Re-verified on current master, kani 0.67.0.
