### PR TITLE
[codex] Unblock terminal empty asset restart

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -8637,6 +8637,37 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok((V16PodU128::default(), V16PodU128::default()))
     }
 
+    fn clear_terminal_source_backing_pair(
+        market_id: u64,
+        source: SourceCreditStateV16,
+        bucket: BackingBucketV16,
+    ) -> V16Result<(SourceCreditStateV16, BackingBucketV16)> {
+        if source.is_empty_amount_shape() && bucket.is_empty_amount_shape() {
+            return Ok((source, bucket));
+        }
+        if source.positive_claim_bound_num != 0
+            || source.exact_positive_claim_num != 0
+            || source.fresh_reserved_backing_num != 0
+            || source.valid_liened_backing_num != 0
+            || source.impaired_liened_backing_num != 0
+            || source.insurance_credit_reserved_num != 0
+            || source.valid_liened_insurance_num != 0
+            || source.impaired_liened_insurance_num != 0
+            || bucket.fresh_unliened_backing_num != 0
+            || bucket.valid_liened_backing_num != 0
+            || bucket.impaired_liened_backing_num != 0
+            || bucket.utilization_fee_earnings != 0
+            || source.spent_backing_num != source.provider_receivable_num
+            || source.spent_backing_num != bucket.consumed_liened_backing_num
+        {
+            return Err(V16Error::LockActive);
+        }
+        Ok((
+            SourceCreditStateV16::EMPTY,
+            BackingBucketV16::empty_for_market(market_id),
+        ))
+    }
+
     fn set_domain_insurance_budget_core(
         &mut self,
         domain: usize,
@@ -11826,6 +11857,21 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 || asset.b_epoch_start_long_num != 0
                 || asset.b_epoch_start_short_num != 0
         };
+        let source_backing_blocks_empty = if allow_terminal_inert_price_state {
+            Self::clear_terminal_source_backing_pair(asset.market_id, long_source, long_bucket)
+                .is_err()
+                || Self::clear_terminal_source_backing_pair(
+                    asset.market_id,
+                    short_source,
+                    short_bucket,
+                )
+                .is_err()
+        } else {
+            !long_source.is_empty_amount_shape()
+                || !short_source.is_empty_amount_shape()
+                || !long_bucket.is_empty_amount_shape()
+                || !short_bucket.is_empty_amount_shape()
+        };
 
         if slot.pending_domain_loss_barrier_long.get() != 0
             || slot.pending_domain_loss_barrier_short.get() != 0
@@ -11849,10 +11895,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             || asset.explicit_unallocated_loss_long != 0
             || asset.explicit_unallocated_loss_short != 0
             || spent_blocks_empty
-            || !long_source.is_empty_amount_shape()
-            || !short_source.is_empty_amount_shape()
-            || !long_bucket.is_empty_amount_shape()
-            || !short_bucket.is_empty_amount_shape()
+            || source_backing_blocks_empty
             || long_bucket.market_id != asset.market_id
             || short_bucket.market_id != asset.market_id
             || long_reservation != InsuranceCreditReservationV16::EMPTY
@@ -15171,11 +15214,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     /// Clears inert terminal ledgers on an otherwise empty terminal asset.
     ///
     /// This is value-neutral: it may only erase a domain whose remaining budget
-    /// is already zero (`budget == spent`) and side-reset price indexes after no
-    /// position, stale-account, pending-obligation, loss, barrier, source,
-    /// backing, or reservation state can still reference them. If `budget >
-    /// spent`, callers must withdraw the remaining domain budget before terminal
-    /// cleanup.
+    /// is already zero (`budget == spent`), side-reset price indexes, and
+    /// matched consumed-only source/backing audit counters after no position,
+    /// stale-account, pending-obligation, loss, barrier, live source claim,
+    /// fresh backing, backing fee, or reservation state can still reference
+    /// them. If `budget > spent`, callers must withdraw the remaining domain
+    /// budget before terminal cleanup.
     pub fn clear_terminal_spent_domain_budgets_for_empty_asset_not_atomic(
         &mut self,
         asset_index: usize,
@@ -15189,7 +15233,19 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Err(V16Error::LockActive);
         }
         self.require_empty_asset_lifecycle_state_with_terminal_policy(asset_index, true, true)?;
+        let long_domain = self.insurance_domain_index(asset_index, SideV16::Long)?;
+        let short_domain = self.insurance_domain_index(asset_index, SideV16::Short)?;
         let mut asset = self.asset_state(asset_index)?;
