### PR TITLE
[codex] Charge sub-atom trade fees on ceil notional

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -15886,6 +15886,20 @@ fn checked_fee_bps(notional: u128, fee_bps: u64) -> V16Result<u128> {
     .ok_or(V16Error::ArithmeticOverflow)
 }
 
+/// Per-side trade fee atoms, mirroring the production derivation in
+/// `execute_trade_*` exactly (ceil fee notional -> ceil bps). Proof shim for the
+/// no-free-OI lower bound: a nonzero fill at nonzero price with nonzero fee must
+/// charge >= 1 atom. See `proof_v16_nonzero_trade_charges_positive_fee_per_side`.
+#[cfg(any(kani, feature = "fuzz"))]
+pub fn kani_trade_fee_atoms_per_side(
+    size_q: u128,
+    exec_price: u64,
+    fee_bps: u64,
+) -> V16Result<u128> {
+    let fee_notional = trade_fee_notional_ceil(size_q, exec_price)?;
+    checked_fee_bps(fee_notional, fee_bps)
+}
+
 fn checked_i128_mul(a: i128, b: i128) -> V16Result<i128> {
     let out = a.checked_mul(b).ok_or(V16Error::ArithmeticOverflow)?;
     validate_non_min_i128(out)?;

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -13418,7 +13418,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             self.require_asset_active_for_risk_increase(request.asset_index)?;
         }
         let notional = trade_notional_floor(abs_size_q, request.exec_price)?;
-        let fee = checked_fee_bps(notional, request.fee_bps)?;
+        let fee_notional = trade_fee_notional_ceil(abs_size_q, request.exec_price)?;
+        let fee = checked_fee_bps(fee_notional, request.fee_bps)?;
         let fee_a = self.charge_account_fee_current_not_atomic(long_account, fee)?;
         let fee_b = self.charge_account_fee_current_not_atomic(short_account, fee)?;
         self.apply_current_position_delta_with_lookup(
@@ -15855,6 +15856,13 @@ fn trade_notional_floor(size_q: u128, exec_price: u64) -> V16Result<u128> {
         U256::from_u128(POS_SCALE),
     );
     q.try_into_u128().ok_or(V16Error::ArithmeticOverflow)
+}
+
+fn trade_fee_notional_ceil(size_q: u128, exec_price: u64) -> V16Result<u128> {
+    if size_q == 0 || exec_price == 0 {
+        return Ok(0);
+    }
+    risk_notional_ceil(size_q, exec_price)
 }
 
 fn checked_fee_bps(notional: u128, fee_bps: u64) -> V16Result<u128> {

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -13784,3 +13784,35 @@ fn proof_v16_auto_crank_refresh_is_unique_observation_requiring_plan() {
         reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
     }));
 }
+
+// LoF — no free open interest: a risk-increasing fill with nonzero size, nonzero
+// price, and nonzero fee_bps must charge a STRICTLY POSITIVE fee per side. The
+// pre-fix code derived the fee from trade_notional_floor, which rounds sub-atom
+// notional (size_q * exec_price < POS_SCALE) to 0, so a nonzero fill paid zero fee
+// while still TAKING open interest. Charging on CEIL notional guarantees >= 1 atom
+// per side. This is exactly the LOWER BOUND the conservation/application fee proofs
+// are blind to: a zero fee conserves value and over-charges nothing, so every
+// existing fee proof passes on the bug. Mutation-checked: swapping the shim to
+// trade_notional_floor makes this FAIL on the sub-atom counterexample.
+#[kani::proof]
+#[kani::unwind(40)]
+#[kani::solver(cadical)]
+fn proof_v16_nonzero_trade_charges_positive_fee_per_side() {
+    let size_q: u128 = kani::any();
+    let exec_price: u64 = kani::any();
+    let fee_bps: u64 = kani::any();
+    kani::assume(size_q > 0 && size_q <= percolator::MAX_TRADE_SIZE_Q);
+    kani::assume(exec_price > 0 && exec_price <= percolator::MAX_ORACLE_PRICE);
+    kani::assume(fee_bps > 0 && fee_bps <= percolator::MAX_TRADING_FEE_BPS);
+    // Exercise the bug's regime: sub-atom notional that floored to zero.
+    kani::cover!(
+        (size_q.saturating_mul(exec_price as u128)) < percolator::POS_SCALE,
+        "sub-atom notional (the floored-to-zero regime) is reachable"
+    );
+    let fee =
+        percolator::v16::kani_trade_fee_atoms_per_side(size_q, exec_price, fee_bps).unwrap();
+    assert!(
+        fee >= 1,
+        "nonzero fill at nonzero price with nonzero fee must charge >= 1 atom per side (no free OI)"
+    );
+}

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -828,6 +828,47 @@ fn v16_single_trade_matches_batch_of_one_state() {
 }
 
 #[test]
+fn v16_subatom_trade_charges_fee_on_ceil_fee_notional() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    header.config.max_trading_fee_bps = V16PodU64::new(1);
+    let mut long_header = account_fixture(1, 213);
+    let mut short_header = account_fixture(1, 214);
+    let sub_atom_size = POS_SCALE / 100 - 1;
+    let request = TradeRequestV16 {
+        asset_index: 0,
+        size_q: signed_q(sub_atom_size),
+        exec_price: 100,
+        fee_bps: 1,
+    };
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market.deposit_not_atomic(&mut long, 1_000).unwrap();
+    market.deposit_not_atomic(&mut short, 1_000).unwrap();
+
+    let outcome = market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(&mut long, &mut short, request)
+        .unwrap();
+
+    assert_eq!(outcome.notional, 0);
+    assert_eq!(outcome.fee_a, 1);
+    assert_eq!(outcome.fee_b, 1);
+    assert_eq!(market.header.insurance.get(), 2);
+    assert_eq!(
+        market.markets[0].engine.asset.oi_eff_long_q.get(),
+        sub_atom_size
+    );
+    assert_eq!(
+        market.markets[0].engine.asset.oi_eff_short_q.get(),
+        sub_atom_size
+    );
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+    short.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_batch_trade_checks_initial_margin_on_final_portfolio() {
     let (mut header, mut markets) = market_fixture(2, 100);
     let mut taker_header = account_fixture(2, 211);


### PR DESCRIPTION
## Summary

Fixes a fee-splitting LoF bug where a nonzero trade whose `size_q * exec_price < POS_SCALE` had floor notional 0 and therefore paid zero configured trade fee while still increasing open interest.

The engine now keeps the existing floored trade notional for reporting, but computes fee basis from ceil notional so any nonzero fill at nonzero price and nonzero `fee_bps` pays at least one atom per side.

## Validation

- `cargo test --test v16_spec_tests v16_subatom_trade_charges_fee_on_ceil_fee_notional -- --nocapture`
- `cargo test --test v16_spec_tests v16_single_trade_matches_batch_of_one_state -- --nocapture`