### PR TITLE
[codex] Allow resolved close to wind down unattributed bad debt

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -11241,11 +11241,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // close (expired_close -> DeclareRecovery, reason
         // ActiveBankruptCloseCannotProgress); every other recovery reason is
         // declared REACTIVELY inside the dispatched crank op when it detects
-        // non-progress (BIndexHeadroomExhausted, etc.). A Resolved-mode
-        // unattributed-insolvent account is a TERMINAL RecoveryRequired state with
-        // no permissionless crank (close_resolved returns Err(RecoveryRequired)),
-        // so it is NOT proactively classified here — recovery_eligible stays in
-        // the summary type for the proven selector but is driven by expired_close.
+        // non-progress (BIndexHeadroomExhausted, etc.). Resolved bad-debt
+        // wind-down is handled by CloseResolved itself, not by the recovery
+        // selector flag, so recovery_eligible stays in the summary type for the
+        // proven selector but is driven by expired_close.
         let recovery_eligible = false;
         // resolved_winner routes to close_resolved, which LAZILY captures the
         // payout snapshot itself (initialize_resolved_payout_ledger_if_needed is
@@ -12362,6 +12361,50 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if self.b_target_for_leg(asset_index, leg)? != leg.b_snap {
             return Err(V16Error::Stale);
         }
+        let asset = self.asset_state(asset_index)?;
+        let asset = V16Core::kernel_clear_leg(leg, asset)?;
+        account.header.legs[leg_slot] =
+            PortfolioLegV16Account::from_runtime(&PortfolioLegV16::EMPTY);
+        let mut bitmap = account.header.active_bitmap.map(V16PodU64::get);
+        active_bitmap_clear(&mut bitmap, leg_slot)?;
+        account.header.active_bitmap = bitmap.map(V16PodU64::new);
+        account.header.health_cert.valid = 0;
+        self.set_asset_state(asset_index, asset)?;
+        Ok(())
+    }
+
+    fn clear_resolved_close_leg(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        asset_index: usize,
+    ) -> V16Result<()> {
+        if decode_market_mode(self.header.mode)? != MarketModeV16::Resolved {
+            return Err(V16Error::LockActive);
+        }
+        let leg_slot = Self::require_active_leg_slot_for_asset(&account.as_view(), asset_index)?;
+        let mut leg = account.header.legs[leg_slot].try_to_runtime()?;
+        if !leg.active || leg.b_stale || leg.stale {
+            return Err(V16Error::InvalidLeg);
+        }
+        if account
+            .header
+            .close_progress
+            .try_to_runtime()?
+            .has_pending_residual()
+        {
+            return Err(V16Error::LockActive);
+        }
+        if self.has_pending_domain_loss_barrier(asset_index, leg.side)? {
+            return Err(V16Error::LockActive);
+        }
+        let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;
+        if k_target != leg.k_snap || f_target != leg.f_snap {
+            return Err(V16Error::Stale);
+        }
+        if self.b_target_for_leg(asset_index, leg)? != leg.b_snap {
+            return Err(V16Error::Stale);
+        }
+        leg.b_rem = 0;
         let asset = self.asset_state(asset_index)?;
         let asset = V16Core::kernel_clear_leg(leg, asset)?;
         account.header.legs[leg_slot] =
@@ -13711,19 +13754,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if account.header.pnl.get() >= 0 {
             return Ok(());
         }
-        Err(V16Error::RecoveryRequired)
-    }
-
-    fn resolved_unattributed_insolvent_negative_pnl_requires_recovery(
-        &self,
-        account: &PortfolioV16View<'_>,
-    ) -> V16Result<bool> {
-        Ok(
-            decode_market_mode(self.header.mode)? == MarketModeV16::Resolved
-                && account.header.pnl.get() < 0
-                && account.header.pnl.get().unsigned_abs() > account.header.capital.get()
-                && self.resolved_bankruptcy_attribution(account)?.is_none(),
-        )
+        self.header.bankruptcy_hlock_active = 1;
+        self.set_account_pnl(account, 0)?;
+        account.header.health_cert.valid = 0;
+        Ok(())
     }
 
     fn settle_resolved_bankruptcy_negative_pnl(
@@ -14736,21 +14770,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             self.validate_shape()?;
             return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
         }