+        let (long_source, long_bucket) = Self::clear_terminal_source_backing_pair(
+            asset.market_id,
+            self.source_credit_for_domain_shape(long_domain)?,
+            self.backing_bucket_for_domain(long_domain)?,
+        )?;
+        let (short_source, short_bucket) = Self::clear_terminal_source_backing_pair(
+            asset.market_id,
+            self.source_credit_for_domain_shape(short_domain)?,
+            self.backing_bucket_for_domain(short_domain)?,
+        )?;
         asset.a_long = ADL_ONE;
         asset.a_short = ADL_ONE;
         asset.k_long = 0;
@@ -15207,6 +15263,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         asset.mode_long = SideModeV16::Normal;
         asset.mode_short = SideModeV16::Normal;
         self.set_asset_state(asset_index, asset)?;
+        self.set_source_credit_for_domain(long_domain, long_source)?;
+        self.set_backing_bucket_for_domain(long_domain, long_bucket)?;
+        self.set_source_credit_for_domain(short_domain, short_source)?;
+        self.set_backing_bucket_for_domain(short_domain, short_bucket)?;
         let slot = self.markets[asset_index].engine_slot_mut();
         let (budget_long, spent_long) = Self::clear_terminal_spent_domain_budget_pair(
             slot.insurance_domain_budget_long,

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -11778,13 +11778,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     }
 
     fn require_empty_asset_lifecycle_state(&self, asset_index: usize) -> V16Result<()> {
-        self.require_empty_asset_lifecycle_state_with_spent_policy(asset_index, false)
+        self.require_empty_asset_lifecycle_state_with_terminal_policy(asset_index, false, false)
     }
 
-    fn require_empty_asset_lifecycle_state_with_spent_policy(
+    fn require_empty_asset_lifecycle_state_with_terminal_policy(
         &self,
         asset_index: usize,
         allow_terminal_spent_budget: bool,
+        allow_terminal_inert_price_state: bool,
     ) -> V16Result<()> {
         self.validate_configured_asset_index(asset_index)?;
         let asset = self.asset_state(asset_index)?;
@@ -11807,25 +11808,30 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         } else {
             long_spent != 0 || short_spent != 0
         };
+        let price_state_blocks_empty = if allow_terminal_inert_price_state {
+            false
+        } else {
+            asset.mode_long != SideModeV16::Normal
+                || asset.mode_short != SideModeV16::Normal
+                || asset.k_long != 0
+                || asset.k_short != 0
+                || asset.f_long_num != 0
+                || asset.f_short_num != 0
+                || asset.k_epoch_start_long != 0
+                || asset.k_epoch_start_short != 0
+                || asset.f_epoch_start_long_num != 0
+                || asset.f_epoch_start_short_num != 0
+                || asset.b_long_num != 0
+                || asset.b_short_num != 0
+                || asset.b_epoch_start_long_num != 0
+                || asset.b_epoch_start_short_num != 0
+        };
 
         if slot.pending_domain_loss_barrier_long.get() != 0
             || slot.pending_domain_loss_barrier_short.get() != 0
-            || asset.mode_long != SideModeV16::Normal
-            || asset.mode_short != SideModeV16::Normal
             || !((asset.a_long == ADL_ONE && asset.a_short == ADL_ONE)
                 || (asset.a_long == 0 && asset.a_short == 0))
-            || asset.k_long != 0
-            || asset.k_short != 0
-            || asset.f_long_num != 0
-            || asset.f_short_num != 0
-            || asset.k_epoch_start_long != 0
-            || asset.k_epoch_start_short != 0
-            || asset.f_epoch_start_long_num != 0
-            || asset.f_epoch_start_short_num != 0
-            || asset.b_long_num != 0
-            || asset.b_short_num != 0
-            || asset.b_epoch_start_long_num != 0
-            || asset.b_epoch_start_short_num != 0
+            || price_state_blocks_empty
             || asset.oi_eff_long_q != 0
             || asset.oi_eff_short_q != 0
             || asset.stored_pos_count_long != 0
@@ -15157,11 +15163,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.validate_shape()
     }
 
-    /// Clears spent-only insurance-domain ledgers on an otherwise empty terminal asset.
+    /// Clears inert terminal ledgers on an otherwise empty terminal asset.
     ///
     /// This is value-neutral: it may only erase a domain whose remaining budget
-    /// is already zero (`budget == spent`). If `budget > spent`, callers must
-    /// withdraw the remaining domain budget before terminal cleanup.
+    /// is already zero (`budget == spent`) and side-reset price indexes after no
+    /// position, stale-account, pending-obligation, loss, barrier, source,
+    /// backing, or reservation state can still reference them. If `budget >
+    /// spent`, callers must withdraw the remaining domain budget before terminal
+    /// cleanup.
     pub fn clear_terminal_spent_domain_budgets_for_empty_asset_not_atomic(
         &mut self,
         asset_index: usize,
@@ -15174,7 +15183,25 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         ) {
             return Err(V16Error::LockActive);
         }
