### PR TITLE
[codex] Allow terminal spent domain cleanup

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -8888,6 +8888,21 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.validate_shape()
     }
 
+    fn clear_terminal_spent_domain_budget_pair(
+        budget: V16PodU128,
+        spent: V16PodU128,
+    ) -> V16Result<(V16PodU128, V16PodU128)> {
+        let budget = budget.get();
+        let spent = spent.get();
+        if spent == 0 {
+            return Ok((V16PodU128::new(budget), V16PodU128::default()));
+        }
+        if budget != spent {
+            return Err(V16Error::LockActive);
+        }
+        Ok((V16PodU128::default(), V16PodU128::default()))
+    }
+
     fn set_domain_insurance_budget_core(
         &mut self,
         domain: usize,
@@ -12018,6 +12033,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     }
 
     fn require_empty_asset_lifecycle_state(&self, asset_index: usize) -> V16Result<()> {
+        self.require_empty_asset_lifecycle_state_with_spent_policy(asset_index, false)
+    }
+
+    fn require_empty_asset_lifecycle_state_with_spent_policy(
+        &self,
+        asset_index: usize,
+        allow_terminal_spent_budget: bool,
+    ) -> V16Result<()> {
         self.validate_configured_asset_index(asset_index)?;
         let asset = self.asset_state(asset_index)?;
         let long_domain = self.insurance_domain_index(asset_index, SideV16::Long)?;
@@ -12029,6 +12052,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let long_reservation = self.insurance_reservation_for_domain(long_domain)?;
         let short_reservation = self.insurance_reservation_for_domain(short_domain)?;
         let slot = self.markets[asset_index].engine_slot();
+        let long_budget = slot.insurance_domain_budget_long.get();
+        let long_spent = slot.insurance_domain_spent_long.get();
+        let short_budget = slot.insurance_domain_budget_short.get();
+        let short_spent = slot.insurance_domain_spent_short.get();
+        let spent_blocks_empty = if allow_terminal_spent_budget {
+            (long_spent != 0 && long_budget != long_spent)
+                || (short_spent != 0 && short_budget != short_spent)
+        } else {
+            long_spent != 0 || short_spent != 0
+        };
 
         if slot.pending_domain_loss_barrier_long.get() != 0
             || slot.pending_domain_loss_barrier_short.get() != 0
@@ -12064,8 +12097,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             || asset.social_loss_dust_short_num != 0
             || asset.explicit_unallocated_loss_long != 0
             || asset.explicit_unallocated_loss_short != 0
-            || slot.insurance_domain_spent_long.get() != 0
-            || slot.insurance_domain_spent_short.get() != 0
+            || spent_blocks_empty
             || !long_source.is_empty_amount_shape()
             || !short_source.is_empty_amount_shape()
             || !long_bucket.is_empty_amount_shape()
@@ -15389,6 +15421,40 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.header.last_asset_activation_slot = V16PodU64::new(now_slot);
         self.header.asset_set_epoch = V16PodU64::new(next_asset_set_epoch);
         self.header.risk_epoch = V16PodU64::new(next_risk_epoch);
+        self.validate_shape()
+    }
+
+    /// Clears spent-only insurance-domain ledgers on an otherwise empty terminal asset.
+    ///
+    /// This is value-neutral: it may only erase a domain whose remaining budget
+    /// is already zero (`budget == spent`). If `budget > spent`, callers must
+    /// withdraw the remaining domain budget before terminal cleanup.
+    pub fn clear_terminal_spent_domain_budgets_for_empty_asset_not_atomic(
+        &mut self,
+        asset_index: usize,
+    ) -> V16Result<()> {
+        self.validate_configured_asset_index(asset_index)?;
+        let asset = self.asset_state(asset_index)?;
+        if !matches!(
+            asset.lifecycle,
+            AssetLifecycleV16::Recovery | AssetLifecycleV16::Retired
+        ) {
+            return Err(V16Error::LockActive);
+        }
+        self.require_empty_asset_lifecycle_state_with_spent_policy(asset_index, true)?;
+        let slot = self.markets[asset_index].engine_slot_mut();
+        let (budget_long, spent_long) = Self::clear_terminal_spent_domain_budget_pair(
+            slot.insurance_domain_budget_long,
+            slot.insurance_domain_spent_long,
+        )?;
+        let (budget_short, spent_short) = Self::clear_terminal_spent_domain_budget_pair(
+            slot.insurance_domain_budget_short,
+            slot.insurance_domain_spent_short,
+        )?;
+        slot.insurance_domain_budget_long = budget_long;
+        slot.insurance_domain_spent_long = spent_long;
+        slot.insurance_domain_budget_short = budget_short;
+        slot.insurance_domain_spent_short = spent_short;
         self.validate_shape()
     }
 

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -538,6 +538,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         )
     }
 
