### PR TITLE
Skip Recovery legs in auto-crank selection

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -11607,8 +11607,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         );
         let ledger = account.header.close_progress.try_to_runtime()?;
 
-        let has_open_risk =
-            !active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get));
+        let (_, dispatchable_active_asset) = self.auto_crank_selected_assets(account)?;
+        let has_open_risk = dispatchable_active_asset.is_some();
         // A close ledger with residual_remaining==0 is already fully booked/covered
         // (e.g. insurance absorbed the loss); only OUTSTANDING residual is real,
         // actionable close work. The `active` flag can linger past that.
@@ -11676,20 +11676,30 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     /// ENGINE asset self-selection (engine.md): scan the account's bounded legs and
     /// return, for each asset-scoped continuation, the engine-chosen asset_index —
     /// the FIRST active b-stale leg's asset (SettleBChunk), and the FIRST active
-    /// leg's asset (used for both Liquidate and the refresh accrual target). The
+    /// leg whose asset is currently accrual/reduction-dispatchable (Active or
+    /// DrainOnly, used for both Liquidate and the refresh accrual target). Recovery
+    /// legs remain refreshable as part of the account scan, but cannot be selected
+    /// as the action asset because both accrual and liquidation reject them. The
     /// selection is proven in-range / actionable / first-match / complete by the
-    /// first_actionable_slot contract; the slot->asset_index read is by inspection.
+    /// first_actionable_slot contract; the slot->asset_index and lifecycle filter
+    /// are bound to production state here.
     fn auto_crank_selected_assets(
+        &self,
         account: &PortfolioV16View<'_>,
     ) -> V16Result<(Option<usize>, Option<usize>)> {
         let bitmap = account.header.active_bitmap.map(V16PodU64::get);
-        let mut active_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+        let mut dispatchable_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut b_stale_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
             let active = active_bitmap_get(bitmap, slot) && leg.active;
-            active_flags[slot] = active;
+            if active {
+                dispatchable_flags[slot] = matches!(
+                    self.asset_state(leg.asset_index as usize)?.lifecycle,
+                    AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
+                );
+            }
             b_stale_flags[slot] = active && leg.b_stale;
             slot += 1;
         }
@@ -11702,7 +11712,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
         };
         let b_stale_asset = asset_of(V16Core::first_actionable_slot(b_stale_flags))?;
-        let active_asset = asset_of(V16Core::first_actionable_slot(active_flags))?;
+        let active_asset = asset_of(V16Core::first_actionable_slot(dispatchable_flags))?;
         Ok((b_stale_asset, active_asset))
     }
 