-        self.require_empty_asset_lifecycle_state_with_spent_policy(asset_index, true)?;
+        self.require_empty_asset_lifecycle_state_with_terminal_policy(asset_index, true, true)?;
+        let mut asset = self.asset_state(asset_index)?;
+        asset.a_long = ADL_ONE;
+        asset.a_short = ADL_ONE;
+        asset.k_long = 0;
+        asset.k_short = 0;
+        asset.f_long_num = 0;
+        asset.f_short_num = 0;
+        asset.k_epoch_start_long = 0;
+        asset.k_epoch_start_short = 0;
+        asset.f_epoch_start_long_num = 0;
+        asset.f_epoch_start_short_num = 0;
+        asset.b_long_num = 0;
+        asset.b_short_num = 0;
+        asset.b_epoch_start_long_num = 0;
+        asset.b_epoch_start_short_num = 0;
+        asset.mode_long = SideModeV16::Normal;
+        asset.mode_short = SideModeV16::Normal;
+        self.set_asset_state(asset_index, asset)?;
         let slot = self.markets[asset_index].engine_slot_mut();
         let (budget_long, spent_long) = Self::clear_terminal_spent_domain_budget_pair(
             slot.insurance_domain_budget_long,

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -14192,6 +14192,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         {
             return Err(V16Error::LockActive);
         }
+        if Self::account_has_source_claims(account)?
+            && !self.account_has_active_source_claim_exposure(account)?
+        {
+            return Ok(());
+        }
         self.ensure_favorable_action_allowed(account)
     }
 

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -8622,6 +8622,21 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.validate_shape()
     }
 
+    fn clear_terminal_spent_domain_budget_pair(
+        budget: V16PodU128,
+        spent: V16PodU128,
+    ) -> V16Result<(V16PodU128, V16PodU128)> {
+        let budget = budget.get();
+        let spent = spent.get();
+        if spent == 0 {
+            return Ok((V16PodU128::new(budget), V16PodU128::default()));
+        }
+        if budget != spent {
+            return Err(V16Error::LockActive);
+        }
+        Ok((V16PodU128::default(), V16PodU128::default()))
+    }
+
     fn set_domain_insurance_budget_core(
         &mut self,
         domain: usize,
@@ -11763,6 +11778,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     }
 
     fn require_empty_asset_lifecycle_state(&self, asset_index: usize) -> V16Result<()> {
+        self.require_empty_asset_lifecycle_state_with_spent_policy(asset_index, false)
+    }
+
+    fn require_empty_asset_lifecycle_state_with_spent_policy(
+        &self,
+        asset_index: usize,
+        allow_terminal_spent_budget: bool,
+    ) -> V16Result<()> {
         self.validate_configured_asset_index(asset_index)?;
         let asset = self.asset_state(asset_index)?;
         let long_domain = self.insurance_domain_index(asset_index, SideV16::Long)?;
@@ -11774,6 +11797,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let long_reservation = self.insurance_reservation_for_domain(long_domain)?;
         let short_reservation = self.insurance_reservation_for_domain(short_domain)?;
         let slot = self.markets[asset_index].engine_slot();
+        let long_budget = slot.insurance_domain_budget_long.get();
+        let long_spent = slot.insurance_domain_spent_long.get();
+        let short_budget = slot.insurance_domain_budget_short.get();
+        let short_spent = slot.insurance_domain_spent_short.get();
+        let spent_blocks_empty = if allow_terminal_spent_budget {
+            (long_spent != 0 && long_budget != long_spent)
+                || (short_spent != 0 && short_budget != short_spent)
+        } else {
+            long_spent != 0 || short_spent != 0
+        };
 
         if slot.pending_domain_loss_barrier_long.get() != 0
             || slot.pending_domain_loss_barrier_short.get() != 0
@@ -11809,8 +11842,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             || asset.social_loss_dust_short_num != 0
             || asset.explicit_unallocated_loss_long != 0
             || asset.explicit_unallocated_loss_short != 0
-            || slot.insurance_domain_spent_long.get() != 0
-            || slot.insurance_domain_spent_short.get() != 0
+            || spent_blocks_empty
             || !long_source.is_empty_amount_shape()
             || !short_source.is_empty_amount_shape()
             || !long_bucket.is_empty_amount_shape()
@@ -15122,6 +15154,40 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.header.last_asset_activation_slot = V16PodU64::new(now_slot);
         self.header.asset_set_epoch = V16PodU64::new(next_asset_set_epoch);
         self.header.risk_epoch = V16PodU64::new(next_risk_epoch);
+        self.validate_shape()
+    }
+
+    /// Clears spent-only insurance-domain ledgers on an otherwise empty terminal asset.
+    ///
+    /// This is value-neutral: it may only erase a domain whose remaining budget
+    /// is already zero (`budget == spent`). If `budget > spent`, callers must
+    /// withdraw the remaining domain budget before terminal cleanup.
+    pub fn clear_terminal_spent_domain_budgets_for_empty_asset_not_atomic(
+        &mut self,
+        asset_index: usize,
+    ) -> V16Result<()> {
+        self.validate_configured_asset_index(asset_index)?;
+        let asset = self.asset_state(asset_index)?;
+        if !matches!(
+            asset.lifecycle,
+            AssetLifecycleV16::Recovery | AssetLifecycleV16::Retired
+        ) {
+            return Err(V16Error::LockActive);
+        }
+        self.require_empty_asset_lifecycle_state_with_spent_policy(asset_index, true)?;
+        let slot = self.markets[asset_index].engine_slot_mut();
+        let (budget_long, spent_long) = Self::clear_terminal_spent_domain_budget_pair(
+            slot.insurance_domain_budget_long,
+            slot.insurance_domain_spent_long,
+        )?;
+        let (budget_short, spent_short) = Self::clear_terminal_spent_domain_budget_pair(
+            slot.insurance_domain_budget_short,
+            slot.insurance_domain_spent_short,
+        )?;
+        slot.insurance_domain_budget_long = budget_long;
+        slot.insurance_domain_spent_long = spent_long;
+        slot.insurance_domain_budget_short = budget_short;
+        slot.insurance_domain_spent_short = spent_short;
         self.validate_shape()
     }
 

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -438,6 +438,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         )
     }
 