-        if self
-            .resolved_unattributed_insolvent_negative_pnl_requires_recovery(&account.as_view())?
-        {
-            return Err(V16Error::RecoveryRequired);
-        }
         self.sync_account_fee_to_slot_not_atomic(
             account,
             self.header.resolved_slot.get(),
             fee_rate_per_slot,
         )?;
-        if self
-            .resolved_unattributed_insolvent_negative_pnl_requires_recovery(&account.as_view())?
-        {
-            return Err(V16Error::RecoveryRequired);
-        }
         self.settle_negative_pnl_from_principal_not_atomic(account)?;
         if account.header.pnl.get() < 0 {
             self.settle_resolved_bankruptcy_negative_pnl(account)?;
@@ -14875,7 +14899,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
             if leg.active {
-                self.clear_leg(account, leg.asset_index as usize)?;
+                self.clear_resolved_close_leg(account, leg.asset_index as usize)?;
             }
             slot += 1;
         }

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -840,6 +840,20 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.settle_negative_pnl_from_principal_core_not_atomic(account)
     }
 
+        pub fn kani_resolved_bankruptcy_attribution(
+        &self,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<Option<(usize, SideV16)>> {
+        self.resolved_bankruptcy_attribution(account)
+    }
+
+        pub fn kani_settle_resolved_bankruptcy_negative_pnl(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+    ) -> V16Result<()> {
+        self.settle_resolved_bankruptcy_negative_pnl(account)
+    }
+
         pub fn kani_resolved_receipt_claimable_against_ledger(
         receipt: ResolvedPayoutReceiptV16,
         ledger: ResolvedPayoutLedgerV16,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -79,6 +79,27 @@ fn one_market_view_fixture() -> (
     (header, markets, account_header)
 }
 
+fn two_market_view_fixture() -> (
+    MarketGroupV16HeaderAccount,
+    [Market<u64>; 2],
+    PortfolioAccountV16Account,
+) {
+    let (market_id, _, _) = ids();
+    let cfg = V16Config::public_user_fund_with_market_slots(2, 2, 0, 10);
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_id, cfg, 2, 0).unwrap();
+    let mut markets = [
+        Market::new(0u64, EngineAssetSlotV16Account::default()),
+        Market::new(0u64, EngineAssetSlotV16Account::default()),
+    ];
+    {
+        let mut view = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        view.activate_empty_market_not_atomic(0, 100, 1).unwrap();
+        view.activate_empty_market_not_atomic(1, 100, 2).unwrap();
+    }
+    let account_header = empty_account_fixture(market_id, 2);
+    (header, markets, account_header)
+}
+
 fn one_market_only_fixture() -> (MarketGroupV16HeaderAccount, [Market<u64>; 1]) {
     let (market_id, _, _) = ids();
     let cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
@@ -7755,6 +7776,110 @@ fn proof_v16_public_resolved_close_flat_account_pays_only_capital_and_vault() {
     assert_eq!(account.header.reserved_pnl.get(), 0);
     assert_eq!(market.validate_shape(), Ok(()));
     assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
+}
+
+#[kani::proof]
+#[kani::unwind(40)]
+#[kani::solver(cadical)]
+fn proof_v16_resolved_two_active_legs_are_unattributed_for_bankruptcy() {
+    let (mut header, mut markets, mut account_header) = two_market_view_fixture();
+    header.mode = 1; // Resolved
+    header.current_slot = V16PodU64::new(2);
+    header.resolved_slot = V16PodU64::new(2);
+    header.slot_last = V16PodU64::new(2);
+
+    let mut bitmap = account_header.active_bitmap.map(V16PodU64::get);
+    active_bitmap_set(&mut bitmap, 0).unwrap();
+    active_bitmap_set(&mut bitmap, 1).unwrap();
+    account_header.active_bitmap = bitmap.map(V16PodU64::new);
+
+    let mut asset0 = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset0.oi_eff_long_q = POS_SCALE;
+    asset0.stored_pos_count_long = 1;
+    asset0.loss_weight_sum_long = POS_SCALE;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset0);
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset0.market_id,
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset0.k_long,
+        f_snap: asset0.f_long_num,
+        epoch_snap: asset0.epoch_long,
+        loss_weight: POS_SCALE,
+        b_snap: asset0.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset0.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+
+    let mut asset1 = markets[1].engine.asset.try_to_runtime().unwrap();
+    asset1.oi_eff_short_q = POS_SCALE;
+    asset1.stored_pos_count_short = 1;
+    asset1.loss_weight_sum_short = POS_SCALE;
+    markets[1].engine.asset = AssetStateV16Account::from_runtime(&asset1);
+    account_header.legs[1] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 1,
+        market_id: asset1.market_id,
+        side: SideV16::Short,
+        basis_pos_q: -(POS_SCALE as i128),
+        a_basis: ADL_ONE,
+        k_snap: asset1.k_short,
+        f_snap: asset1.f_short_num,
+        epoch_snap: asset1.epoch_short,
+        loss_weight: POS_SCALE,
+        b_snap: asset1.b_short_num,
+        b_rem: 0,
+        b_epoch_snap: asset1.epoch_short,
+        b_stale: false,
+        stale: false,
+    });
+
+    let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let account = PortfolioV16ViewMut::new(&mut account_header);
+    let attribution = market
+        .kani_resolved_bankruptcy_attribution(&account.as_view())
+        .unwrap();
+
+    kani::cover!(true, "resolved bankruptcy attribution sees two active legs");
+    assert_eq!(attribution, None);
+}
+
+#[kani::proof]
+#[kani::unwind(40)]
+#[kani::solver(cadical)]
+fn proof_v16_resolved_unattributed_bad_debt_clears_without_recovery() {
+    let loss_raw: u8 = kani::any();
+    kani::assume((1..=8).contains(&loss_raw));
+    let loss = loss_raw as i128;
+    let (mut header, mut markets, mut account_header) = one_market_view_fixture();
+    header.mode = 1; // Resolved
+    header.current_slot = V16PodU64::new(2);
+    header.resolved_slot = V16PodU64::new(2);
+    header.slot_last = V16PodU64::new(2);
+    header.negative_pnl_account_count = V16PodU64::new(1);
+    account_header.pnl = V16PodI128::new(-loss);
+    account_header.last_fee_slot = V16PodU64::new(2);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let result = market.kani_settle_resolved_bankruptcy_negative_pnl(&mut account);
+
+    kani::cover!(
+        loss > 3,
+        "resolved close covers nontrivial unattributed terminal bad debt"
+    );
+    assert_ne!(result, Err(V16Error::RecoveryRequired));
+    assert_eq!(result, Ok(()));
+    assert_eq!(account.header.pnl.get(), 0);
+    assert!(active_bitmap_is_empty(
+        account.header.active_bitmap.map(V16PodU64::get)
+    ));
+    assert_eq!(market.header.negative_pnl_account_count.get(), 0);
 }
 
 #[kani::proof]


### PR DESCRIPTION
## Summary
- Allows resolved close to clear terminal unattributed negative PnL instead of returning RecoveryRequired forever.
- Adds a resolved-close leg detach path that avoids terminal wind-down being blocked by social-loss residue accounting.
- Updates the actionable-summary comment so it no longer claims resolved unattributed insolvency has no permissionless crank.

## Root Cause
A resolved account with multi-asset bad debt could have no single bankruptcy attribution. CloseResolved returned RecoveryRequired, so the wrapper-level PermissionlessCrank could not make progress and the account remained materialized.

## Validation
- cargo test --quiet in /home/anatoly/percolator
- Downstream wrapper LiteSVM regression passes when pinned to this commit.