### PR TITLE
[codex] Fix liquidation min-fee chunking

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -317,6 +317,15 @@ fn liquidation_close_would_leave_uncovered_loss_with_open_risk(
     Ok(uncovered_loss_after_principal != 0 && !active_bitmap_is_empty(remaining_active_bitmap))
 }
 
+#[inline]
+fn liquidation_engine_close_request_q(leg_basis_pos_q: i128) -> V16Result<u128> {
+    let close_q = leg_basis_pos_q.unsigned_abs();
+    if close_q == 0 {
+        return Err(V16Error::InvalidLeg);
+    }
+    Ok(close_q)
+}
+
 fn add_open_interest_for_new_position(
     asset: &mut AssetStateV16,
     side: SideV16,
@@ -4508,15 +4517,15 @@ pub struct AutoCrankObservationV16 {
     pub funding_rate_e9: i128,
 }
 
-/// Bounded work a keeper submits to the order-insensitive auto-crank (engine.md):
-/// observations that may land in any order, a liquidation work budget, and the
-/// resolved-close fee rate. NO caller-chosen action, asset, or liquidation fee —
-/// the engine selects the step and the asset and derives the fee from config.
+/// Work a keeper submits to the order-insensitive auto-crank (engine.md):
+/// observations that may land in any order and the resolved-close fee rate. NO
+/// caller-chosen action, asset, liquidation size, or liquidation fee — the engine
+/// selects the step/asset, closes the selected leg, and derives the fee from
+/// config.
 #[derive(Clone, Copy, Debug)]
 pub struct AutoCrankWorkV16<'a> {
     pub now_slot: u64,
     pub observations: &'a [AutoCrankObservationV16],
-    pub liquidation_max_close_q: u128,
     pub resolved_close_fee_rate_per_slot: u128,
 }
 
@@ -5096,7 +5105,6 @@ impl SourceCreditLienAggregateProofV16 {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LiquidationRequestV16 {
     pub asset_index: usize,
-    pub close_q: u128,
     pub fee_bps: u64,
 }
 
@@ -11380,12 +11388,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     /// Calling convention (wrapper side):
     /// 1. Decode a public auto-crank instruction carrying a bounded set of oracle
     ///    OBSERVATIONS (asset, authenticated price, funding) — one per asset the
-    ///    keeper has fresh data for — plus a `liquidation_max_close_q` work budget
-    ///    and the `resolved_close_fee_rate_per_slot`.
+    ///    keeper has fresh data for — plus the `resolved_close_fee_rate_per_slot`.
     /// 2. Authenticate clock/slot + each observation against the oracle.
-    /// 3. Build `AutoCrankWorkV16 { now_slot, observations, liquidation_max_close_q,
-    ///    resolved_close_fee_rate_per_slot }` and call this ONCE (one ix = one step;
-    ///    never loop to a fixed point — CU).
+    /// 3. Build `AutoCrankWorkV16 { now_slot, observations,
+    ///    resolved_close_fee_rate_per_slot }` and call this ONCE (one ix = one
+    ///    step; never loop to a fixed point — CU).
     /// 4. The engine classifies the account, selects the highest-priority step AND
     ///    its asset (self-selected — the caller never chooses action or asset),
     ///    matches the observation that step needs, derives the liquidation fee from
@@ -11505,7 +11512,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     obs,
                     PermissionlessCrankActionV16::Liquidate(LiquidationRequestV16 {
                         asset_index,
-                        close_q: work.liquidation_max_close_q,
                         fee_bps,
                     }),
                 )?)
@@ -13172,7 +13178,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         let config = self.header.config.try_to_runtime_shape()?;
         if request.asset_index >= config.max_market_slots as usize