+    pub fn kani_clear_terminal_spent_domain_budget_pair(
+        budget: u128,
+        spent: u128,
+    ) -> V16Result<(u128, u128)> {
+        let (budget, spent) = Self::clear_terminal_spent_domain_budget_pair(
+            V16PodU128::new(budget),
+            V16PodU128::new(spent),
+        )?;
+        Ok((budget.get(), spent.get()))
+    }
+
     pub fn kani_credit_account_from_insurance_delta(
         insurance: u128,
         budget_remaining: u128,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -449,6 +449,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok((budget.get(), spent.get()))
     }
 
+    pub fn kani_clear_terminal_source_backing_pair(
+        market_id: u64,
+        source: SourceCreditStateV16,
+        bucket: BackingBucketV16,
+    ) -> V16Result<(SourceCreditStateV16, BackingBucketV16)> {
+        Self::clear_terminal_source_backing_pair(market_id, source, bucket)
+    }
+
     pub fn kani_credit_account_from_insurance_delta(
         insurance: u128,
         budget_remaining: u128,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -2032,6 +2032,50 @@ fn proof_v16_public_restart_rejects_spent_domain_before_mutation() {
 }
 
 #[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_terminal_spent_domain_cleanup_is_value_neutral_and_remaining_budget_gated() {
+    let budget_raw: u8 = kani::any();
+    let spent_raw: u8 = kani::any();
+    kani::assume(budget_raw > 0);
+    kani::assume(spent_raw <= budget_raw);
+    let budget = budget_raw as u128;
+    let spent = spent_raw as u128;
+    let remaining_before = budget - spent;
+    let result =
+        MarketGroupV16ViewMut::<u64>::kani_clear_terminal_spent_domain_budget_pair(budget, spent);
+    let expected_ok = spent == 0 || budget == spent;
+
+    kani::cover!(
+        spent != 0 && budget == spent,
+        "terminal cleanup covers nonzero spent-only domain"
+    );
+    kani::cover!(
+        spent != 0 && budget > spent,
+        "terminal cleanup rejects domain with remaining budget"
+    );
+    kani::cover!(
+        spent == 0 && budget > 1,
+        "terminal cleanup covers no-op domain with remaining budget"
+    );
+    assert_eq!(result.is_ok(), expected_ok);
+    if let Ok((next_budget, next_spent)) = result {
+        assert_eq!(next_spent, 0);
+        assert_eq!(next_budget - next_spent, remaining_before);
+        if spent == 0 {
+            assert_eq!(next_budget, budget);
+        } else {
+            assert_eq!(next_budget, 0);
+            assert_eq!(remaining_before, 0);
+        }
+    } else {
+        assert!(spent != 0 && budget > spent);
+        assert!(remaining_before > 0);
+        assert_eq!(result, Err(V16Error::LockActive));
+    }
+}
+
+#[kani::proof]
 #[kani::unwind(16)]
 #[kani::solver(cadical)]
 fn proof_v16_canonical_retired_asset_slot_preserves_identity_and_clears_local_ledgers() {

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -2034,6 +2034,132 @@ fn proof_v16_public_restart_rejects_spent_domain_before_mutation() {
 #[kani::proof]
 #[kani::unwind(8)]
 #[kani::solver(cadical)]
+fn proof_v16_terminal_source_backing_cleanup_only_erases_matched_inert_residue() {
+    let market_id_raw: u8 = kani::any();
+    kani::assume(market_id_raw > 0);
+    let market_id = u64::from(market_id_raw);
+
+    let positive_claim_raw: u8 = kani::any();
+    let exact_claim_raw: u8 = kani::any();
+    let fresh_reserved_raw: u8 = kani::any();
+    let spent_raw: u8 = kani::any();
+    let provider_raw: u8 = kani::any();
+    let valid_liened_raw: u8 = kani::any();
+    let impaired_liened_raw: u8 = kani::any();
+    let insurance_reserved_raw: u8 = kani::any();
+    let valid_insurance_raw: u8 = kani::any();
+    let impaired_insurance_raw: u8 = kani::any();
+    let bucket_fresh_raw: u8 = kani::any();
+    let bucket_valid_raw: u8 = kani::any();
+    let bucket_consumed_raw: u8 = kani::any();
+    let bucket_impaired_raw: u8 = kani::any();
+    let bucket_earnings_raw: u8 = kani::any();
+    let credit_rate_raw: u8 = kani::any();
+    let credit_epoch_raw: u8 = kani::any();
+    let bucket_expiry_raw: u8 = kani::any();
+    let bucket_status_raw: u8 = kani::any();
+
+    let scale = |v: u8| u128::from(v) * BOUND_SCALE;
+    let source = SourceCreditStateV16 {
+        positive_claim_bound_num: scale(positive_claim_raw),
+        exact_positive_claim_num: scale(exact_claim_raw),
+        fresh_reserved_backing_num: scale(fresh_reserved_raw),
+        spent_backing_num: scale(spent_raw),
+        provider_receivable_num: scale(provider_raw),
+        valid_liened_backing_num: scale(valid_liened_raw),
+        impaired_liened_backing_num: scale(impaired_liened_raw),
+        insurance_credit_reserved_num: scale(insurance_reserved_raw),
+        valid_liened_insurance_num: scale(valid_insurance_raw),
+        impaired_liened_insurance_num: scale(impaired_insurance_raw),
+        credit_rate_num: scale(credit_rate_raw),
+        credit_epoch: u64::from(credit_epoch_raw),
+    };
+    let bucket = BackingBucketV16 {
+        market_id,
+        fresh_unliened_backing_num: scale(bucket_fresh_raw),
+        valid_liened_backing_num: scale(bucket_valid_raw),
+        consumed_liened_backing_num: scale(bucket_consumed_raw),
+        impaired_liened_backing_num: scale(bucket_impaired_raw),
+        utilization_fee_earnings: scale(bucket_earnings_raw),
+        expiry_slot: u64::from(bucket_expiry_raw),
+        status: match bucket_status_raw & 3 {
+            0 => BackingBucketStatusV16::Empty,
+            1 => BackingBucketStatusV16::Fresh,
+            2 => BackingBucketStatusV16::Expired,
+            _ => BackingBucketStatusV16::Impaired,
+        },
+    };
+
+    let source_has_live_value = source.positive_claim_bound_num != 0
+        || source.exact_positive_claim_num != 0
+        || source.fresh_reserved_backing_num != 0
+        || source.valid_liened_backing_num != 0
+        || source.impaired_liened_backing_num != 0
+        || source.insurance_credit_reserved_num != 0
+        || source.valid_liened_insurance_num != 0
+        || source.impaired_liened_insurance_num != 0;
+    let bucket_has_live_value = bucket.fresh_unliened_backing_num != 0
+        || bucket.valid_liened_backing_num != 0
+        || bucket.impaired_liened_backing_num != 0
+        || bucket.utilization_fee_earnings != 0;
+    let residue_is_matched = source.spent_backing_num == source.provider_receivable_num
+        && source.spent_backing_num == bucket.consumed_liened_backing_num;
+    let expected_ok = !source_has_live_value && !bucket_has_live_value && residue_is_matched;
+
+    let result = MarketGroupV16ViewMut::<u64>::kani_clear_terminal_source_backing_pair(
+        market_id, source, bucket,
+    );
+
+    kani::cover!(
+        result.is_ok() && source.spent_backing_num != 0,
+        "terminal source/backing cleanup clears matched consumed-only residue"
+    );
+    kani::cover!(
+        result.is_err() && source.positive_claim_bound_num != 0,
+        "terminal source/backing cleanup rejects live source claims"
+    );
+    kani::cover!(
+        result.is_err() && bucket.fresh_unliened_backing_num != 0,
+        "terminal source/backing cleanup rejects fresh backing value"
+    );
+    kani::cover!(
+        result.is_err() && !source_has_live_value && !bucket_has_live_value && !residue_is_matched,
+        "terminal source/backing cleanup rejects mismatched consumed/provider residue"
+    );
+
+    assert_eq!(result.is_ok(), expected_ok);
+    match result {
+        Ok((next_source, next_bucket)) => {
+            assert!(!source_has_live_value);
+            assert!(!bucket_has_live_value);
+            assert!(residue_is_matched);
+            assert_eq!(next_source.positive_claim_bound_num, 0);
+            assert_eq!(next_source.exact_positive_claim_num, 0);
+            assert_eq!(next_source.fresh_reserved_backing_num, 0);
+            assert_eq!(next_source.spent_backing_num, 0);
+            assert_eq!(next_source.provider_receivable_num, 0);
+            assert_eq!(next_source.valid_liened_backing_num, 0);
+            assert_eq!(next_source.impaired_liened_backing_num, 0);
+            assert_eq!(next_source.insurance_credit_reserved_num, 0);
+            assert_eq!(next_source.valid_liened_insurance_num, 0);
+            assert_eq!(next_source.impaired_liened_insurance_num, 0);
+            assert_eq!(next_bucket.market_id, market_id);
+            assert_eq!(next_bucket.fresh_unliened_backing_num, 0);
+            assert_eq!(next_bucket.valid_liened_backing_num, 0);
+            assert_eq!(next_bucket.consumed_liened_backing_num, 0);
+            assert_eq!(next_bucket.impaired_liened_backing_num, 0);
+            assert_eq!(next_bucket.utilization_fee_earnings, 0);
+        }
+        Err(err) => {
+            assert_eq!(err, V16Error::LockActive);
+            assert!(source_has_live_value || bucket_has_live_value || !residue_is_matched);
+        }
+    }
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
 fn proof_v16_terminal_spent_domain_cleanup_is_value_neutral_and_remaining_budget_gated() {
     let budget_raw: u8 = kani::any();
     let spent_raw: u8 = kani::any();

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -2695,6 +2695,51 @@ fn v16_grant_source_positive_pnl_attributes_claims_and_aggregates_in_lockstep() 
     assert_eq!(account.header.pnl.get(), 25);
 }
 
+#[test]
+fn v16_flat_source_claim_conversion_does_not_require_live_risk_cert() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 44);
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+
+    market
+        .deposit_fresh_counterparty_backing_not_atomic(0, 25, 10)
+        .unwrap();
+    market
+        .add_account_source_positive_pnl_not_atomic(&mut account, 0, 25)
+        .unwrap();
+    assert_eq!(account.header.pnl.get(), 25);
+    assert!(!account.header.health_cert.try_to_runtime().unwrap().valid);
+
+    market.force_asset_recovery_not_atomic(0, 2).unwrap();
+    let converted = market
+        .convert_released_pnl_to_capital_not_atomic(&mut account)
+        .expect("flat source-backed PnL must remain convertible after asset recovery");
+
+    assert_eq!(converted, 25);
+    assert_eq!(account.header.pnl.get(), 0);
+    assert_eq!(account.header.capital.get(), 25);
+    assert_eq!(market.header.c_tot.get(), 25);
+    assert_eq!(
+        market.markets[0]
+            .engine
+            .source_credit_long
+            .positive_claim_bound_num
+            .get(),
+        0
+    );
+    assert_eq!(
+        market.markets[0]
+            .engine
+            .backing_long
+            .consumed_liened_backing_num
+            .get(),
+        25 * BOUND_SCALE
+    );
+    assert_eq!(market.validate_shape(), Ok(()));
+    assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
+}
+
 // ROADMAP 3C step 4 — self-classifying crank. The keeper no longer chooses the
 // action: build_actionable_summary classifies the account and
 // select_progress_witness picks the continuation the auto-crank dispatches.

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1313,6 +1313,21 @@ fn v16_terminal_spent_domain_cleanup_canonicalizes_empty_price_state() {
     asset.k_epoch_start_long = 700;
     asset.mode_long = SideModeV16::ResetPending;
     markets[1].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    markets[1].engine.source_credit_short =
+        SourceCreditStateV16Account::from_runtime(&SourceCreditStateV16 {
+            spent_backing_num: 4 * BOUND_SCALE,
+            provider_receivable_num: 4 * BOUND_SCALE,
+            credit_rate_num: CREDIT_RATE_SCALE,
+            credit_epoch: 7,
+            ..SourceCreditStateV16::EMPTY
+        });
+    markets[1].engine.backing_short = BackingBucketV16Account::from_runtime(&BackingBucketV16 {
+        market_id: asset.market_id,
+        consumed_liened_backing_num: 4 * BOUND_SCALE,
+        expiry_slot: 99,
+        status: BackingBucketStatusV16::Expired,
+        ..BackingBucketV16::empty_for_market(asset.market_id)
+    });
 
     let old_market_id = markets[1].engine.asset.market_id.get();
     let vault_before = header.vault.get();
@@ -1342,6 +1357,17 @@ fn v16_terminal_spent_domain_cleanup_canonicalizes_empty_price_state() {
     assert_eq!(cleaned.mode_short, SideModeV16::Normal);
     assert_eq!(cleaned.k_short, 0);
     assert_eq!(cleaned.k_epoch_start_long, 0);
+    assert_eq!(
+        market.markets[1]
+            .engine
+            .source_credit_short
+            .try_to_runtime(),
+        Ok(SourceCreditStateV16::EMPTY)
+    );
+    assert_eq!(
+        market.markets[1].engine.backing_short.try_to_runtime(),
+        Ok(BackingBucketV16::empty_for_market(old_market_id))
+    );
     assert_eq!(
         market.markets[1].engine.insurance_domain_budget_long.get(),
         0

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1245,6 +1245,109 @@ fn v16_restart_empty_asset_preserves_domain_budget_for_nonzero_asset() {
 }
 
 #[test]
+fn v16_terminal_spent_domain_budget_cleanup_unblocks_empty_asset_restart() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        market.deposit_domain_insurance_not_atomic(2, 10).unwrap();
+        market.force_asset_recovery_not_atomic(1, 2).unwrap();
+    }
+    header.insurance = V16PodU128::new(0);
+    header.insurance_domain_budget_remaining_total = V16PodU128::new(0);
+    markets[1].engine.insurance_domain_spent_long = V16PodU128::new(10);
+    let old_market_id = markets[1].engine.asset.market_id.get();
+    let vault_before = header.vault.get();
+    let c_tot_before = header.c_tot.get();
+    let insurance_before = header.insurance.get();
+    let remaining_before = header.insurance_domain_budget_remaining_total.get();
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    assert_eq!(market.validate_shape(), Ok(()));
+    assert_eq!(
+        market.restart_empty_asset_preserving_insurance_budget_not_atomic(1, 222, 3),
+        Err(V16Error::LockActive)
+    );
+
+    market
+        .clear_terminal_spent_domain_budgets_for_empty_asset_not_atomic(1)
+        .unwrap();
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), c_tot_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
+    assert_eq!(
+        market.header.insurance_domain_budget_remaining_total.get(),
+        remaining_before
+    );
+    assert_eq!(
+        market.markets[1].engine.insurance_domain_budget_long.get(),
+        0
+    );
+    assert_eq!(
+        market.markets[1].engine.insurance_domain_spent_long.get(),
+        0
+    );
+
+    market
+        .restart_empty_asset_preserving_insurance_budget_not_atomic(1, 222, 3)
+        .unwrap();
+    let asset = market.markets[1].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(asset.lifecycle, AssetLifecycleV16::Active);
+    assert_ne!(asset.market_id, old_market_id);
+    assert_eq!(asset.effective_price, 222);
+    market.validate_shape().unwrap();
+}
+
+#[test]
+fn v16_terminal_spent_domain_budget_cleanup_rejects_remaining_budget() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        market.deposit_domain_insurance_not_atomic(2, 10).unwrap();
+        market.force_asset_recovery_not_atomic(1, 2).unwrap();
+    }
+    header.insurance = V16PodU128::new(6);
+    header.insurance_domain_budget_remaining_total = V16PodU128::new(6);
+    markets[1].engine.insurance_domain_spent_long = V16PodU128::new(4);
+    let vault_before = header.vault;
+    let insurance_before = header.insurance;
+    let remaining_before = header.insurance_domain_budget_remaining_total;
+    let budget_before = markets[1].engine.insurance_domain_budget_long;
+    let spent_before = markets[1].engine.insurance_domain_spent_long;
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    assert_eq!(market.validate_shape(), Ok(()));
+    assert_eq!(
+        market.clear_terminal_spent_domain_budgets_for_empty_asset_not_atomic(1),
+        Err(V16Error::LockActive)
+    );
+    assert_eq!(market.header.vault, vault_before);
+    assert_eq!(market.header.insurance, insurance_before);
+    assert_eq!(
+        market.header.insurance_domain_budget_remaining_total,
+        remaining_before
+    );
+    assert_eq!(
+        market.markets[1].engine.insurance_domain_budget_long,
+        budget_before
+    );
+    assert_eq!(
+        market.markets[1].engine.insurance_domain_spent_long,
+        spent_before
+    );
+}
+
+#[test]
+fn v16_terminal_spent_domain_budget_cleanup_rejects_active_asset() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    assert_eq!(market.validate_shape(), Ok(()));
+    assert_eq!(
+        market.clear_terminal_spent_domain_budgets_for_empty_asset_not_atomic(1),
+        Err(V16Error::LockActive)
+    );
+}
+
+#[test]
 fn v16_canonicalize_retired_empty_asset_slot_clears_inert_domain_state() {
     let (mut header, mut markets) = market_fixture(2, 100);
     {

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1298,6 +1298,70 @@ fn v16_terminal_spent_domain_budget_cleanup_unblocks_empty_asset_restart() {
 }
 
 #[test]
+fn v16_terminal_spent_domain_cleanup_canonicalizes_empty_price_state() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        market.deposit_domain_insurance_not_atomic(2, 10).unwrap();
+        market.force_asset_recovery_not_atomic(1, 2).unwrap();
+    }
+    header.insurance = V16PodU128::new(0);
+    header.insurance_domain_budget_remaining_total = V16PodU128::new(0);
+    markets[1].engine.insurance_domain_spent_long = V16PodU128::new(10);
+    let mut asset = markets[1].engine.asset.try_to_runtime().unwrap();
+    asset.k_short = -700;
+    asset.k_epoch_start_long = 700;
+    asset.mode_long = SideModeV16::ResetPending;
+    markets[1].engine.asset = AssetStateV16Account::from_runtime(&asset);
+
+    let old_market_id = markets[1].engine.asset.market_id.get();
+    let vault_before = header.vault.get();
+    let c_tot_before = header.c_tot.get();
+    let insurance_before = header.insurance.get();
+    let remaining_before = header.insurance_domain_budget_remaining_total.get();
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    assert_eq!(market.validate_shape(), Ok(()));
+    assert_eq!(
+        market.restart_empty_asset_preserving_insurance_budget_not_atomic(1, 222, 3),
+        Err(V16Error::LockActive)
+    );
+
+    market
+        .clear_terminal_spent_domain_budgets_for_empty_asset_not_atomic(1)
+        .unwrap();
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), c_tot_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
+    assert_eq!(
+        market.header.insurance_domain_budget_remaining_total.get(),
+        remaining_before
+    );
+    let cleaned = market.markets[1].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(cleaned.mode_long, SideModeV16::Normal);
+    assert_eq!(cleaned.mode_short, SideModeV16::Normal);
+    assert_eq!(cleaned.k_short, 0);
+    assert_eq!(cleaned.k_epoch_start_long, 0);
+    assert_eq!(
+        market.markets[1].engine.insurance_domain_budget_long.get(),
+        0
+    );
+    assert_eq!(
+        market.markets[1].engine.insurance_domain_spent_long.get(),
+        0
+    );
+
+    market
+        .restart_empty_asset_preserving_insurance_budget_not_atomic(1, 222, 3)
+        .unwrap();
+    let restarted = market.markets[1].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(restarted.lifecycle, AssetLifecycleV16::Active);
+    assert_ne!(restarted.market_id, old_market_id);
+    assert_eq!(restarted.effective_price, 222);
+    market.validate_shape().unwrap();
+}
+
+#[test]
 fn v16_terminal_spent_domain_budget_cleanup_rejects_remaining_budget() {
     let (mut header, mut markets) = market_fixture(2, 100);
     {


### PR DESCRIPTION
## Summary
- allow terminal empty Recovery/Retired assets to clear fully spent domain-budget residue
- allow flat source-backed PnL conversion in Recovery when no live risk exposure remains
- canonicalize matched consumed-only source/backing residue during terminal empty-asset cleanup

## Root Cause
A public liquidation/forfeit flow could leave an otherwise empty terminal asset with inert price reset fields, fully spent insurance-domain budget residue, and matched consumed-only source/backing counters. Those counters were not live withdrawable balances or open claims, but the empty-asset lifecycle gate treated them as active blockers, so restart/retire could be permanently blocked after normal user wind-down.

## Safety Shape
The cleanup still rejects any remaining unspent budget, positive source claim, fresh/valid/impaired backing, backing-provider fee earnings, insurance reservation, open interest, stale account, pending obligation, barrier, or loss state. It only clears terminal residue where budget == spent and source.spent == source.provider_receivable == bucket.consumed with no live backing amounts.

## Validation
- cargo test v16_terminal_spent_domain -- --nocapture
- cargo test v16_flat_source_claim_conversion_does_not_require_live_risk_cert -- --nocapture

Wrapper PR aeyakovenko/percolator-prog#191 pins to fb64ac40742803446c602c00d7dda38addb6af18 and proves the full public LiteSVM flow.
