### PR TITLE
[codex] Recertify single trades on any account oracle lag

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -13447,8 +13447,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         {
             return Err(V16Error::InvalidConfig);
         }
-        let asset = self.asset_state(asset_index)?;
-        if asset.raw_oracle_target_price != asset.effective_price {
+        if self.account_has_target_effective_lag(&account.as_view())? {
             let cert = self.compute_account_health_cert_with_price_override(
                 &account.as_view(),
                 false,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -783,6 +783,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Self::ensure_no_positive_credit_initial_margin(account)
     }
 
+    pub fn kani_account_has_target_effective_lag(
+        &self,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<bool> {
+        self.account_has_target_effective_lag(account)
+    }
+
     pub fn kani_apply_trade_after_refresh_not_atomic(
         &mut self,
         long_account: &mut PortfolioV16ViewMut<'_>,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -3588,6 +3588,62 @@ fn proof_v16_final_batch_margin_gate_accepts_only_final_certified_im() {
 }
 
 #[kani::proof]
+#[kani::unwind(32)]
+#[kani::solver(cadical)]
+fn proof_v16_single_trade_recert_lag_gate_sees_nontraded_active_asset() {
+    let raw_target_1: u8 = kani::any();
+    kani::assume((1..=99).contains(&raw_target_1));
+    let (mut header, mut markets, mut account_header) = two_market_view_fixture();
+    markets[1].engine.asset.raw_oracle_target_price = V16PodU64::new(raw_target_1 as u64);
+
+    let leg0 = PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: markets[0].engine.asset.market_id.get(),
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        loss_weight: POS_SCALE,
+        ..PortfolioLegV16::EMPTY
+    };
+    let leg1 = PortfolioLegV16 {
+        active: true,
+        asset_index: 1,
+        market_id: markets[1].engine.asset.market_id.get(),
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        loss_weight: POS_SCALE,
+        ..PortfolioLegV16::EMPTY
+    };
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&leg0);
+    account_header.legs[1] = PortfolioLegV16Account::from_runtime(&leg1);
+    let mut bitmap = account_header.active_bitmap.map(V16PodU64::get);
+    active_bitmap_set(&mut bitmap, 0).unwrap();
+    active_bitmap_set(&mut bitmap, 1).unwrap();
+    account_header.active_bitmap = bitmap.map(V16PodU64::new);
+
+    assert_eq!(markets[0].engine.asset.raw_oracle_target_price.get(), 100);
+    assert_eq!(markets[0].engine.asset.effective_price.get(), 100);
+    assert_ne!(
+        markets[1].engine.asset.raw_oracle_target_price.get(),
+        markets[1].engine.asset.effective_price.get()
+    );
+
+    let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let account = PortfolioV16ViewMut::new(&mut account_header);
+    let expected_nontraded_lag = 100u128 - raw_target_1 as u128;
+    kani::cover!(
+        expected_nontraded_lag > 40,
+        "single-trade recert lag gate covers material lag on a non-traded held asset"
+    );
+    assert_eq!(
+        market.kani_account_has_target_effective_lag(&account.as_view()),
+        Ok(true)
+    );
+}
+
+#[kani::proof]
 #[kani::unwind(8)]
 #[kani::solver(cadical)]
 fn proof_v16_locked_trade_margin_gate_cannot_use_positive_pnl_credit() {

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -916,6 +916,56 @@ fn v16_batch_trade_checks_initial_margin_on_final_portfolio() {
 }
 
 #[test]
+fn v16_single_trade_recert_applies_unrelated_asset_target_lag_penalty() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut taker_header = account_fixture(2, 213);
+    let mut lp_header = account_fixture(2, 214);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut taker = PortfolioV16ViewMut::new(&mut taker_header);
+        let mut lp = PortfolioV16ViewMut::new(&mut lp_header);
+        market.deposit_not_atomic(&mut taker, 200).unwrap();
+        market.deposit_not_atomic(&mut lp, 10_000).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut taker,
+                &mut lp,
+                TradeRequestV16 {
+                    asset_index: 1,
+                    size_q: signed_q(POS_SCALE),
+                    exec_price: 100,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+        market
+            .set_asset_raw_oracle_target_not_atomic(1, 50)
+            .unwrap();
+    }
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut taker = PortfolioV16ViewMut::new(&mut taker_header);
+    let mut lp = PortfolioV16ViewMut::new(&mut lp_header);
+    let res = market.execute_trade_with_fee_loss_stale_scoped_not_atomic(
+        &mut taker,
+        &mut lp,
+        TradeRequestV16 {
+            asset_index: 0,
+            size_q: signed_q(POS_SCALE),
+            exec_price: 100,
+            fee_bps: 0,
+        },
+    );
+    assert_eq!(res, Err(V16Error::InvalidConfig));
+
+    let full_cert = taker.header.health_cert.try_to_runtime().unwrap();
+    assert_eq!(
+        full_cert.certified_initial_req, 250,
+        "post-trade full cert must include asset-1 lag penalty"
+    );
+}
+
+#[test]
 fn v16_batch_trade_self_settles_stale_certificates_once_before_fills() {
     let (mut header, mut markets) = market_fixture(1, 100);
     let mut long_header = account_fixture(1, 203);


### PR DESCRIPTION
Fixes #93.

## Summary
- Make the single-fill recertification path fall back to full account health certification whenever any active account leg has raw-target/effective oracle lag, not only when the traded asset has lag.
- Add a regression where a trader holds a lagged asset 1 leg and attempts a single asset 0 trade that would pass only if the asset 1 lag penalty were ignored.
- Add focused Kani coverage proving the recert lag gate sees a lagged non-traded active asset.

## Root Cause
The single-trade fast path incrementally adjusted the certificate when the traded asset had no target/effective lag. That preserved a stale requirement for other active legs if a non-traded asset had acquired target/effective lag without bumping certificate epochs.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test v16_single_trade_recert_applies_unrelated_asset_target_lag_penalty --test v16_spec_tests -- --nocapture`
- `cargo test --tests --features fuzz`
- `cargo kani --tests --features fuzz --exact --harness proof_v16_single_trade_recert_lag_gate_sees_nontraded_active_asset --output-format regular`