@@ -11737,7 +11747,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         work: AutoCrankWorkV16<'_>,
     ) -> V16Result<AutoCrankResultV16> {
         let summary = self.build_actionable_summary(&account.as_view())?;
-        let (b_stale_asset, active_asset) = Self::auto_crank_selected_assets(&account.as_view())?;
+        let (b_stale_asset, active_asset) = self.auto_crank_selected_assets(&account.as_view())?;
         let recovery_reason = if summary.expired_close {
             PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
         } else {

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1532,6 +1532,16 @@ impl V16Core {
         None
     }
 
+    /// PRODUCTION KERNEL: ordinary refresh accrual and liquidation can target
+    /// only a live or draining asset. Recovery legs remain account obligations,
+    /// but selecting one as the action asset would deterministically fail.
+    fn kernel_auto_crank_lifecycle_dispatchable(lifecycle: AssetLifecycleV16) -> bool {
+        matches!(
+            lifecycle,
+            AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
+        )
+    }
+
     /// PRODUCTION KERNEL (engine.md selection semantics): from the actionable
     /// summary and the ENGINE-selected assets, choose the single highest-priority
     /// bounded plan, carrying the engine-chosen asset (the caller chooses neither
@@ -11695,9 +11705,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             let leg = account.header.legs[slot].try_to_runtime()?;
             let active = active_bitmap_get(bitmap, slot) && leg.active;
             if active {
-                dispatchable_flags[slot] = matches!(
+                dispatchable_flags[slot] = V16Core::kernel_auto_crank_lifecycle_dispatchable(
                     self.asset_state(leg.asset_index as usize)?.lifecycle,
-                    AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
                 );
             }
             b_stale_flags[slot] = active && leg.b_stale;

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -9,6 +9,30 @@
 use super::*;
 use crate::wide_math::U256;
 
+pub fn kani_auto_crank_lifecycle_dispatchable(lifecycle: AssetLifecycleV16) -> bool {
+    V16Core::kernel_auto_crank_lifecycle_dispatchable(lifecycle)
+}
+
+pub fn kani_first_actionable_slot(flags: [bool; V16_MAX_PORTFOLIO_ASSETS_N]) -> Option<usize> {
+    V16Core::first_actionable_slot(flags)
+}
+
+pub fn kani_select_auto_crank_plan(
+    summary: ActionableSummaryV16,
+    b_stale_slot: usize,
+    liq_slot: usize,
+    refresh_asset: Option<usize>,
+    recovery_reason: PermissionlessRecoveryReasonV16,
+) -> AutoCrankPlanV16 {
+    V16Core::select_auto_crank_plan(
+        summary,
+        b_stale_slot,
+        liq_slot,
+        refresh_asset,
+        recovery_reason,
+    )
+}
+
 pub fn kani_apply_backing_utilization_fee_charge(
     account_capital: u128,
     group_c_tot: u128,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -5,20 +5,21 @@ use percolator::v16::{
     backing_domain_fee_split_for_lien_delta_num, kani_active_bitmap_set as active_bitmap_set,
     kani_add_open_interest_for_new_position, kani_apply_backing_provider_earnings_withdraw,
     kani_apply_backing_utilization_fee_charge, kani_apply_resolved_payout_receipt_payment,
-    kani_available_backing_num_for_source_credit_state,
+    kani_auto_crank_lifecycle_dispatchable, kani_available_backing_num_for_source_credit_state,
     kani_backing_utilization_fee_quote_atoms_for_lien,
     kani_backing_utilization_rate_e9_for_source_state, kani_cert_is_current,
-    kani_expected_source_credit_rate_num_for_state, kani_health_cert_after_capital_debit,
-    kani_health_requirements_from_base_and_target_lag,
+    kani_expected_source_credit_rate_num_for_state, kani_first_actionable_slot,
+    kani_health_cert_after_capital_debit, kani_health_requirements_from_base_and_target_lag,
     kani_liquidation_close_would_leave_uncovered_loss_with_open_risk,
     kani_liquidation_engine_close_request_q, kani_liquidation_fee_from_raw_fee,
     kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
     kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
-    kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
-    kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
-    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
-    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
+    kani_prepare_asset_recovery_transition, kani_select_auto_crank_plan,
+    kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
+    kani_trade_preexisting_oi_reduction_gate, kani_trade_preflight_risk_gate,
+    kani_validate_positive_pnl_source_attribution, ActionableSummaryV16, AssetLifecycleV16,
+    AssetStateV16, AssetStateV16Account, AutoCrankPlanV16, BackingBucketStatusV16,
     BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
     CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
     HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
@@ -15401,4 +15402,147 @@ fn proof_v16_backing_utilization_zero_fee_carries_accrual_forward() {
     assert_eq!(market.header.c_tot.get(), c_tot_before);
     assert_eq!(market.header.vault.get(), vault_before);
     assert_eq!(market.header.insurance.get(), insurance_before);
+}
+
+// Permissionless mixed-lifecycle liveness theorem. Symbolic masks cover every
+// ordering and multiplicity across the full 16-leg account shape. Recovery
+// obligations must never be selected as ordinary refresh/liquidation targets;
+// when any Active or DrainOnly leg exists, first-match selection and both plans
+// must carry a dispatchable leg. Recovery-only portfolios advertise no fake
+// liquidation target.
+#[kani::proof]
+#[kani::unwind(18)]
+#[kani::solver(cadical)]
+fn proof_v16_recovery_legs_cannot_starve_dispatchable_auto_crank_work() {
+    let recovery_mask: u16 = kani::any();
+    let active_mask: u16 = kani::any();
+    let drain_only_mask: u16 = kani::any();
+    kani::assume(recovery_mask != 0);
+    kani::assume(recovery_mask & active_mask == 0);
+    kani::assume(recovery_mask & drain_only_mask == 0);
+    kani::assume(active_mask & drain_only_mask == 0);
+
+    let dispatchable_mask = active_mask | drain_only_mask;
+    let mut dispatchable_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+    let mut slot = 0usize;
+    while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+        let bit = 1u16 << slot;
+        let lifecycle = if recovery_mask & bit != 0 {
+            AssetLifecycleV16::Recovery
+        } else if active_mask & bit != 0 {
+            AssetLifecycleV16::Active
+        } else if drain_only_mask & bit != 0 {
+            AssetLifecycleV16::DrainOnly
+        } else {
+            AssetLifecycleV16::Retired
+        };
+        let dispatchable = kani_auto_crank_lifecycle_dispatchable(lifecycle);
+        assert_eq!(dispatchable, dispatchable_mask & bit != 0);
+        dispatchable_flags[slot] = dispatchable;
+        slot += 1;
+    }
+
+    let selected = kani_first_actionable_slot(dispatchable_flags);
+    let mut recovery_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+    slot = 0;
+    while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+        recovery_flags[slot] = recovery_mask & (1u16 << slot) != 0;
+        slot += 1;
+    }
+    let first_recovery = kani_first_actionable_slot(recovery_flags).unwrap();
+
+    if dispatchable_mask == 0 {
+        assert!(selected.is_none());
+        let plan = kani_select_auto_crank_plan(
+            ActionableSummaryV16 {
+                stale: false,
+                b_stale: false,
+                pending_close: false,
+                expired_close: false,
+                liquidatable: false,
+                recovery_eligible: false,
+                resolved_winner: false,
+            },
+            0,
+            0,
+            None,
+            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+        );
+        assert_eq!(plan, AutoCrankPlanV16::NoAction);
+    } else {
+        let selected = selected.unwrap();
+        let selected_bit = 1u16 << selected;
+        assert!(dispatchable_mask & selected_bit != 0);
+        assert!(recovery_mask & selected_bit == 0);
+        slot = 0;
+        while slot < selected {
+            assert!(dispatchable_mask & (1u16 << slot) == 0);
+            slot += 1;
+        }
+
+        let refresh = kani_select_auto_crank_plan(
+            ActionableSummaryV16 {
+                stale: true,
+                b_stale: false,
+                pending_close: false,
+                expired_close: false,
+                liquidatable: false,
+                recovery_eligible: false,
+                resolved_winner: false,
+            },
+            0,
+            selected,
+            Some(selected),
+            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+        );
+        assert_eq!(
+            refresh,
+            AutoCrankPlanV16::RefreshAccount {
+                asset_index: Some(selected)
+            }
+        );
+        let liquidate = kani_select_auto_crank_plan(
+            ActionableSummaryV16 {
+                stale: false,
+                b_stale: false,
+                pending_close: false,
+                expired_close: false,
+                liquidatable: true,
+                recovery_eligible: false,
+                resolved_winner: false,
+            },
+            0,
+            selected,
+            Some(selected),
+            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+        );
+        assert_eq!(
+            liquidate,
+            AutoCrankPlanV16::Liquidate {
+                asset_index: selected
+            }
+        );
+
+        kani::cover!(
+            first_recovery < selected,
+            "Recovery obligation can precede dispatchable work"
+        );
+        kani::cover!(
+            selected < first_recovery,
+            "dispatchable work can precede Recovery obligation"
+        );
+        kani::cover!(
+            active_mask & selected_bit != 0,
+            "Active candidate is selected"
+        );
+        kani::cover!(
+            drain_only_mask & selected_bit != 0,
+            "DrainOnly candidate is selected"
+        );
+    }
+
+    kani::cover!(
+        dispatchable_mask == 0,
+        "Recovery-only account has no fake liquidation target"
+    );
 }

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3030,6 +3030,113 @@ fn v16_auto_crank_classifies_fresh_account_stale_then_refreshes_to_clean() {
     account.validate_with_market(&market.as_view()).unwrap();
 }
 
+#[test]
+fn v16_auto_crank_skips_recovery_first_leg_for_live_refresh() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut account_header = account_fixture(2, 22);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut account_header);
+        market.deposit_not_atomic(&mut account, 1_000).unwrap();
+    }
+
+    header.current_slot = V16PodU64::new(10);
+    header.slot_last = V16PodU64::new(10);
+    let mut asset0 = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset0.lifecycle = AssetLifecycleV16::Recovery;
+    asset0.slot_last = 10;
+    asset0.oi_eff_long_q = POS_SCALE;
+    asset0.oi_eff_short_q = POS_SCALE;
+    asset0.loss_weight_sum_long = POS_SCALE;
+    asset0.loss_weight_sum_short = POS_SCALE;
+    asset0.stored_pos_count_long = 1;
+    asset0.stored_pos_count_short = 1;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset0);
+
+    let mut asset1 = markets[1].engine.asset.try_to_runtime().unwrap();
+    asset1.slot_last = 10;
+    asset1.oi_eff_long_q = POS_SCALE;
+    asset1.oi_eff_short_q = POS_SCALE;
+    asset1.loss_weight_sum_long = POS_SCALE;
+    asset1.loss_weight_sum_short = POS_SCALE;
+    asset1.stored_pos_count_long = 1;
+    asset1.stored_pos_count_short = 1;
+    markets[1].engine.asset = AssetStateV16Account::from_runtime(&asset1);
+    header.resolved_payout_blocker_count = V16PodU64::new(4);
+
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset0.market_id,
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset0.k_long,
+        f_snap: asset0.f_long_num,
+        epoch_snap: asset0.epoch_long,
+        loss_weight: POS_SCALE,
+        b_snap: asset0.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset0.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.legs[1] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 1,
+        market_id: asset1.market_id,
+        side: SideV16::Short,
+        basis_pos_q: -(POS_SCALE as i128),
+        a_basis: ADL_ONE,
+        k_snap: asset1.k_short,
+        f_snap: asset1.f_short_num,
+        epoch_snap: asset1.epoch_short,
+        loss_weight: POS_SCALE,
+        b_snap: asset1.b_short_num,
+        b_rem: 0,
+        b_epoch_snap: asset1.epoch_short,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(3);
+
+    let obs = [AutoCrankObservationV16 {
+        asset_index: 1,
+        effective_price: 100,
+        funding_rate_e9: 0,
+    }];
+    let work = AutoCrankWorkV16 {
+        now_slot: 10,
+        observations: &obs,
+        liquidation_max_close_q: POS_SCALE,
+        resolved_close_fee_rate_per_slot: 0,
+    };
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    assert!(
+        market
+            .build_actionable_summary(&account.as_view())
+            .unwrap()
+            .stale
+    );
+
+    let result = market
+        .permissionless_auto_crank_not_atomic(&mut account, work)
+        .expect("a Recovery first leg must not block the live asset refresh");
+    assert_eq!(
+        result.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(1),
+        },
+    );
+    assert_eq!(
+        result.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent),
+    );
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
 // ROADMAP 3C step 4 / NB2 finite-multi-step liveness via the self-classifying
 // crank: an uncertified, underwater account must be driven to a de-risked fixed
 // point by repeated auto-cranks — the classifier ESCALATES (stale -> refresh,

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3108,7 +3108,6 @@ fn v16_auto_crank_skips_recovery_first_leg_for_live_refresh() {
     let work = AutoCrankWorkV16 {
         now_slot: 10,
         observations: &obs,
-        liquidation_max_close_q: POS_SCALE,
         resolved_close_fee_rate_per_slot: 0,
     };
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);


