### PR TITLE
[codex] Allow active auto-crank refresh without observation

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -166,15 +166,16 @@ pub fn v16_domain_pair_for_asset_index(asset_index: usize) -> V16Result<(usize, 
 
 /// REALIZABILITY — the no-DoS auto-crank dispatch-seam invariant.
 ///
-/// `RefreshAccount` is the UNIQUE [`AutoCrankPlanV16`] whose dispatch hard-requires
-/// a caller-supplied oracle observation: it must accrue a NEW price, which is not
-/// derivable from committed state, so with no observation it justifiably returns
-/// `NonProgress`. EVERY other plan is dispatchable from committed on-chain state
-/// alone — `SettleBChunk` ignores price, `Liquidate` reads the current health
-/// cert, `DeclareRecovery`/`CloseResolved`/`NoAction` take no price — so a keeper
-/// holding no fresh observation can still drive the account forward (no liveness
-/// stall). A wrapper may call this to decide whether it must source an oracle
-/// observation before cranking.
+/// `RefreshAccount { asset_index: None }` is the UNIQUE [`AutoCrankPlanV16`] whose
+/// dispatch hard-requires a caller-supplied oracle observation: there is no active
+/// account leg from which to choose a committed asset, so it must accrue a NEW
+/// price. `RefreshAccount { asset_index: Some(_) }` and EVERY other plan are
+/// dispatchable from committed on-chain state alone — `SettleBChunk` ignores
+/// price, `Liquidate` reads the current health cert, `DeclareRecovery` /
+/// `CloseResolved` / `NoAction` take no price — so a keeper holding no fresh
+/// observation can still drive the account forward (no liveness stall). A wrapper
+/// may call this to decide whether it must source an oracle observation before
+/// cranking.
 ///
 /// The exhaustive match forces a conscious classification if a plan variant is
 /// added. `proof_v16_auto_crank_refresh_is_unique_observation_requiring_plan` pins
@@ -185,7 +186,7 @@ pub fn v16_domain_pair_for_asset_index(asset_index: usize) -> V16Result<(usize, 
 /// b-stale / committed-state-liquidation stall before the observation fallback.
 pub fn auto_crank_plan_requires_caller_observation(plan: &AutoCrankPlanV16) -> bool {
     match plan {
-        AutoCrankPlanV16::RefreshAccount { .. } => true,
+        AutoCrankPlanV16::RefreshAccount { asset_index } => asset_index.is_none(),
         AutoCrankPlanV16::SettleBChunk { .. }
         | AutoCrankPlanV16::Liquidate { .. }
         | AutoCrankPlanV16::DeclareRecovery { .. }
@@ -11323,8 +11324,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     ///    `result.selected` (the `AutoCrankPlanV16`): refresh / settle-B move no
     ///    custody; liquidate / close-resolved may. `NoAction` => nothing was needed.
     ///    `Err(NonProgress)` => the selected step needed an observation the caller
-    ///    did not supply (a stale/late tx whose task changed) — no mutation, so SVM
-    ///    rollback is a clean no-op and arbitrary landing order is safe.
+    ///    did not supply (currently the no-active-asset refresh fallback, or a
+    ///    stale/late tx whose task changed) — no mutation, so SVM rollback is a
+    ///    clean no-op and arbitrary landing order is safe.
     pub fn permissionless_auto_crank_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
@@ -11348,13 +11350,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             recovery_reason,
         );
 
-        let obs_for = |i: usize| -> V16Result<AutoCrankObservationV16> {
-            work.observations
-                .iter()
-                .copied()
-                .find(|o| o.asset_index == i)
-                .ok_or(V16Error::NonProgress)
-        };
         let obs_or_current_asset = |me: &Self, i: usize| -> V16Result<AutoCrankObservationV16> {
             match work.observations.iter().copied().find(|o| o.asset_index == i) {
                 Some(obs) => Ok(obs),
@@ -11390,10 +11385,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let outcome = match plan {
             AutoCrankPlanV16::NoAction => AutoCrankOutcomeV16::NoAction,
             AutoCrankPlanV16::RefreshAccount { asset_index } => {
-                // accrue the engine-selected asset; if none, use the first
-                // supplied observation (account/market refresh needs price data).
+                // Accrue the engine-selected active asset from either a fresh
+                // observation or committed state; if no active asset exists, use
+                // the first supplied observation to give the refresh a price.
                 let (ai, obs) = match asset_index {
-                    Some(i) => (i, obs_for(i)?),
+                    Some(i) => (i, obs_or_current_asset(self, i)?),
                     None => {
                         let o = work
                             .observations

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -13757,21 +13757,21 @@ fn proof_v16_validator_sound_account_reserves() {
             <= h.residual_crystallized_loss_atoms_total.get());                            // U19b
 }
 
-// REALIZABILITY (no-DoS auto-crank dispatch seam): RefreshAccount is the UNIQUE
-// plan that hard-requires a caller-supplied observation; every other plan is
-// dispatchable from committed state. Pinning this truth table means a future arm
-// that gates a non-Refresh plan on an observation (the bug class that stalled
-// b-stale accounts and blocked committed-state liquidation) contradicts a machine-
-// checked theorem. Exhaustive over the six AutoCrankPlanV16 variants; the spec
-// matrix ties the predicate to the real dispatch for each reachable class.
+// REALIZABILITY (no-DoS auto-crank dispatch seam): only the no-active-asset
+// RefreshAccount fallback hard-requires a caller-supplied observation; active-
+// asset refresh and every other plan are dispatchable from committed state.
+// Pinning this truth table means a future arm that gates committed-state progress
+// on an observation contradicts a machine-checked theorem. Exhaustive over the
+// six AutoCrankPlanV16 variants; the spec matrix ties the predicate to the real
+// dispatch for each reachable class.
 #[kani::proof]
 fn proof_v16_auto_crank_refresh_is_unique_observation_requiring_plan() {
     use percolator::v16::auto_crank_plan_requires_caller_observation as needs_obs;
     use percolator::v16::AutoCrankPlanV16;
     let i: usize = kani::any();
-    // Both RefreshAccount forms (engine-selected asset, first-observation fallback)
-    // require an observation.
-    assert!(needs_obs(&AutoCrankPlanV16::RefreshAccount { asset_index: Some(i) }));
+    // Active-asset refresh can use the committed asset state; only the fallback
+    // with no selected active asset requires a caller observation.
+    assert!(!needs_obs(&AutoCrankPlanV16::RefreshAccount { asset_index: Some(i) }));
     assert!(needs_obs(&AutoCrankPlanV16::RefreshAccount { asset_index: None }));
     // No other plan does — committed on-chain state suffices.
     assert!(!needs_obs(&AutoCrankPlanV16::SettleBChunk { asset_index: i }));

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3000,14 +3000,14 @@ fn v16_auto_crank_missing_observation_is_clean_nonprogress_no_mutation() {
 // INDEPENDENCE: for a plan that `auto_crank_plan_requires_caller_observation`
 // reports as NOT requiring one, the single public crank must return the SAME
 // outcome whether or not an observation is supplied (the observation is redundant
-// — the plan is realizable from committed state). For the one class that DOES
-// require one (RefreshAccount, which must accrue a new price), the empty-
-// observation call cleanly stalls (NonProgress) while supplying the observation
-// progresses. This both guards liveness AND ties the pure predicate to the REAL
-// dispatch per class, so the predicate cannot drift from behaviour. Note: a
-// committed-state plan may still return a genuine economic terminal (e.g.
-// RecoveryRequired) — that is fine, because it returns the SAME terminal with or
-// without the observation; the bug was an outcome that DIFFERED on the observation.
+// — the plan is realizable from committed state). For the one form that DOES
+// require one (RefreshAccount with no active asset), the empty-observation call
+// cleanly stalls (NonProgress) while supplying the observation progresses. This
+// both guards liveness AND ties the pure predicate to the REAL dispatch per class,
+// so the predicate cannot drift from behaviour. Note: a committed-state plan may
+// still return a genuine economic terminal (e.g. RecoveryRequired) — that is fine,
+// because it returns the SAME terminal with or without the observation; the bug
+// was an outcome that DIFFERED on the observation.
 fn assert_observation_independent(
     label: &str,
     build: impl Fn() -> (
@@ -3088,9 +3088,10 @@ fn assert_observation_independent(
 
 #[test]
 fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
-    // --- A1 stale: RefreshAccount must accrue a NEW price -> observation MATTERS.
+    // --- A1 stale with no active asset: fallback refresh has no committed asset
+    // to use, so it still needs a caller observation.
     assert_observation_independent(
-        "stale",
+        "stale_empty_account",
         || {
             let (mut header, mut markets) = market_fixture(1, 100);
             let mut account_header = account_fixture(1, 200);
@@ -3106,6 +3107,36 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
         0,
         AutoCrankPlanV16::RefreshAccount { asset_index: None },
         true,
+    );
+
+    // --- A1 stale with an active asset: refresh is realizable from committed
+    // state. This is the no-DoS case for stale multi-asset accounts whose first
+    // active asset does not have a fresh oracle observation available.
+    assert_observation_independent(
+        "stale_active_asset",
+        || {
+            let (mut header, mut markets) = market_fixture(1, 100);
+            let mut account_header = account_fixture(1, 209);
+            let mut counterparty_header = account_fixture(1, 210);
+            let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+            let mut account = PortfolioV16ViewMut::new(&mut account_header);
+            let mut counterparty = PortfolioV16ViewMut::new(&mut counterparty_header);
+            market.deposit_not_atomic(&mut account, 1_000).unwrap();
+            market.deposit_not_atomic(&mut counterparty, 1_000).unwrap();
+            open_one_lot_pair(&mut market, &mut account, &mut counterparty);
+            account.header.health_cert.valid = 0;
+            drop(market);
+            drop(account);
+            drop(counterparty);
+            (header, markets, account_header)
+        },
+        0,
+        5,
+        0,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0),
+        },
+        false,
     );
 
     // --- A2 b_stale: SettleBChunk ignores price -> observation REDUNDANT.


### PR DESCRIPTION
## Summary

- Fix `permissionless_auto_crank_not_atomic` so `RefreshAccount { asset_index: Some(_) }` can use committed asset state when no fresh observation is supplied.
- Keep `RefreshAccount { asset_index: None }` as the only observation-required refresh fallback.
- Update the no-DoS realizability predicate, Kani truth-table proof, and auto-crank spec matrix to pin the distinction.

## Root Cause

The auto-crank selector self-selects an active asset for stale-account refresh, but dispatch still treated every active-asset refresh as requiring a caller-supplied oracle observation. That made public cranks return `NonProgress` even when committed state was sufficient to refresh/certify the account.

## Validation

- `cargo test v16_auto_crank_ -- --nocapture`

Wrapper LiteSVM regression is in the companion percolator-prog PR pinned to engine commit `83387267a09c95cfbf5dfd7b66f55bb8e4d3489e`.