+    pub fn kani_clear_terminal_spent_domain_budget_pair(
+        budget: u128,
+        spent: u128,
+    ) -> V16Result<(u128, u128)> {
+        let (budget, spent) = Self::clear_terminal_spent_domain_budget_pair(
+            V16PodU128::new(budget),
+            V16PodU128::new(spent),
+        )?;
+        Ok((budget.get(), spent.get()))
+    }
+
     pub fn kani_credit_account_from_insurance_delta(
         insurance: u128,
         budget_remaining: u128,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -2142,6 +2142,203 @@ fn proof_v16_terminal_spent_domain_cleanup_is_value_neutral_and_remaining_budget
 }
 
 #[kani::proof]
+#[kani::unwind(48)]
+#[kani::solver(cadical)]
+fn proof_v16_public_terminal_spent_cleanup_then_restart_preserves_value() {
+    let restart_retired: bool = kani::any();
+    let long_spent_raw: u8 = kani::any();
+    let short_spent_raw: u8 = kani::any();
+    let capital_raw: u8 = kani::any();
+    let insurance_raw: u8 = kani::any();
+    let surplus_raw: u8 = kani::any();
+    let price_raw: u16 = kani::any();
+    kani::assume(long_spent_raw != 0 || short_spent_raw != 0);
+    kani::assume((1..=10_000).contains(&price_raw));
+
+    let old_market_id = 1u64;
+    let next_market_id = 2u64;
+    let current_slot = 5u64;
+    let now_slot = 6u64;
+    let capital = u128::from(capital_raw);
+    let insurance = u128::from(insurance_raw);
+    let vault = capital + insurance + u128::from(surplus_raw);
+    let long_spent = u128::from(long_spent_raw);
+    let short_spent = u128::from(short_spent_raw);
+
+    let (market_group_id, _, _) = ids();
+    let cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_group_id, cfg, 1, 0).unwrap();
+    header.current_slot = V16PodU64::new(current_slot);
+    header.slot_last = V16PodU64::new(current_slot);
+    header.next_market_id = V16PodU64::new(next_market_id);
+    header.asset_activation_count = V16PodU64::new(1);
+    header.last_asset_activation_slot = V16PodU64::new(current_slot);
+    header.asset_set_epoch = V16PodU64::new(3);
+    header.risk_epoch = V16PodU64::new(4);
+    header.vault = V16PodU128::new(vault);
+    header.c_tot = V16PodU128::new(capital);
+    header.insurance = V16PodU128::new(insurance);
+
+    let mut markets = [Market::new(
+        7u64,
+        EngineAssetSlotV16Account::empty_for_market(old_market_id),
+    )];
+    let mut asset = AssetStateV16::default();
+    asset.market_id = old_market_id;
+    asset.lifecycle = if restart_retired {
+        AssetLifecycleV16::Retired
+    } else {
+        AssetLifecycleV16::Recovery
+    };
+    asset.raw_oracle_target_price = 100;
+    asset.effective_price = 100;
+    asset.fund_px_last = 100;
+    asset.slot_last = current_slot;
+    asset.retired_slot = if restart_retired { current_slot } else { 0 };
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    markets[0].engine.insurance_domain_budget_long = V16PodU128::new(long_spent);
+    markets[0].engine.insurance_domain_spent_long = V16PodU128::new(long_spent);
+    markets[0].engine.insurance_domain_budget_short = V16PodU128::new(short_spent);
+    markets[0].engine.insurance_domain_spent_short = V16PodU128::new(short_spent);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    assert_eq!(market.validate_shape(), Ok(()));
+    let residual_before = market.kani_residual();
+
+    market
+        .clear_terminal_spent_domain_budgets_for_empty_asset_not_atomic(0)
+        .unwrap();
+    assert_eq!(market.header.vault.get(), vault);
+    assert_eq!(market.header.c_tot.get(), capital);
+    assert_eq!(market.header.insurance.get(), insurance);
+    assert_eq!(market.kani_residual(), residual_before);
+    assert_eq!(
+        market.markets[0].engine.insurance_domain_budget_long.get(),
+        0
+    );
+    assert_eq!(
+        market.markets[0].engine.insurance_domain_spent_long.get(),
+        0
+    );
+    assert_eq!(
+        market.markets[0].engine.insurance_domain_budget_short.get(),
+        0
+    );
+    assert_eq!(
+        market.markets[0].engine.insurance_domain_spent_short.get(),
+        0
+    );
+
+    market
+        .restart_empty_asset_preserving_insurance_budget_not_atomic(
+            0,
+            u64::from(price_raw),
+            now_slot,
+        )
+        .unwrap();
+
+    kani::cover!(
+        long_spent != 0 && short_spent != 0 && capital != 0 && insurance != 0,
+        "cleanup and restart cover both spent domains with unrelated senior value"
+    );
+    kani::cover!(restart_retired, "cleanup and restart cover Retired assets");
+    kani::cover!(
+        !restart_retired,
+        "cleanup and restart cover Recovery assets"
+    );
+
+    let restarted = market.markets[0].engine;
+    let restarted_asset = restarted.asset.try_to_runtime().unwrap();
+    assert_eq!(market.markets[0].wrapper, 7);
+    assert_eq!(restarted_asset.lifecycle, AssetLifecycleV16::Active);
+    assert_eq!(restarted_asset.market_id, next_market_id);
+    assert_eq!(restarted_asset.effective_price, u64::from(price_raw));
+    assert_eq!(restarted.insurance_domain_budget_long.get(), 0);
+    assert_eq!(restarted.insurance_domain_budget_short.get(), 0);
+    assert_eq!(restarted.insurance_domain_spent_long.get(), 0);
+    assert_eq!(restarted.insurance_domain_spent_short.get(), 0);
+    assert_eq!(market.header.vault.get(), vault);
+    assert_eq!(market.header.c_tot.get(), capital);
+    assert_eq!(market.header.insurance.get(), insurance);
+    assert_eq!(market.kani_residual(), residual_before);
+    assert_eq!(market.header.next_market_id.get(), next_market_id + 1);
+    assert_eq!(market.header.asset_activation_count.get(), 2);
+    assert_eq!(market.header.asset_set_epoch.get(), 4);
+    assert_eq!(market.header.risk_epoch.get(), 5);
+    assert_eq!(market.validate_shape(), Ok(()));
+}
+
+#[kani::proof]
+#[kani::unwind(40)]
+#[kani::solver(cadical)]
+fn proof_v16_terminal_spent_cleanup_cannot_erase_provider_receivable() {
+    let receivable_raw: u8 = kani::any();
+    kani::assume(receivable_raw != 0);
+    let receivable = u128::from(receivable_raw) * BOUND_SCALE;
+    let old_market_id = 1u64;
+
+    let (market_group_id, _, _) = ids();
+    let cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_group_id, cfg, 1, 0).unwrap();
+    header.current_slot = V16PodU64::new(5);
+    header.slot_last = V16PodU64::new(5);
+    header.next_market_id = V16PodU64::new(2);
+    header.asset_activation_count = V16PodU64::new(1);
+    header.last_asset_activation_slot = V16PodU64::new(5);
+
+    let mut markets = [Market::new(
+        9u64,
+        EngineAssetSlotV16Account::empty_for_market(old_market_id),
+    )];
+    let mut asset = AssetStateV16::default();
+    asset.market_id = old_market_id;
+    asset.lifecycle = AssetLifecycleV16::Recovery;
+    asset.raw_oracle_target_price = 100;
+    asset.effective_price = 100;
+    asset.fund_px_last = 100;
+    asset.slot_last = 5;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    markets[0].engine.insurance_domain_budget_long = V16PodU128::new(1);
+    markets[0].engine.insurance_domain_spent_long = V16PodU128::new(1);
+
+    let source = SourceCreditStateV16 {
+        spent_backing_num: receivable,
+        provider_receivable_num: receivable,
+        ..SourceCreditStateV16::EMPTY
+    };
+    let bucket = BackingBucketV16 {
+        market_id: old_market_id,
+        consumed_liened_backing_num: receivable,
+        expiry_slot: 1,
+        status: BackingBucketStatusV16::Expired,
+        ..BackingBucketV16::EMPTY
+    };
+    markets[0].engine.source_credit_long = SourceCreditStateV16Account::from_runtime(&source);
+    markets[0].engine.backing_long = BackingBucketV16Account::from_runtime(&bucket);
+
+    let header_before = header;
+    let slot_before = markets[0].engine;
+    let wrapper_before = markets[0].wrapper;
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let result = market.clear_terminal_spent_domain_budgets_for_empty_asset_not_atomic(0);
+
+    kani::cover!(
+        receivable > BOUND_SCALE,
+        "terminal cleanup rejection covers a nontrivial provider receivable"
+    );
+    assert_eq!(result, Err(V16Error::LockActive));
+    assert!(kani_eq_market_group_v16_header_account(
+        market.header,
+        &header_before
+    ));
+    assert_eq!(market.markets[0].wrapper, wrapper_before);
+    assert!(kani_eq_engine_asset_slot_v16_account(
+        &market.markets[0].engine,
+        &slot_before
+    ));
+}
+
+#[kani::proof]
 #[kani::unwind(16)]
 #[kani::solver(cadical)]
 fn proof_v16_canonical_retired_asset_slot_preserves_identity_and_clears_local_ledgers() {

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -2098,6 +2098,50 @@ fn proof_v16_public_restart_rejects_spent_domain_before_mutation() {
 }
 
 #[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_terminal_spent_domain_cleanup_is_value_neutral_and_remaining_budget_gated() {
+    let budget_raw: u8 = kani::any();
+    let spent_raw: u8 = kani::any();
+    kani::assume(budget_raw > 0);
+    kani::assume(spent_raw <= budget_raw);
+    let budget = budget_raw as u128;
+    let spent = spent_raw as u128;
+    let remaining_before = budget - spent;
+    let result =
+        MarketGroupV16ViewMut::<u64>::kani_clear_terminal_spent_domain_budget_pair(budget, spent);
+    let expected_ok = spent == 0 || budget == spent;
+
+    kani::cover!(
+        spent != 0 && budget == spent,
+        "terminal cleanup covers nonzero spent-only domain"
+    );
+    kani::cover!(
+        spent != 0 && budget > spent,
+        "terminal cleanup rejects domain with remaining budget"
+    );
+    kani::cover!(
+        spent == 0 && budget > 1,
+        "terminal cleanup covers no-op domain with remaining budget"
+    );
+    assert_eq!(result.is_ok(), expected_ok);
+    if let Ok((next_budget, next_spent)) = result {
+        assert_eq!(next_spent, 0);
+        assert_eq!(next_budget - next_spent, remaining_before);
+        if spent == 0 {
+            assert_eq!(next_budget, budget);
+        } else {
+            assert_eq!(next_budget, 0);
+            assert_eq!(remaining_before, 0);
+        }
+    } else {
+        assert!(spent != 0 && budget > spent);
+        assert!(remaining_before > 0);
+        assert_eq!(result, Err(V16Error::LockActive));
+    }
+}
+
+#[kani::proof]
 #[kani::unwind(16)]
 #[kani::solver(cadical)]
 fn proof_v16_canonical_retired_asset_slot_preserves_identity_and_clears_local_ledgers() {

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1194,6 +1194,109 @@ fn v16_restart_empty_asset_preserves_domain_budget_for_nonzero_asset() {
 }
 
 #[test]
+fn v16_terminal_spent_domain_budget_cleanup_unblocks_empty_asset_restart() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        market.deposit_domain_insurance_not_atomic(2, 10).unwrap();
+        market.force_asset_recovery_not_atomic(1, 2).unwrap();
+    }
+    header.insurance = V16PodU128::new(0);
+    header.insurance_domain_budget_remaining_total = V16PodU128::new(0);
+    markets[1].engine.insurance_domain_spent_long = V16PodU128::new(10);
+    let old_market_id = markets[1].engine.asset.market_id.get();
+    let vault_before = header.vault.get();
+    let c_tot_before = header.c_tot.get();
+    let insurance_before = header.insurance.get();
+    let remaining_before = header.insurance_domain_budget_remaining_total.get();
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    assert_eq!(market.validate_shape(), Ok(()));
+    assert_eq!(
+        market.restart_empty_asset_preserving_insurance_budget_not_atomic(1, 222, 3),
+        Err(V16Error::LockActive)
+    );
+
+    market
+        .clear_terminal_spent_domain_budgets_for_empty_asset_not_atomic(1)
+        .unwrap();
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), c_tot_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
+    assert_eq!(
+        market.header.insurance_domain_budget_remaining_total.get(),
+        remaining_before
+    );
+    assert_eq!(
+        market.markets[1].engine.insurance_domain_budget_long.get(),
+        0
+    );
+    assert_eq!(
+        market.markets[1].engine.insurance_domain_spent_long.get(),
+        0
+    );
+
+    market
+        .restart_empty_asset_preserving_insurance_budget_not_atomic(1, 222, 3)
+        .unwrap();
+    let asset = market.markets[1].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(asset.lifecycle, AssetLifecycleV16::Active);
+    assert_ne!(asset.market_id, old_market_id);
+    assert_eq!(asset.effective_price, 222);
+    market.validate_shape().unwrap();
+}
+
+#[test]
+fn v16_terminal_spent_domain_budget_cleanup_rejects_remaining_budget() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        market.deposit_domain_insurance_not_atomic(2, 10).unwrap();
+        market.force_asset_recovery_not_atomic(1, 2).unwrap();
+    }
+    header.insurance = V16PodU128::new(6);
+    header.insurance_domain_budget_remaining_total = V16PodU128::new(6);
+    markets[1].engine.insurance_domain_spent_long = V16PodU128::new(4);
+    let vault_before = header.vault;
+    let insurance_before = header.insurance;
+    let remaining_before = header.insurance_domain_budget_remaining_total;
+    let budget_before = markets[1].engine.insurance_domain_budget_long;
+    let spent_before = markets[1].engine.insurance_domain_spent_long;
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    assert_eq!(market.validate_shape(), Ok(()));
+    assert_eq!(
+        market.clear_terminal_spent_domain_budgets_for_empty_asset_not_atomic(1),
+        Err(V16Error::LockActive)
+    );
+    assert_eq!(market.header.vault, vault_before);
+    assert_eq!(market.header.insurance, insurance_before);
+    assert_eq!(
+        market.header.insurance_domain_budget_remaining_total,
+        remaining_before
+    );
+    assert_eq!(
+        market.markets[1].engine.insurance_domain_budget_long,
+        budget_before
+    );
+    assert_eq!(
+        market.markets[1].engine.insurance_domain_spent_long,
+        spent_before
+    );
+}
+
+#[test]
+fn v16_terminal_spent_domain_budget_cleanup_rejects_active_asset() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    assert_eq!(market.validate_shape(), Ok(()));
+    assert_eq!(
+        market.clear_terminal_spent_domain_budgets_for_empty_asset_not_atomic(1),
+        Err(V16Error::LockActive)
+    );
+}
+
+#[test]
 fn v16_canonicalize_retired_empty_asset_slot_clears_inert_domain_state() {
     let (mut header, mut markets) = market_fixture(2, 100);
     {


### PR DESCRIPTION
Fixes #91.

## Summary
- Add a terminal-only engine API that clears fully consumed insurance-domain accounting (`budget == spent`) after every existing empty-asset gate passes.
- Preserve any unspent domain budget and reject Active assets.
- Keep source claims, backing principal, provider receivables, reservations, barriers, positions, and losses as strict blockers.
- Permit the existing restart/retire paths after value-neutral spent-history cleanup.

## Proof-driven safety
- The arithmetic proof covers fully spent cleanup, no-op zero-spent domains, and rejection when withdrawable budget remains.
- A production-view theorem proves cleanup followed by restart preserves `V`, `C_tot`, `I`, and junior residual across symbolic spent domains, senior balances, Recovery/Retired lifecycle, and restart price.
- A production-view exact-frame theorem proves matched nonzero `provider_receivable_num == consumed_liened_backing_num` rejects without any header or slot mutation. This prevents terminal cleanup from writing off recoverable provider principal.

## Validation
- `cargo fmt --check`
- `cargo test --tests --features fuzz`: all tests passed
- `proof_v16_terminal_spent_domain_cleanup_is_value_neutral_and_remaining_budget_gated`: 0 failures, 3/3 covers, 0.52s
- `proof_v16_public_terminal_spent_cleanup_then_restart_preserves_value`: 0 failures, 3/3 covers, 164.5s
- `proof_v16_terminal_spent_cleanup_cannot_erase_provider_receivable`: 0 failures, 1/1 cover, 33.2s