### PR DESCRIPTION
## Finding

The self-classifying crank selected the first active portfolio leg without checking the selected asset's lifecycle. In a mixed portfolio where the first leg's asset was in `Recovery` and a later leg remained live, refresh and liquidation repeatedly selected the Recovery asset and returned `LockActive`.

## Fix

Ordinary refresh accrual and liquidation now select the first leg whose asset is `Active` or `DrainOnly`. Recovery legs remain account obligations and remain eligible for B-stale settlement, but are not selected for operations that reject Recovery assets. Recovery-only portfolios no longer advertise an impossible liquidation target.

## Broad proof

`proof_v16_recovery_legs_cannot_starve_dispatchable_auto_crank_work` symbolically partitions the full 16-leg account shape into disjoint Recovery, Active, DrainOnly, and inert masks. Across every ordering and multiplicity it proves:

- selected refresh/liquidation work is always Active or DrainOnly
- no Recovery leg can starve a later dispatchable leg
- first-match selection is deterministic
- Active and DrainOnly plans carry the exact selected asset
- Recovery-only portfolios expose no fake liquidation continuation

Result: 199 checks passed, 5/5 covers, 0.60s. Covers include Recovery before and after live work, Active and DrainOnly selection, and Recovery-only portfolios.

Mutation sensitivity: making Recovery lifecycle dispatchable fails the theorem at the lifecycle-equivalence assertion.

The production-state regression `v16_auto_crank_skips_recovery_first_leg_for_live_refresh` binds the symbolic kernel result to the persisted public auto-crank path.

## Validation

- `cargo test`: 50 unit + 9 backing fuzz + 2 resolved fuzz + 62 v16 spec tests
- `cargo fmt --all -- --check`
- `git diff --check`