-            || request.close_q == 0
             || request.fee_bps > config.liquidation_fee_bps.max(config.max_trading_fee_bps)
         {
             return Err(V16Error::InvalidConfig);
@@ -13200,11 +13205,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if !leg.active {
             return Err(V16Error::InvalidLeg);
         }
+        let close_request_q = liquidation_engine_close_request_q(leg.basis_pos_q)?;
         // PRODUCTION KERNEL: clamp + toward-zero reduction delta — the SAME
         // risk-reduction kernel rebalance uses, so A5.dec's strict-progress
-        // contract now governs the real liquidation route (3C).
+        // contract now governs the real liquidation route (3C). Liquidation size
+        // is engine-selected: close the selected leg fully, never a keeper chunk.
         let (close_q, close_delta) =
-            V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, request.close_q)?;
+            V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, close_request_q)?;
         if self.position_delta_touches_pending_domain_loss_barrier(
             &account.as_view(),
             request.asset_index,

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -317,13 +317,168 @@ fn liquidation_close_would_leave_uncovered_loss_with_open_risk(
     Ok(uncovered_loss_after_principal != 0 && !active_bitmap_is_empty(remaining_active_bitmap))
 }
 
-#[inline]
-fn liquidation_engine_close_request_q(leg_basis_pos_q: i128) -> V16Result<u128> {
-    let close_q = leg_basis_pos_q.unsigned_abs();
-    if close_q == 0 {
+fn liquidation_leg_maintenance_requirement(
+    config: V16Config,
+    abs_q: u128,
+    side: SideV16,
+    effective_price: u64,
+    raw_target_price: u64,
+) -> V16Result<u128> {
+    if abs_q == 0 {
+        return Ok(0);
+    }
+    let risk_notional = risk_notional_ceil(abs_q, effective_price)?;
+    let target_lag_penalty =
+        V16Core::target_effective_lag_loss_penalty(abs_q, side, effective_price, raw_target_price)?;
+    let (_, maintenance, _) = V16Core::health_requirements_from_notional_and_target_lag(
+        config,
+        risk_notional,
+        target_lag_penalty,
+    )?;
+    Ok(maintenance)
+}
+
+fn liquidation_projected_healthy_after_close(
+    config: V16Config,
+    cert: HealthCertV16,
+    capital: u128,
+    pnl: i128,
+    leg: PortfolioLegV16,
+    effective_price: u64,
+    raw_target_price: u64,
+    fee_bps: u64,
+    close_q: u128,
+) -> V16Result<bool> {
+    let old_abs_q = leg.basis_pos_q.unsigned_abs();
+    if close_q == 0 || close_q > old_abs_q {
+        return Ok(false);
+    }
+    let old_maintenance = liquidation_leg_maintenance_requirement(
+        config,
+        old_abs_q,
+        leg.side,
+        effective_price,
+        raw_target_price,
+    )?;
+    let new_abs_q = old_abs_q - close_q;
+    let new_maintenance = liquidation_leg_maintenance_requirement(
+        config,
+        new_abs_q,
+        leg.side,
+        effective_price,
+        raw_target_price,
+    )?;
+    let fee_notional = risk_notional_ceil(close_q, effective_price)?;
+    let fee = liquidation_fee_for_close(
+        fee_notional,
+        fee_bps,
+        config.min_liquidation_abs,
+        config.liquidation_fee_cap,
+        close_q == old_abs_q,
+    )?;
+    let charged_fee = if pnl >= 0 { fee.min(capital) } else { 0 };
+    Ok(liquidation_projected_health_deficit_from_parts(
+        cert.certified_equity,
+        cert.certified_maintenance_req,
+        old_maintenance,
+        new_maintenance,
+        charged_fee,
+    )? == 0)
+}
+
+fn liquidation_projected_health_deficit_from_parts(
+    certified_equity: i128,
+    certified_maintenance_req: u128,
+    old_leg_maintenance: u128,
+    new_leg_maintenance: u128,
+    charged_fee: u128,
+) -> V16Result<u128> {
+    let post_maintenance = certified_maintenance_req
+        .checked_sub(old_leg_maintenance)
+        .and_then(|v| v.checked_add(new_leg_maintenance))
+        .ok_or(V16Error::ArithmeticOverflow)?;
+    let charged_fee_i128 = i128::try_from(charged_fee).map_err(|_| V16Error::ArithmeticOverflow)?;
+    let post_equity = certified_equity
+        .checked_sub(charged_fee_i128)
+        .ok_or(V16Error::ArithmeticOverflow)?;
+    if post_equity < 0 {
+        return post_maintenance
+            .checked_add(post_equity.unsigned_abs())
+            .ok_or(V16Error::ArithmeticOverflow);
+    }
+    Ok(post_maintenance.saturating_sub(post_equity as u128))
+}
+
+fn liquidation_engine_close_request_q(
+    config: V16Config,
+    cert: HealthCertV16,
+    capital: u128,
+    pnl: i128,
+    leg: PortfolioLegV16,
+    effective_price: u64,
+    raw_target_price: u64,
+    fee_bps: u64,
+) -> V16Result<u128> {
+    let old_abs_q = leg.basis_pos_q.unsigned_abs();
+    if old_abs_q == 0 {
         return Err(V16Error::InvalidLeg);
     }
-    Ok(close_q)
+    if cert.certified_equity < 0 || pnl < 0 {
+        return Ok(old_abs_q);
+    }
+    if !liquidation_projected_healthy_after_close(
+        config,
+        cert,
+        capital,
+        pnl,
+        leg,
+        effective_price,
+        raw_target_price,
+        fee_bps,
+        old_abs_q,
+    )? {
+        return Ok(old_abs_q);
+    }
+
+    let mut lo = 1u128;
+    let mut hi = old_abs_q;
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        let healthy = liquidation_projected_healthy_after_close(
+            config,
+            cert,
+            capital,
+            pnl,
+            leg,
+            effective_price,
+            raw_target_price,
+            fee_bps,
+            mid,
+        )
+        .unwrap_or(false);
+        if healthy {
+            hi = mid;
+        } else {
+            lo = mid.checked_add(1).ok_or(V16Error::ArithmeticOverflow)?;
+        }
+    }
+    if liquidation_projected_healthy_after_close(
+        config,
+        cert,
+        capital,
+        pnl,
+        leg,
+        effective_price,
+        raw_target_price,
+        fee_bps,
+        lo,
+    )
+    .unwrap_or(false)
+    {
+        Ok(lo)
+    } else {
+        Ok(old_abs_q)
+    }
 }
 
 fn add_open_interest_for_new_position(
@@ -13205,11 +13360,22 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if !leg.active {
             return Err(V16Error::InvalidLeg);
         }
-        let close_request_q = liquidation_engine_close_request_q(leg.basis_pos_q)?;
+        let asset = self.asset_state(request.asset_index)?;
+        let close_request_q = liquidation_engine_close_request_q(
+            config,
+            cert,
+            account.header.capital.get(),
+            account.header.pnl.get(),
+            leg,
+            asset.effective_price,
+            asset.raw_oracle_target_price,
+            request.fee_bps,
+        )?;
         // PRODUCTION KERNEL: clamp + toward-zero reduction delta — the SAME
         // risk-reduction kernel rebalance uses, so A5.dec's strict-progress
         // contract now governs the real liquidation route (3C). Liquidation size
-        // is engine-selected: close the selected leg fully, never a keeper chunk.
+        // is engine-selected: close just enough to restore maintenance health
+        // when possible, otherwise close the selected leg fully.
         let (close_q, close_delta) =
             V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, close_request_q)?;
         if self.position_delta_touches_pending_domain_loss_barrier(
@@ -13237,10 +13403,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             leg.side,
             &account.as_view(),
         )?;
-        let fee_notional = risk_notional_ceil(
-            close_q,
-            self.asset_state(request.asset_index)?.effective_price,
-        )?;
+        let fee_notional = risk_notional_ceil(close_q, asset.effective_price)?;
         let fee = liquidation_fee_for_close(
             fee_notional,
             request.fee_bps,

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -13234,9 +13234,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             close_q,
             self.asset_state(request.asset_index)?.effective_price,
         )?;
-        let fee = checked_fee_bps(fee_notional, request.fee_bps)?
-            .max(config.min_liquidation_abs)
-            .min(config.liquidation_fee_cap);
+        let fee = liquidation_fee_for_close(
+            fee_notional,
+            request.fee_bps,
+            config.min_liquidation_abs,
+            config.liquidation_fee_cap,
+            close_q == leg.basis_pos_q.unsigned_abs(),
+        )?;
         let charged_fee = self.charge_account_fee_not_atomic(account, fee)?;
         self.settle_negative_pnl_from_principal_core_not_atomic(account)?;
         let gross_bankruptcy_residual = if account.header.pnl.get() < 0 {
@@ -15986,6 +15990,34 @@ fn checked_fee_bps(notional: u128, fee_bps: u64) -> V16Result<u128> {
     )
     .and_then(|v| v.try_into_u128())
     .ok_or(V16Error::ArithmeticOverflow)
+}
+
+fn liquidation_fee_for_close(
+    fee_notional: u128,
+    fee_bps: u64,
+    min_liquidation_abs: u128,
+    liquidation_fee_cap: u128,
+    closes_full_position: bool,
+) -> V16Result<u128> {
+    let raw_fee = checked_fee_bps(fee_notional, fee_bps)?;
+    liquidation_fee_from_raw_fee(
+        raw_fee,
+        min_liquidation_abs,
+        liquidation_fee_cap,
+        closes_full_position,
+    )
+}
+
+fn liquidation_fee_from_raw_fee(
+    raw_fee: u128,
+    min_liquidation_abs: u128,
+    liquidation_fee_cap: u128,
+    closes_full_position: bool,
+) -> V16Result<u128> {
+    if !closes_full_position && min_liquidation_abs != 0 && raw_fee < min_liquidation_abs {
+        return Err(V16Error::NonProgress);
+    }
+    Ok(raw_fee.max(min_liquidation_abs).min(liquidation_fee_cap))
 }
 
 /// Per-side trade fee atoms, mirroring the production derivation in

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -317,6 +317,19 @@ fn liquidation_close_would_leave_uncovered_loss_with_open_risk(
     Ok(uncovered_loss_after_principal != 0 && !active_bitmap_is_empty(remaining_active_bitmap))
 }
 
+fn liquidation_risk_notional_ceil(abs_pos_q: u128, price: u64) -> V16Result<u128> {
+    if abs_pos_q == 0 {
+        return Ok(0);
+    }
+    if abs_pos_q > MAX_POSITION_ABS_Q || price > MAX_ORACLE_PRICE {
+        return Err(V16Error::InvalidConfig);
+    }
+    let product = abs_pos_q * price as u128;
+    (product / POS_SCALE)
+        .checked_add(u128::from(product % POS_SCALE != 0))
+        .ok_or(V16Error::ArithmeticOverflow)
+}
+
 fn liquidation_leg_maintenance_requirement(
     config: V16Config,
     abs_q: u128,
@@ -327,15 +340,17 @@ fn liquidation_leg_maintenance_requirement(
     if abs_q == 0 {
         return Ok(0);
     }
-    let risk_notional = risk_notional_ceil(abs_q, effective_price)?;
-    let target_lag_penalty =
-        V16Core::target_effective_lag_loss_penalty(abs_q, side, effective_price, raw_target_price)?;
-    let (_, maintenance, _) = V16Core::health_requirements_from_notional_and_target_lag(
-        config,
-        risk_notional,
-        target_lag_penalty,
-    )?;
-    Ok(maintenance)
+    if config.maintenance_margin_bps > MAX_MARGIN_BPS {
+        return Err(V16Error::InvalidConfig);
+    }
+    let risk_notional = liquidation_risk_notional_ceil(abs_q, effective_price)?;
+    let adverse_delta =
+        V16Core::target_effective_lag_adverse_delta(side, effective_price, raw_target_price);
+    let target_lag_penalty = liquidation_risk_notional_ceil(abs_q, adverse_delta)?;
+    let base = ((risk_notional * config.maintenance_margin_bps as u128) / MAX_MARGIN_BPS as u128)
+        .max(config.min_nonzero_mm_req);
+    base.checked_add(target_lag_penalty)
+        .ok_or(V16Error::ArithmeticOverflow)
 }
 
 fn liquidation_projected_healthy_after_close(
@@ -368,7 +383,7 @@ fn liquidation_projected_healthy_after_close(
         effective_price,
         raw_target_price,
     )?;
-    let fee_notional = risk_notional_ceil(close_q, effective_price)?;
+    let fee_notional = liquidation_risk_notional_ceil(close_q, effective_price)?;
     let fee = liquidation_fee_for_close(
         fee_notional,
         fee_bps,
@@ -384,6 +399,76 @@ fn liquidation_projected_healthy_after_close(
         new_maintenance,
         charged_fee,
     )? == 0)
+}
+
+fn liquidation_partial_close_is_healthy(
+    config: V16Config,
+    cert: HealthCertV16,
+    capital: u128,
+    pnl: i128,
+    leg: PortfolioLegV16,
+    effective_price: u64,
+    raw_target_price: u64,
+    fee_bps: u64,
+    close_q: u128,
+) -> V16Result<bool> {
+    match liquidation_projected_healthy_after_close(
+        config,
+        cert,
+        capital,
+        pnl,
+        leg,
+        effective_price,
+        raw_target_price,
+        fee_bps,
+        close_q,
+    ) {
+        // A partial close below the configured absolute fee floor is not an
+        // admissible liquidation chunk. Every other error remains fail-closed.
+        Err(V16Error::NonProgress) => Ok(false),
+        result => result,
+    }
+}
+
+fn min_abs_q_for_risk_notional_at_least(
+    risk_notional: u128,
+    effective_price: u64,
+) -> V16Result<u128> {
+    if risk_notional == 0 {
+        return Ok(0);
+    }
+    if effective_price == 0 {
+        return Err(V16Error::InvalidConfig);
+    }
+    let numerator = risk_notional - 1;
+    if let Some(product) = numerator.checked_mul(POS_SCALE) {
+        return (product / effective_price as u128)
+            .checked_add(1)
+            .ok_or(V16Error::ArithmeticOverflow);
+    }
+    U256::from_u128(numerator)
+        .checked_mul(U256::from_u128(POS_SCALE))
+        .and_then(|v| v.checked_div(U256::from_u128(effective_price as u128)))
+        .and_then(|v| v.try_into_u128())
+        .and_then(|v| v.checked_add(1))
+        .ok_or(V16Error::ArithmeticOverflow)
+}
+
+fn liquidation_partial_search_hi(
+    config: V16Config,
+    old_abs_q: u128,
+    effective_price: u64,
+) -> V16Result<u128> {
+    if config.maintenance_margin_bps == 0 {
+        return Ok(0);
+    }
+    let floor_exit_notional = V16Config::checked_mul_div_ceil_to_u128(
+        config.min_nonzero_mm_req,
+        MAX_MARGIN_BPS as u128,
+        config.maintenance_margin_bps as u128,
+    )?;
+    let floor_exit_q = min_abs_q_for_risk_notional_at_least(floor_exit_notional, effective_price)?;
+    Ok(old_abs_q.saturating_sub(floor_exit_q))
 }
 
 fn liquidation_projected_health_deficit_from_parts(
@@ -440,11 +525,33 @@ fn liquidation_engine_close_request_q(
         return Ok(old_abs_q);
     }
 
+    // The absolute maintenance floor makes projected health non-monotone: a
+    // partial close can become healthy, unhealthy again as its fee grows while
+    // maintenance is flat, then healthy on the full-close discontinuity. Search
+    // only the proportional-margin prefix. Crossing into the floor region is a
+    // deterministic dust/full-close policy.
+    let partial_hi = liquidation_partial_search_hi(config, old_abs_q, effective_price)?;
+    if partial_hi == 0
+        || !liquidation_partial_close_is_healthy(
+            config,
+            cert,
+            capital,
+            pnl,
+            leg,
+            effective_price,
+            raw_target_price,
+            fee_bps,
+            partial_hi,
+        )?
+    {
+        return Ok(old_abs_q);
+    }
+
     let mut lo = 1u128;
-    let mut hi = old_abs_q;
+    let mut hi = partial_hi;
     while lo < hi {
         let mid = lo + (hi - lo) / 2;
-        let healthy = liquidation_projected_healthy_after_close(
+        let healthy = liquidation_partial_close_is_healthy(
             config,
             cert,
             capital,
@@ -454,15 +561,14 @@ fn liquidation_engine_close_request_q(
             raw_target_price,
             fee_bps,
             mid,
-        )
-        .unwrap_or(false);
+        )?;
         if healthy {
             hi = mid;
         } else {
             lo = mid.checked_add(1).ok_or(V16Error::ArithmeticOverflow)?;
         }
     }
-    if liquidation_projected_healthy_after_close(
+    if liquidation_partial_close_is_healthy(
         config,
         cert,
         capital,
@@ -472,9 +578,7 @@ fn liquidation_engine_close_request_q(
         raw_target_price,
         fee_bps,
         lo,
-    )
-    .unwrap_or(false)
-    {
+    )? {
         Ok(lo)
     } else {
         Ok(old_abs_q)
@@ -5260,7 +5364,6 @@ impl SourceCreditLienAggregateProofV16 {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LiquidationRequestV16 {
     pub asset_index: usize,
-    pub fee_bps: u64,
 }
 
 #[repr(C)]
@@ -11654,21 +11757,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
             AutoCrankPlanV16::Liquidate { asset_index } => {
                 let obs = obs_or_current_asset(self, asset_index)?;
-                // CONFIG fee policy — never a caller hint (engine.md).
-                let fee_bps = self
-                    .header
-                    .config
-                    .try_to_runtime_shape()?
-                    .liquidation_fee_bps;
                 AutoCrankOutcomeV16::Progressed(crank_with(
                     self,
                     account,
                     asset_index,
                     obs,
-                    PermissionlessCrankActionV16::Liquidate(LiquidationRequestV16 {
-                        asset_index,
-                        fee_bps,
-                    }),
+                    PermissionlessCrankActionV16::Liquidate(LiquidationRequestV16 { asset_index }),
                 )?)
             }
             AutoCrankPlanV16::DeclareRecovery { reason } => {
@@ -13332,11 +13426,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Err(V16Error::LockActive);
         }
         let config = self.header.config.try_to_runtime_shape()?;
-        if request.asset_index >= config.max_market_slots as usize
-            || request.fee_bps > config.liquidation_fee_bps.max(config.max_trading_fee_bps)
-        {
+        if request.asset_index >= config.max_market_slots as usize {
             return Err(V16Error::InvalidConfig);
         }
+        let fee_bps = config.liquidation_fee_bps;
         self.require_asset_live_reducible(request.asset_index)?;
         self.validate_account_scalar_preflight(&account.as_view())?;
         Self::require_active_leg_slot_for_asset(&account.as_view(), request.asset_index)?;
@@ -13369,7 +13462,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             leg,
             asset.effective_price,
             asset.raw_oracle_target_price,
-            request.fee_bps,
+            fee_bps,
         )?;
         // PRODUCTION KERNEL: clamp + toward-zero reduction delta — the SAME
         // risk-reduction kernel rebalance uses, so A5.dec's strict-progress
@@ -13403,10 +13496,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             leg.side,
             &account.as_view(),
         )?;
-        let fee_notional = risk_notional_ceil(close_q, asset.effective_price)?;
+        let fee_notional = liquidation_risk_notional_ceil(close_q, asset.effective_price)?;
         let fee = liquidation_fee_for_close(
             fee_notional,
-            request.fee_bps,
+            fee_bps,
             config.min_liquidation_abs,
             config.liquidation_fee_cap,
             close_q == leg.basis_pos_q.unsigned_abs(),
@@ -16169,7 +16262,13 @@ fn liquidation_fee_for_close(
     liquidation_fee_cap: u128,
     closes_full_position: bool,
 ) -> V16Result<u128> {
-    let raw_fee = checked_fee_bps(fee_notional, fee_bps)?;
+    if fee_notional > MAX_ACCOUNT_NOTIONAL || fee_bps > MAX_MARGIN_BPS {
+        return Err(V16Error::InvalidConfig);
+    }
+    let product = fee_notional * fee_bps as u128;
+    let raw_fee = (product / MAX_MARGIN_BPS as u128)
+        .checked_add(u128::from(product % MAX_MARGIN_BPS as u128 != 0))
+        .ok_or(V16Error::ArithmeticOverflow)?;
     liquidation_fee_from_raw_fee(
         raw_fee,
         min_liquidation_abs,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -65,16 +65,20 @@ pub fn kani_liquidation_close_would_leave_uncovered_loss_with_open_risk(
     )
 }
 
-pub fn kani_liquidation_engine_close_request_q(leg_basis_pos_q: i128) -> V16Result<u128> {
-    liquidation_engine_close_request_q(leg_basis_pos_q)
-}
-
-pub fn kani_kernel_reduce_position_delta(
-    pre_basis_signed: i128,
-    side: SideV16,
-    requested: u128,
-) -> V16Result<(u128, i128)> {
-    V16Core::kernel_reduce_position_delta(pre_basis_signed, side, requested)
+pub fn kani_liquidation_projected_health_deficit_from_parts(
+    certified_equity: i128,
+    certified_maintenance_req: u128,
+    old_leg_maintenance: u128,
+    new_leg_maintenance: u128,
+    charged_fee: u128,
+) -> V16Result<u128> {
+    liquidation_projected_health_deficit_from_parts(
+        certified_equity,
+        certified_maintenance_req,
+        old_leg_maintenance,
+        new_leg_maintenance,
+        charged_fee,
+    )
 }
 
 pub fn kani_add_open_interest_for_new_position(

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -215,6 +215,36 @@ pub fn kani_checked_fee_bps(notional: u128, fee_bps: u64) -> V16Result<u128> {
     checked_fee_bps(notional, fee_bps)
 }
 
+pub fn kani_liquidation_fee_for_close(
+    fee_notional: u128,
+    fee_bps: u64,
+    min_liquidation_abs: u128,
+    liquidation_fee_cap: u128,
+    closes_full_position: bool,
+) -> V16Result<u128> {
+    liquidation_fee_for_close(
+        fee_notional,
+        fee_bps,
+        min_liquidation_abs,
+        liquidation_fee_cap,
+        closes_full_position,
+    )
+}
+
+pub fn kani_liquidation_fee_from_raw_fee(
+    raw_fee: u128,
+    min_liquidation_abs: u128,
+    liquidation_fee_cap: u128,
+    closes_full_position: bool,
+) -> V16Result<u128> {
+    liquidation_fee_from_raw_fee(
+        raw_fee,
+        min_liquidation_abs,
+        liquidation_fee_cap,
+        closes_full_position,
+    )
+}
+
 pub fn kani_adjust_u128(current: u128, old: u128, new: u128) -> V16Result<u128> {
     adjust_u128(current, old, new)
 }

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -81,6 +81,60 @@ pub fn kani_liquidation_projected_health_deficit_from_parts(
     )
 }
 
+pub fn kani_liquidation_projected_healthy_after_close(
+    config: V16Config,
+    cert: HealthCertV16,
+    capital: u128,
+    pnl: i128,
+    leg: PortfolioLegV16,
+    effective_price: u64,
+    raw_target_price: u64,
+    fee_bps: u64,
+    close_q: u128,
+) -> V16Result<bool> {
+    liquidation_projected_healthy_after_close(
+        config,
+        cert,
+        capital,
+        pnl,
+        leg,
+        effective_price,
+        raw_target_price,
+        fee_bps,
+        close_q,
+    )
+}
+
+pub fn kani_liquidation_engine_close_request_q(
+    config: V16Config,
+    cert: HealthCertV16,
+    capital: u128,
+    pnl: i128,
+    leg: PortfolioLegV16,
+    effective_price: u64,
+    raw_target_price: u64,
+    fee_bps: u64,
+) -> V16Result<u128> {
+    liquidation_engine_close_request_q(
+        config,
+        cert,
+        capital,
+        pnl,
+        leg,
+        effective_price,
+        raw_target_price,
+        fee_bps,
+    )
+}
+
+pub fn kani_liquidation_partial_search_hi(
+    config: V16Config,
+    old_abs_q: u128,
+    effective_price: u64,
+) -> V16Result<u128> {
+    liquidation_partial_search_hi(config, old_abs_q, effective_price)
+}
+
 pub fn kani_add_open_interest_for_new_position(
     asset: &mut AssetStateV16,
     side: SideV16,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -65,6 +65,18 @@ pub fn kani_liquidation_close_would_leave_uncovered_loss_with_open_risk(
     )
 }
 
+pub fn kani_liquidation_engine_close_request_q(leg_basis_pos_q: i128) -> V16Result<u128> {
+    liquidation_engine_close_request_q(leg_basis_pos_q)
+}
+
+pub fn kani_kernel_reduce_position_delta(
+    pre_basis_signed: i128,
+    side: SideV16,
+    requested: u128,
+) -> V16Result<(u128, i128)> {
+    V16Core::kernel_reduce_position_delta(pre_basis_signed, side, requested)
+}
+
 pub fn kani_add_open_interest_for_new_position(
     asset: &mut AssetStateV16,
     side: SideV16,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -9,9 +9,9 @@ use percolator::v16::{
     kani_backing_utilization_fee_quote_atoms_for_lien,
     kani_backing_utilization_rate_e9_for_source_state,
     kani_expected_source_credit_rate_num_for_state, kani_health_cert_after_capital_debit,
-    kani_health_requirements_from_base_and_target_lag, kani_kernel_reduce_position_delta,
+    kani_health_requirements_from_base_and_target_lag,
     kani_liquidation_close_would_leave_uncovered_loss_with_open_risk,
-    kani_liquidation_engine_close_request_q, kani_liquidation_fee_from_raw_fee,
+    kani_liquidation_fee_from_raw_fee, kani_liquidation_projected_health_deficit_from_parts,
     kani_loss_stale_trade_scope_allowed, kani_pending_domain_loss_barrier_blocks_position_change,
     kani_position_delta_increases_risk, kani_prepare_asset_recovery_transition,
     kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
@@ -3850,56 +3850,82 @@ fn proof_v16_pending_domain_loss_barrier_allows_only_same_side_reductions() {
 #[kani::proof]
 #[kani::unwind(8)]
 #[kani::solver(cadical)]
-fn proof_v16_liquidation_engine_selected_size_closes_full_leg() {
-    let basis_raw: i64 = kani::any();
-    let raw_fee_raw: u16 = kani::any();
-    let min_liquidation_abs_raw: u16 = kani::any();
-    let cap_extra: u16 = kani::any();
+fn proof_v16_liquidation_projection_identifies_minimum_no_fee_close() {
+    let abs_q_raw: u16 = kani::any();
+    let equity_raw: u16 = kani::any();
 
-    kani::assume(basis_raw != 0);
-    let basis = basis_raw as i128;
-    let side = if basis > 0 {
-        SideV16::Long
-    } else {
-        SideV16::Short
-    };
-    let leg_abs_q = basis.unsigned_abs();
-    let close_request_q = kani_liquidation_engine_close_request_q(basis).unwrap();
-    let (closed_q, delta_q) =
-        kani_kernel_reduce_position_delta(basis, side, close_request_q).unwrap();
+    kani::assume(abs_q_raw >= 2);
+    kani::assume(equity_raw >= 1 && equity_raw < abs_q_raw);
+    let abs_q = abs_q_raw as u128;
+    let equity = equity_raw as u128;
 
-    kani::cover!(
-        basis > 0 && leg_abs_q > 1024,
-        "engine-selected liquidation proof covers nontrivial long position"
-    );
-    kani::cover!(
-        basis < 0 && leg_abs_q > 1024,
-        "engine-selected liquidation proof covers nontrivial short position"
-    );
-    assert_eq!(close_request_q, leg_abs_q);
-    assert_eq!(closed_q, leg_abs_q);
-    assert_eq!(basis.checked_add(delta_q).unwrap(), 0);
-
-    let raw_fee = raw_fee_raw as u128;
-    let min_liquidation_abs = min_liquidation_abs_raw as u128;
-    let liquidation_fee_cap = min_liquidation_abs + cap_extra as u128;
-    let closes_full_position = closed_q == leg_abs_q;
-    let fee = kani_liquidation_fee_from_raw_fee(
-        raw_fee,
-        min_liquidation_abs,
-        liquidation_fee_cap,
-        closes_full_position,
+    let selected_new_maintenance = equity;
+    let one_less_new_maintenance = equity + 1;
+    let selected_deficit = kani_liquidation_projected_health_deficit_from_parts(
+        equity as i128,
+        abs_q,
+        abs_q,
+        selected_new_maintenance,
+        0,
+    )
+    .unwrap();
+    let one_less_deficit = kani_liquidation_projected_health_deficit_from_parts(
+        equity as i128,
+        abs_q,
+        abs_q,
+        one_less_new_maintenance,
+        0,
     )
     .unwrap();
 
     kani::cover!(
-        min_liquidation_abs > 0 && raw_fee < min_liquidation_abs && cap_extra > 0,
-        "engine-selected liquidation proof covers dust full close with absolute min fee"
+        abs_q > equity + 8,
+        "minimum no-fee liquidation projection covers nontrivial partial close"
     );
-    assert!(closes_full_position);
-    if min_liquidation_abs > 0 && raw_fee < min_liquidation_abs {
-        assert_eq!(fee, min_liquidation_abs);
-    }
+    assert_eq!(selected_deficit, 0);
+    assert_eq!(one_less_deficit, 1);
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_liquidation_projection_includes_fee_equity_debit() {
+    let abs_q_raw: u16 = kani::any();
+    let equity_raw: u16 = kani::any();
+    let fee_raw: u16 = kani::any();
+
+    kani::assume(abs_q_raw >= 3);
+    kani::assume(equity_raw >= 2 && equity_raw < abs_q_raw);
+    kani::assume(fee_raw > 0 && fee_raw < equity_raw);
+    let abs_q = abs_q_raw as u128;
+    let equity = equity_raw as u128;
+    let fee = fee_raw as u128;
+    let selected_new_maintenance = equity - fee;
+    let one_less_new_maintenance = selected_new_maintenance + 1;
+
+    let selected_deficit = kani_liquidation_projected_health_deficit_from_parts(
+        equity as i128,
+        abs_q,
+        abs_q,
+        selected_new_maintenance,
+        fee,
+    )
+    .unwrap();
+    let one_less_deficit = kani_liquidation_projected_health_deficit_from_parts(
+        equity as i128,
+        abs_q,
+        abs_q,
+        one_less_new_maintenance,
+        fee,
+    )
+    .unwrap();
+
+    kani::cover!(
+        abs_q > equity + 8 && fee > 1,
+        "minimum liquidation projection covers nontrivial fee debit"
+    );
+    assert_eq!(selected_deficit, 0);
+    assert_eq!(one_less_deficit, 1);
 }
 
 #[kani::proof]

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -9,18 +9,18 @@ use percolator::v16::{
     kani_backing_utilization_fee_quote_atoms_for_lien,
     kani_backing_utilization_rate_e9_for_source_state,
     kani_expected_source_credit_rate_num_for_state, kani_health_cert_after_capital_debit,
-    kani_health_requirements_from_base_and_target_lag,
+    kani_health_requirements_from_base_and_target_lag, kani_kernel_reduce_position_delta,
     kani_liquidation_close_would_leave_uncovered_loss_with_open_risk,
-    kani_liquidation_fee_from_raw_fee, kani_loss_stale_trade_scope_allowed,
-    kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
-    kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
-    kani_target_effective_lag_adverse_delta, kani_trade_preflight_risk_gate,
-    kani_validate_positive_pnl_source_attribution, AssetLifecycleV16, AssetStateV16,
-    AssetStateV16Account, BackingBucketStatusV16, BackingBucketV16, BackingBucketV16Account,
-    BatchTradeOutcomeV16, CloseProgressLedgerV16, CloseProgressLedgerV16Account,
-    EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16, HealthCertV16Account,
-    InsuranceCreditReservationV16, InsuranceCreditReservationV16Account, Market,
-    MarketGroupV16HeaderAccount, MarketGroupV16View, MarketGroupV16ViewMut,
+    kani_liquidation_engine_close_request_q, kani_liquidation_fee_from_raw_fee,
+    kani_loss_stale_trade_scope_allowed, kani_pending_domain_loss_barrier_blocks_position_change,
+    kani_position_delta_increases_risk, kani_prepare_asset_recovery_transition,
+    kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
+    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
+    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
+    BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
+    CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
+    HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
+    Market, MarketGroupV16HeaderAccount, MarketGroupV16View, MarketGroupV16ViewMut,
     PermissionlessCrankActionV16, PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
@@ -3844,6 +3844,61 @@ fn proof_v16_pending_domain_loss_barrier_allows_only_same_side_reductions() {
     }
     if touches_barrier && current != 0 && next != 0 && current.signum() != next.signum() {
         assert!(blocked);
+    }
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_liquidation_engine_selected_size_closes_full_leg() {
+    let basis_raw: i64 = kani::any();
+    let raw_fee_raw: u16 = kani::any();
+    let min_liquidation_abs_raw: u16 = kani::any();
+    let cap_extra: u16 = kani::any();
+
+    kani::assume(basis_raw != 0);
+    let basis = basis_raw as i128;
+    let side = if basis > 0 {
+        SideV16::Long
+    } else {
+        SideV16::Short
+    };
+    let leg_abs_q = basis.unsigned_abs();
+    let close_request_q = kani_liquidation_engine_close_request_q(basis).unwrap();
+    let (closed_q, delta_q) =
+        kani_kernel_reduce_position_delta(basis, side, close_request_q).unwrap();
+
+    kani::cover!(
+        basis > 0 && leg_abs_q > 1024,
+        "engine-selected liquidation proof covers nontrivial long position"
+    );
+    kani::cover!(
+        basis < 0 && leg_abs_q > 1024,
+        "engine-selected liquidation proof covers nontrivial short position"
+    );
+    assert_eq!(close_request_q, leg_abs_q);
+    assert_eq!(closed_q, leg_abs_q);
+    assert_eq!(basis.checked_add(delta_q).unwrap(), 0);
+
+    let raw_fee = raw_fee_raw as u128;
+    let min_liquidation_abs = min_liquidation_abs_raw as u128;
+    let liquidation_fee_cap = min_liquidation_abs + cap_extra as u128;
+    let closes_full_position = closed_q == leg_abs_q;
+    let fee = kani_liquidation_fee_from_raw_fee(
+        raw_fee,
+        min_liquidation_abs,
+        liquidation_fee_cap,
+        closes_full_position,
+    )
+    .unwrap();
+
+    kani::cover!(
+        min_liquidation_abs > 0 && raw_fee < min_liquidation_abs && cap_extra > 0,
+        "engine-selected liquidation proof covers dust full close with absolute min fee"
+    );
+    assert!(closes_full_position);
+    if min_liquidation_abs > 0 && raw_fee < min_liquidation_abs {
+        assert_eq!(fee, min_liquidation_abs);
     }
 }
 

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -11,16 +11,18 @@ use percolator::v16::{
     kani_expected_source_credit_rate_num_for_state, kani_health_cert_after_capital_debit,
     kani_health_requirements_from_base_and_target_lag,
     kani_liquidation_close_would_leave_uncovered_loss_with_open_risk,
-    kani_liquidation_fee_from_raw_fee, kani_liquidation_projected_health_deficit_from_parts,
-    kani_loss_stale_trade_scope_allowed, kani_pending_domain_loss_barrier_blocks_position_change,
-    kani_position_delta_increases_risk, kani_prepare_asset_recovery_transition,
-    kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
-    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
-    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
-    BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
-    CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
-    HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
-    Market, MarketGroupV16HeaderAccount, MarketGroupV16View, MarketGroupV16ViewMut,
+    kani_liquidation_engine_close_request_q, kani_liquidation_fee_from_raw_fee,
+    kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
+    kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
+    kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
+    kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
+    kani_target_effective_lag_adverse_delta, kani_trade_preflight_risk_gate,
+    kani_validate_positive_pnl_source_attribution, AssetLifecycleV16, AssetStateV16,
+    AssetStateV16Account, BackingBucketStatusV16, BackingBucketV16, BackingBucketV16Account,
+    BatchTradeOutcomeV16, CloseProgressLedgerV16, CloseProgressLedgerV16Account,
+    EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16, HealthCertV16Account,
+    InsuranceCreditReservationV16, InsuranceCreditReservationV16Account, Market,
+    MarketGroupV16HeaderAccount, MarketGroupV16View, MarketGroupV16ViewMut,
     PermissionlessCrankActionV16, PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
@@ -3926,6 +3928,108 @@ fn proof_v16_liquidation_projection_includes_fee_equity_debit() {
     );
     assert_eq!(selected_deficit, 0);
     assert_eq!(one_less_deficit, 1);
+}
+
+#[kani::proof]
+#[kani::unwind(10)]
+#[kani::solver(cadical)]
+fn proof_v16_liquidation_selector_is_healthy_locally_minimal_or_full_close() {
+    let equity_raw: u8 = kani::any();
+    let position_q = 1_000u128;
+    let maintenance = (position_q / 10).max(80);
+    let equity = equity_raw as u128;
+    kani::assume(equity > 0 && equity < maintenance);
+
+    let mut config = V16Config::public_user_fund(1, 0, 1);
+    config.maintenance_margin_bps = 1_000;
+    config.initial_margin_bps = 1_000;
+    config.min_nonzero_mm_req = 80;
+    config.min_nonzero_im_req = 81;
+    config.liquidation_fee_bps = 800;
+    config.liquidation_fee_cap = 1_000;
+    config.max_price_move_bps_per_slot = 1;
+    let cert = HealthCertV16 {
+        certified_equity: equity as i128,
+        certified_maintenance_req: maintenance,
+        certified_liq_deficit: maintenance - equity,
+        valid: true,
+        ..HealthCertV16::default()
+    };
+    let leg = PortfolioLegV16 {
+        active: true,
+        side: SideV16::Long,
+        basis_pos_q: position_q as i128,
+        ..PortfolioLegV16::EMPTY
+    };
+    let price = POS_SCALE as u64;
+
+    let selected = kani_liquidation_engine_close_request_q(
+        config,
+        cert,
+        equity,
+        0,
+        leg,
+        price,
+        price,
+        config.liquidation_fee_bps,
+    )
+    .unwrap();
+    let partial_hi = kani_liquidation_partial_search_hi(config, position_q, price).unwrap();
+
+    kani::cover!(
+        selected < position_q && selected > 8,
+        "selector covers a nontrivial health-restoring partial liquidation"
+    );
+    kani::cover!(
+        selected == position_q && partial_hi > 0,
+        "selector covers full close when no pre-floor partial restores health"
+    );
+    assert!((1..=position_q).contains(&selected));
+    if selected < position_q {
+        assert!(selected <= partial_hi);
+        assert!(kani_liquidation_projected_healthy_after_close(
+            config,
+            cert,
+            equity,
+            0,
+            leg,
+            price,
+            price,
+            config.liquidation_fee_bps,
+            selected,
+        )
+        .unwrap());
+        if selected > 1 {
+            assert!(!kani_liquidation_projected_healthy_after_close(
+                config,
+                cert,
+                equity,
+                0,
+                leg,
+                price,
+                price,
+                config.liquidation_fee_bps,
+                selected - 1,
+            )
+            .unwrap());
+        }
+    } else {
+        assert!(
+            partial_hi == 0
+                || !kani_liquidation_projected_healthy_after_close(
+                    config,
+                    cert,
+                    equity,
+                    0,
+                    leg,
+                    price,
+                    price,
+                    config.liquidation_fee_bps,
+                    partial_hi,
+                )
+                .unwrap()
+        );
+    }
 }
 
 #[kani::proof]

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -11,15 +11,16 @@ use percolator::v16::{
     kani_expected_source_credit_rate_num_for_state, kani_health_cert_after_capital_debit,
     kani_health_requirements_from_base_and_target_lag,
     kani_liquidation_close_would_leave_uncovered_loss_with_open_risk,
-    kani_loss_stale_trade_scope_allowed, kani_pending_domain_loss_barrier_blocks_position_change,
-    kani_position_delta_increases_risk, kani_prepare_asset_recovery_transition,
-    kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
-    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
-    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
-    BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
-    CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
-    HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
-    Market, MarketGroupV16HeaderAccount, MarketGroupV16View, MarketGroupV16ViewMut,
+    kani_liquidation_fee_from_raw_fee, kani_loss_stale_trade_scope_allowed,
+    kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
+    kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
+    kani_target_effective_lag_adverse_delta, kani_trade_preflight_risk_gate,
+    kani_validate_positive_pnl_source_attribution, AssetLifecycleV16, AssetStateV16,
+    AssetStateV16Account, BackingBucketStatusV16, BackingBucketV16, BackingBucketV16Account,
+    BatchTradeOutcomeV16, CloseProgressLedgerV16, CloseProgressLedgerV16Account,
+    EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16, HealthCertV16Account,
+    InsuranceCreditReservationV16, InsuranceCreditReservationV16Account, Market,
+    MarketGroupV16HeaderAccount, MarketGroupV16View, MarketGroupV16ViewMut,
     PermissionlessCrankActionV16, PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
@@ -3921,6 +3922,79 @@ fn proof_v16_liquidation_cannot_leave_uncovered_loss_with_other_open_risk() {
         uncovered && close_q < leg_abs_q
     );
     assert!(!covered_loss_with_other_risk);
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_liquidation_fee_rejects_subminimum_partial_chunks() {
+    let raw_fee_raw: u16 = kani::any();
+    let min_liquidation_abs_raw: u16 = kani::any();
+    let cap_extra: u16 = kani::any();
+
+    kani::assume(min_liquidation_abs_raw > 0);
+    let raw_fee = raw_fee_raw as u128;
+    let min_liquidation_abs = min_liquidation_abs_raw as u128;
+    let liquidation_fee_cap = min_liquidation_abs + cap_extra as u128;
+    kani::assume(raw_fee < min_liquidation_abs);
+
+    let result =
+        kani_liquidation_fee_from_raw_fee(raw_fee, min_liquidation_abs, liquidation_fee_cap, false);
+
+    kani::cover!(
+        raw_fee > 0 && cap_extra > 0,
+        "subminimum partial liquidation proof covers positive proportional fee and nontrivial cap"
+    );
+    assert_eq!(result, Err(V16Error::NonProgress));
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_liquidation_fee_allows_subminimum_full_close() {
+    let raw_fee_raw: u16 = kani::any();
+    let min_liquidation_abs_raw: u16 = kani::any();
+    let cap_extra: u16 = kani::any();
+
+    kani::assume(min_liquidation_abs_raw > 0);
+    let raw_fee = raw_fee_raw as u128;
+    let min_liquidation_abs = min_liquidation_abs_raw as u128;
+    let liquidation_fee_cap = min_liquidation_abs + cap_extra as u128;
+    kani::assume(raw_fee < min_liquidation_abs);
+
+    let fee =
+        kani_liquidation_fee_from_raw_fee(raw_fee, min_liquidation_abs, liquidation_fee_cap, true)
+            .unwrap();
+
+    kani::cover!(
+        raw_fee > 0 && cap_extra > 0,
+        "subminimum full liquidation proof covers dust close with nontrivial fee cap"
+    );
+    assert_eq!(fee, min_liquidation_abs);
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_liquidation_partial_fee_acceptance_implies_no_min_floor_extraction() {
+    let raw_fee_raw: u16 = kani::any();
+    let min_liquidation_abs_raw: u16 = kani::any();
+    let cap_extra: u16 = kani::any();
+
+    let raw_fee = raw_fee_raw as u128;
+    let min_liquidation_abs = min_liquidation_abs_raw as u128;
+    let liquidation_fee_cap = min_liquidation_abs + cap_extra as u128;
+    let result =
+        kani_liquidation_fee_from_raw_fee(raw_fee, min_liquidation_abs, liquidation_fee_cap, false);
+
+    kani::cover!(
+        min_liquidation_abs > 0 && raw_fee >= min_liquidation_abs && cap_extra > 0,
+        "accepted partial liquidation proof covers nonzero minimum fee with proportional fee above floor"
+    );
+    if let Ok(fee) = result {
+        assert!(min_liquidation_abs == 0 || raw_fee >= min_liquidation_abs);
+        assert_eq!(fee, raw_fee.min(liquidation_fee_cap));
+    }
 }
 
 #[kani::proof]

--- a/tests/v16_fuzzing.rs
+++ b/tests/v16_fuzzing.rs
@@ -239,10 +239,7 @@ fn apply_fuzz_action(
                 market
                     .liquidate_account_not_atomic(
                         &mut account,
-                        LiquidationRequestV16 {
-                            asset_index: 0,
-                            fee_bps: 0,
-                        },
+                        LiquidationRequestV16 { asset_index: 0 },
                     )
                     .map(|_| ())
             } else {
@@ -250,10 +247,7 @@ fn apply_fuzz_action(
                 market
                     .liquidate_account_not_atomic(
                         &mut account,
-                        LiquidationRequestV16 {
-                            asset_index: 0,
-                            fee_bps: 0,
-                        },
+                        LiquidationRequestV16 { asset_index: 0 },
                     )
                     .map(|_| ())
             }

--- a/tests/v16_fuzzing.rs
+++ b/tests/v16_fuzzing.rs
@@ -234,7 +234,6 @@ fn apply_fuzz_action(
         }
         8 => {
             let mut market = MarketGroupV16ViewMut::new(header, markets);
-            let close_q = 1 + (amount % 4);
             if target_a {
                 let mut account = PortfolioV16ViewMut::new(account_a);
                 market
@@ -242,7 +241,6 @@ fn apply_fuzz_action(
                         &mut account,
                         LiquidationRequestV16 {
                             asset_index: 0,
-                            close_q,
                             fee_bps: 0,
                         },
                     )
@@ -254,7 +252,6 @@ fn apply_fuzz_action(
                         &mut account,
                         LiquidationRequestV16 {
                             asset_index: 0,
-                            close_q,
                             fee_bps: 0,
                         },
                     )

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1782,13 +1782,7 @@ fn v16_public_liquidation_on_unfunded_domain_cannot_drain_shared_insurance() {
     let vault_before = market.header.vault.get();
 
     let out = market
-        .liquidate_account_not_atomic(
-            &mut account,
-            LiquidationRequestV16 {
-                asset_index: 0,
-                fee_bps: 0,
-            },
-        )
+        .liquidate_account_not_atomic(&mut account, LiquidationRequestV16 { asset_index: 0 })
         .expect("liquidation should progress by booking residual, not draining other domains");
 
     assert_eq!(out.insurance_used, 0);
@@ -1856,13 +1850,7 @@ fn v16_liquidation_engine_selects_full_close_and_allows_dust_min_fee() {
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
     let mut full_account = PortfolioV16ViewMut::new(&mut full_header);
     let full = market
-        .liquidate_account_not_atomic(
-            &mut full_account,
-            LiquidationRequestV16 {
-                asset_index: 0,
-                fee_bps: LIQ_FEE_BPS,
-            },
-        )
+        .liquidate_account_not_atomic(&mut full_account, LiquidationRequestV16 { asset_index: 0 })
         .unwrap();
 
     assert_eq!(full.closed_q, POSITION_Q);
@@ -1880,19 +1868,28 @@ fn v16_liquidation_engine_selects_full_close_and_allows_dust_min_fee() {
 }
 
 #[test]
-fn v16_liquidation_engine_selects_minimum_health_restoring_partial_close() {
+fn v16_liquidation_engine_selects_healthy_partial_before_margin_floor() {
     const PRICE: u64 = POS_SCALE as u64;
-    const POSITION_Q: u128 = 100;
-    const ACCOUNT_CAPITAL: u128 = 50;
+    const POSITION_Q: u128 = 10_000;
+    const ACCOUNT_CAPITAL: u128 = 980;
+    const EXPECTED_CLOSE_Q: u128 = 981;
+    const EXPECTED_FEE: u128 = 79;
 
     let (mut header, mut markets) = market_fixture(1, PRICE);
-    header.config.maintenance_margin_bps = V16PodU64::new(10_000);
-    header.config.initial_margin_bps = V16PodU64::new(10_000);
-    header.config.min_nonzero_mm_req = V16PodU128::new(1);
-    header.config.min_nonzero_im_req = V16PodU128::new(2);
-    header.config.liquidation_fee_bps = V16PodU64::new(0);
+    header.config.maintenance_margin_bps = V16PodU64::new(1_000);
+    header.config.initial_margin_bps = V16PodU64::new(1_000);
+    header.config.min_nonzero_mm_req = V16PodU128::new(800);
+    header.config.min_nonzero_im_req = V16PodU128::new(801);
+    header.config.liquidation_fee_bps = V16PodU64::new(800);
     header.config.min_liquidation_abs = V16PodU128::new(0);
-    header.config.liquidation_fee_cap = V16PodU128::new(0);
+    header.config.liquidation_fee_cap = V16PodU128::new(1_000);
+    header.config.max_price_move_bps_per_slot = V16PodU64::new(1);
+    header
+        .config
+        .try_to_runtime_shape()
+        .unwrap()
+        .validate_public_user_fund()
+        .unwrap();
     header.vault = V16PodU128::new(ACCOUNT_CAPITAL * 2);
     header.c_tot = V16PodU128::new(ACCOUNT_CAPITAL * 2);
 
@@ -1932,25 +1929,22 @@ fn v16_liquidation_engine_selects_minimum_health_restoring_partial_close() {
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
     let mut account = PortfolioV16ViewMut::new(&mut account_header);
     let out = market
-        .liquidate_account_not_atomic(
-            &mut account,
-            LiquidationRequestV16 {
-                asset_index: 0,
-                fee_bps: 0,
-            },
-        )
+        .liquidate_account_not_atomic(&mut account, LiquidationRequestV16 { asset_index: 0 })
         .unwrap();
 
-    assert_eq!(out.closed_q, POSITION_Q - ACCOUNT_CAPITAL);
-    assert_eq!(out.fee_charged, 0);
-    assert_eq!(account.header.capital.get(), ACCOUNT_CAPITAL);
+    assert_eq!(out.closed_q, EXPECTED_CLOSE_Q);
+    assert_eq!(out.fee_charged, EXPECTED_FEE);
+    assert_eq!(account.header.capital.get(), ACCOUNT_CAPITAL - EXPECTED_FEE);
     assert_eq!(account.header.active_bitmap[0].get(), 1);
     let leg = account.header.legs[0].try_to_runtime().unwrap();
-    assert_eq!(leg.basis_pos_q, ACCOUNT_CAPITAL as i128);
+    assert_eq!(
+        leg.basis_pos_q,
+        i128::try_from(POSITION_Q - EXPECTED_CLOSE_Q).unwrap()
+    );
     let cert = account.header.health_cert.try_to_runtime().unwrap();
     assert_eq!(cert.certified_liq_deficit, 0);
-    assert_eq!(cert.certified_equity, ACCOUNT_CAPITAL as i128);
-    assert_eq!(cert.certified_maintenance_req, ACCOUNT_CAPITAL);
+    assert_eq!(cert.certified_equity, 901);
+    assert_eq!(cert.certified_maintenance_req, 901);
     market.validate_shape().unwrap();
     account.validate_with_market(&market.as_view()).unwrap();
 }
@@ -2018,10 +2012,7 @@ fn v16_permissionless_liquidation_progresses_when_unrelated_asset_is_loss_stale(
                 effective_price: 100,
                 funding_rate_e9: 0,
                 action: percolator::PermissionlessCrankActionV16::Liquidate(
-                    LiquidationRequestV16 {
-                        asset_index: 0,
-                        fee_bps: 0,
-                    },
+                    LiquidationRequestV16 { asset_index: 0 },
                 ),
             },
         )

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1786,7 +1786,6 @@ fn v16_public_liquidation_on_unfunded_domain_cannot_drain_shared_insurance() {
             &mut account,
             LiquidationRequestV16 {
                 asset_index: 0,
-                close_q: POS_SCALE,
                 fee_bps: 0,
             },
         )
@@ -1805,7 +1804,7 @@ fn v16_public_liquidation_on_unfunded_domain_cannot_drain_shared_insurance() {
 }
 
 #[test]
-fn v16_liquidation_rejects_subminimum_partial_fee_chunks_but_allows_full_close() {
+fn v16_liquidation_engine_selects_full_close_and_allows_dust_min_fee() {
     const PRICE: u64 = 1_000_000;
     const POSITION_Q: u128 = 100;
     const ACCOUNT_CAPITAL: u128 = 50;
@@ -1853,32 +1852,14 @@ fn v16_liquidation_rejects_subminimum_partial_fee_chunks_but_allows_full_close()
         account
     };
 
-    let mut partial_header = make_liquidatable(12);
     let mut full_header = make_liquidatable(13);
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
-    let mut partial_account = PortfolioV16ViewMut::new(&mut partial_header);
-
-    let partial = market.liquidate_account_not_atomic(
-        &mut partial_account,
-        LiquidationRequestV16 {
-            asset_index: 0,
-            close_q: 1,
-            fee_bps: LIQ_FEE_BPS,
-        },
-    );
-
-    assert_eq!(partial, Err(V16Error::NonProgress));
-    assert_eq!(market.header.insurance.get(), 0);
-    assert_eq!(partial_account.header.capital.get(), ACCOUNT_CAPITAL);
-    assert_eq!(partial_account.header.active_bitmap[0].get(), 1);
-
     let mut full_account = PortfolioV16ViewMut::new(&mut full_header);
     let full = market
         .liquidate_account_not_atomic(
             &mut full_account,
             LiquidationRequestV16 {
                 asset_index: 0,
-                close_q: POSITION_Q,
                 fee_bps: LIQ_FEE_BPS,
             },
         )
@@ -1893,9 +1874,6 @@ fn v16_liquidation_rejects_subminimum_partial_fee_chunks_but_allows_full_close()
     assert_eq!(full_account.header.active_bitmap[0].get(), 0);
     assert_eq!(market.header.insurance.get(), MIN_LIQ_FEE);
     market.validate_shape().unwrap();
-    partial_account
-        .validate_with_market(&market.as_view())
-        .unwrap();
     full_account
         .validate_with_market(&market.as_view())
         .unwrap();
@@ -1966,7 +1944,6 @@ fn v16_permissionless_liquidation_progresses_when_unrelated_asset_is_loss_stale(
                 action: percolator::PermissionlessCrankActionV16::Liquidate(
                     LiquidationRequestV16 {
                         asset_index: 0,
-                        close_q: POS_SCALE,
                         fee_bps: 0,
                     },
                 ),
@@ -2611,7 +2588,6 @@ fn v16_auto_crank_classifies_fresh_account_stale_then_refreshes_to_clean() {
     let work = AutoCrankWorkV16 {
         now_slot: 5,
         observations: &obs,
-        liquidation_max_close_q: 0,
         resolved_close_fee_rate_per_slot: 0,
     };
 
@@ -2712,7 +2688,6 @@ fn v16_auto_crank_drives_stale_underwater_account_to_derisked_fixed_point() {
     let work = AutoCrankWorkV16 {
         now_slot: 10,
         observations: &obs,
-        liquidation_max_close_q: POS_SCALE,
         resolved_close_fee_rate_per_slot: 0,
     };
 
@@ -2823,7 +2798,6 @@ fn v16_auto_crank_liquidates_current_account_without_observation() {
     let work = AutoCrankWorkV16 {
         now_slot: 10,
         observations: &[],
-        liquidation_max_close_q: POS_SCALE,
         resolved_close_fee_rate_per_slot: 0,
     };
     let result = market
@@ -2898,7 +2872,6 @@ fn v16_auto_crank_declares_recovery_for_expired_live_close() {
     let work = AutoCrankWorkV16 {
         now_slot: 10,
         observations: &[],
-        liquidation_max_close_q: 0,
         resolved_close_fee_rate_per_slot: 0,
     };
     let vault_before = market.header.vault;
@@ -3012,7 +2985,6 @@ fn v16_auto_crank_settles_b_stale_leg() {
     let work = AutoCrankWorkV16 {
         now_slot: 10,
         observations: &[],
-        liquidation_max_close_q: 0,
         resolved_close_fee_rate_per_slot: 0,
     };
     let r = market
@@ -3057,7 +3029,6 @@ fn v16_auto_crank_missing_observation_is_clean_nonprogress_no_mutation() {
     let work = AutoCrankWorkV16 {
         now_slot: 5,
         observations: &[],
-        liquidation_max_close_q: 0,
         resolved_close_fee_rate_per_slot: 0,
     };
     let r = market.permissionless_auto_crank_not_atomic(&mut account, work);
@@ -3089,7 +3060,6 @@ fn assert_observation_independent(
     ),
     obs_asset_index: usize,
     now_slot: u64,
-    liquidation_max_close_q: u128,
     expected_plan: AutoCrankPlanV16,
     expected_requires_obs: bool,
 ) {
@@ -3109,7 +3079,6 @@ fn assert_observation_independent(
             AutoCrankWorkV16 {
                 now_slot,
                 observations,
-                liquidation_max_close_q,
                 resolved_close_fee_rate_per_slot: 0,
             },
         )
@@ -3179,7 +3148,6 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
         },
         0,
         5,
-        0,
         AutoCrankPlanV16::RefreshAccount { asset_index: None },
         true,
     );
@@ -3207,7 +3175,6 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
         },
         0,
         5,
-        0,
         AutoCrankPlanV16::RefreshAccount {
             asset_index: Some(0),
         },
@@ -3253,7 +3220,6 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
         },
         0,
         10,
-        0,
         AutoCrankPlanV16::SettleBChunk { asset_index: 0 },
         false,
     );
@@ -3309,7 +3275,6 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
         },
         0,
         10,
-        POS_SCALE,
         AutoCrankPlanV16::Liquidate { asset_index: 0 },
         false,
     );
@@ -3319,7 +3284,7 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
         "expired_close",
         || {
             use percolator::{CloseProgressLedgerV16, CloseProgressLedgerV16Account};
-            let (mut header, mut markets) = market_fixture(1, 100);
+            let (mut header, markets) = market_fixture(1, 100);
             let mut account_header = account_fixture(1, 203);
             header.current_slot = V16PodU64::new(10);
             let market_id = markets[0].engine.asset.try_to_runtime().unwrap().market_id;
@@ -3348,7 +3313,6 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
         },
         0,
         10,
-        0,
         AutoCrankPlanV16::DeclareRecovery {
             reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
         },
@@ -3373,7 +3337,6 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
         },
         0,
         10,
-        0,
         AutoCrankPlanV16::CloseResolved,
         false,
     );

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1879,6 +1879,82 @@ fn v16_liquidation_engine_selects_full_close_and_allows_dust_min_fee() {
         .unwrap();
 }
 
+#[test]
+fn v16_liquidation_engine_selects_minimum_health_restoring_partial_close() {
+    const PRICE: u64 = POS_SCALE as u64;
+    const POSITION_Q: u128 = 100;
+    const ACCOUNT_CAPITAL: u128 = 50;
+
+    let (mut header, mut markets) = market_fixture(1, PRICE);
+    header.config.maintenance_margin_bps = V16PodU64::new(10_000);
+    header.config.initial_margin_bps = V16PodU64::new(10_000);
+    header.config.min_nonzero_mm_req = V16PodU128::new(1);
+    header.config.min_nonzero_im_req = V16PodU128::new(2);
+    header.config.liquidation_fee_bps = V16PodU64::new(0);
+    header.config.min_liquidation_abs = V16PodU128::new(0);
+    header.config.liquidation_fee_cap = V16PodU128::new(0);
+    header.vault = V16PodU128::new(ACCOUNT_CAPITAL * 2);
+    header.c_tot = V16PodU128::new(ACCOUNT_CAPITAL * 2);
+
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.effective_price = PRICE;
+    asset.raw_oracle_target_price = PRICE;
+    asset.oi_eff_long_q = POSITION_Q * 2;
+    asset.oi_eff_short_q = POSITION_Q * 2;
+    asset.loss_weight_sum_long = POSITION_Q * 2;
+    asset.loss_weight_sum_short = POSITION_Q * 2;
+    asset.stored_pos_count_long = 2;
+    asset.stored_pos_count_short = 2;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(4);
+
+    let mut account_header = account_fixture(1, 14);
+    account_header.capital = V16PodU128::new(ACCOUNT_CAPITAL);
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Long,
+        basis_pos_q: i128::try_from(POSITION_Q).unwrap(),
+        a_basis: ADL_ONE,
+        k_snap: asset.k_long,
+        f_snap: asset.f_long_num,
+        epoch_snap: asset.epoch_long,
+        loss_weight: POSITION_Q,
+        b_snap: asset.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(1);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let out = market
+        .liquidate_account_not_atomic(
+            &mut account,
+            LiquidationRequestV16 {
+                asset_index: 0,
+                fee_bps: 0,
+            },
+        )
+        .unwrap();
+
+    assert_eq!(out.closed_q, POSITION_Q - ACCOUNT_CAPITAL);
+    assert_eq!(out.fee_charged, 0);
+    assert_eq!(account.header.capital.get(), ACCOUNT_CAPITAL);
+    assert_eq!(account.header.active_bitmap[0].get(), 1);
+    let leg = account.header.legs[0].try_to_runtime().unwrap();
+    assert_eq!(leg.basis_pos_q, ACCOUNT_CAPITAL as i128);
+    let cert = account.header.health_cert.try_to_runtime().unwrap();
+    assert_eq!(cert.certified_liq_deficit, 0);
+    assert_eq!(cert.certified_equity, ACCOUNT_CAPITAL as i128);
+    assert_eq!(cert.certified_maintenance_req, ACCOUNT_CAPITAL);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
 #[cfg(feature = "fuzz")] // exercises the internal direct-crank primitive via the shim
 #[test]
 fn v16_permissionless_liquidation_progresses_when_unrelated_asset_is_loss_stale() {

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1804,6 +1804,103 @@ fn v16_public_liquidation_on_unfunded_domain_cannot_drain_shared_insurance() {
     account.validate_with_market(&market.as_view()).unwrap();
 }
 
+#[test]
+fn v16_liquidation_rejects_subminimum_partial_fee_chunks_but_allows_full_close() {
+    const PRICE: u64 = 1_000_000;
+    const POSITION_Q: u128 = 100;
+    const ACCOUNT_CAPITAL: u128 = 50;
+    const MIN_LIQ_FEE: u128 = 10;
+    const LIQ_FEE_BPS: u64 = 100;
+
+    let (mut header, mut markets) = market_fixture(1, PRICE);
+    header.config.liquidation_fee_bps = V16PodU64::new(LIQ_FEE_BPS);
+    header.config.min_liquidation_abs = V16PodU128::new(MIN_LIQ_FEE);
+    header.config.liquidation_fee_cap = V16PodU128::new(1_000);
+    header.vault = V16PodU128::new(ACCOUNT_CAPITAL * 2);
+    header.c_tot = V16PodU128::new(ACCOUNT_CAPITAL * 2);
+
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.oi_eff_long_q = POSITION_Q * 2;
+    asset.oi_eff_short_q = POSITION_Q * 2;
+    asset.loss_weight_sum_long = POSITION_Q * 2;
+    asset.loss_weight_sum_short = POSITION_Q * 2;
+    asset.stored_pos_count_long = 2;
+    asset.stored_pos_count_short = 2;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(4);
+
+    let make_liquidatable = |seed: u8| {
+        let mut account = account_fixture(1, seed);
+        account.capital = V16PodU128::new(ACCOUNT_CAPITAL);
+        account.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+            active: true,
+            asset_index: 0,
+            market_id: asset.market_id,
+            side: SideV16::Long,
+            basis_pos_q: i128::try_from(POSITION_Q).unwrap(),
+            a_basis: ADL_ONE,
+            k_snap: asset.k_long,
+            f_snap: asset.f_long_num,
+            epoch_snap: asset.epoch_long,
+            loss_weight: POSITION_Q,
+            b_snap: asset.b_long_num,
+            b_rem: 0,
+            b_epoch_snap: asset.epoch_long,
+            b_stale: false,
+            stale: false,
+        });
+        account.active_bitmap[0] = V16PodU64::new(1);
+        account
+    };
+
+    let mut partial_header = make_liquidatable(12);
+    let mut full_header = make_liquidatable(13);
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut partial_account = PortfolioV16ViewMut::new(&mut partial_header);
+
+    let partial = market.liquidate_account_not_atomic(
+        &mut partial_account,
+        LiquidationRequestV16 {
+            asset_index: 0,
+            close_q: 1,
+            fee_bps: LIQ_FEE_BPS,
+        },
+    );
+
+    assert_eq!(partial, Err(V16Error::NonProgress));
+    assert_eq!(market.header.insurance.get(), 0);
+    assert_eq!(partial_account.header.capital.get(), ACCOUNT_CAPITAL);
+    assert_eq!(partial_account.header.active_bitmap[0].get(), 1);
+
+    let mut full_account = PortfolioV16ViewMut::new(&mut full_header);
+    let full = market
+        .liquidate_account_not_atomic(
+            &mut full_account,
+            LiquidationRequestV16 {
+                asset_index: 0,
+                close_q: POSITION_Q,
+                fee_bps: LIQ_FEE_BPS,
+            },
+        )
+        .unwrap();
+
+    assert_eq!(full.closed_q, POSITION_Q);
+    assert_eq!(full.fee_charged, MIN_LIQ_FEE);
+    assert_eq!(
+        full_account.header.capital.get(),
+        ACCOUNT_CAPITAL - MIN_LIQ_FEE
+    );
+    assert_eq!(full_account.header.active_bitmap[0].get(), 0);
+    assert_eq!(market.header.insurance.get(), MIN_LIQ_FEE);
+    market.validate_shape().unwrap();
+    partial_account
+        .validate_with_market(&market.as_view())
+        .unwrap();
+    full_account
+        .validate_with_market(&market.as_view())
+        .unwrap();
+}
+
 #[cfg(feature = "fuzz")] // exercises the internal direct-crank primitive via the shim
 #[test]
 fn v16_permissionless_liquidation_progresses_when_unrelated_asset_is_loss_stale() {


### PR DESCRIPTION
Fixes #90.

## Summary
- Remove keeper-controlled liquidation sizing and fee policy from the engine API. `LiquidationRequestV16` carries only `asset_index`, and auto-crank no longer accepts a maximum close quantity.
- Derive the fee from immutable engine config and select a health-restoring partial close inside the proportional-maintenance region.
- Full-close deterministically for bankruptcy, negative PnL, maintenance-floor dust, or when no admissible partial endpoint restores health.
- Keep the generic arithmetic model unchanged while using bounded u128 liquidation kernels for lower CU and tractable proofs.

## PDD
The original selector binary-searched a non-monotone health predicate across the maintenance-floor discontinuity. An activation-valid regression profile showed it selecting a 10,000-q full close although healthy partials existed. The fixed route closes 981 q, charges 79 atoms, and leaves certified equity and maintenance equal at 901.

The production selector theorem ranges over every under-maintenance equity in a representative activation-valid profile and proves:
- every selected partial is in range and projected healthy;
- its immediate predecessor is unhealthy;
- a full close is selected only when the pre-floor endpoint is unavailable or unhealthy;
- both nontrivial partial and full-fallback paths are reachable.

The existing symbolic proofs also cover fee-equity projection, rejection of sub-minimum partial chunks, full-position dust clearability, and absence of repeated minimum-fee extraction.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --tests --features fuzz`
- `cargo kani --tests --features fuzz --harness proof_v16_liquidation_selector_is_healthy_locally_minimal_or_full_close` (101s, 0/500 failures, 2/2 covers)
- Five focused liquidation fee/projection harnesses, each successful with its cover reached
