### PR TITLE
[HARDENING] Make prior-reset auto-crank obligations progress

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -11675,6 +11675,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         &self,
         account: &PortfolioV16View<'_>,
     ) -> V16Result<ActionableSummaryV16> {
+        Ok(self
+            .build_actionable_summary_and_selected_assets(account)?
+            .0)
+    }
+
+    fn build_actionable_summary_and_selected_assets(
+        &self,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<(
+        ActionableSummaryV16,
+        (Option<usize>, Option<usize>, Option<usize>, Option<usize>),
+    )> {
         let mode = decode_market_mode(self.header.mode)?;
         let live = mode == MarketModeV16::Live;
         let resolved = mode == MarketModeV16::Resolved;
@@ -11690,8 +11702,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         );
         let ledger = account.header.close_progress.try_to_runtime()?;
 
-        let (_, _, liquidatable_asset, reset_obligation_asset) =
-            self.auto_crank_selected_assets(account)?;
+        let selected_assets = self.auto_crank_selected_assets(account)?;
+        let liquidatable_asset = selected_assets.2;
+        let reset_obligation_asset = selected_assets.3;
         let has_open_risk = liquidatable_asset.is_some();
         // A close ledger with residual_remaining==0 is already fully booked/covered
         // (e.g. insurance absorbed the loss); only OUTSTANDING residual is real,
@@ -11744,14 +11757,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let resolved_winner =
             resolved && account.header.pnl.get() > 0 && self.resolved_positive_payout_ready()?;
 
-        Ok(V16Core::actionable_summary_from_signals(
-            stale,
-            b_stale,
-            pending_close,
-            expired_close,
-            liquidatable,
-            recovery_eligible,
-            resolved_winner,
+        Ok((
+            V16Core::actionable_summary_from_signals(
+                stale,
+                b_stale,
+                pending_close,
+                expired_close,
+                liquidatable,
+                recovery_eligible,
+                resolved_winner,
+            ),
+            selected_assets,
         ))
     }
 
@@ -11871,9 +11887,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
         work: AutoCrankWorkV16<'_>,
     ) -> V16Result<AutoCrankResultV16> {
-        let summary = self.build_actionable_summary(&account.as_view())?;
-        let (b_stale_asset, refresh_asset, liquidatable_asset, _) =
-            self.auto_crank_selected_assets(&account.as_view())?;
+        let (summary, (b_stale_asset, refresh_asset, liquidatable_asset, _)) =
+            self.build_actionable_summary_and_selected_assets(&account.as_view())?;
         let recovery_reason = if summary.expired_close {
             PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
         } else {

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1542,6 +1542,52 @@ impl V16Core {
         )
     }
 
+    fn kernel_is_prior_reset_obligation(
+        side_mode: SideModeV16,
+        asset_epoch: u64,
+        leg_epoch_snap: u64,
+    ) -> bool {
+        side_mode == SideModeV16::ResetPending && leg_epoch_snap.checked_add(1) == Some(asset_epoch)
+    }
+
+    /// PRODUCTION KERNEL: classify one account leg for the bounded auto-crank
+    /// scans. A prior-reset obligation remains refreshable but can never be
+    /// dispatched as liquidation work because its effective OI was removed by
+    /// the reset.
+    fn kernel_auto_crank_leg_flags(
+        active: bool,
+        lifecycle: AssetLifecycleV16,
+        basis_pos_q: i128,
+        side_oi_q: u128,
+        side_mode: SideModeV16,
+        asset_epoch: u64,
+        leg_epoch_snap: u64,
+        leg_b_stale: bool,
+    ) -> (bool, bool, bool, bool) {
+        let lifecycle_dispatchable = Self::kernel_auto_crank_lifecycle_dispatchable(lifecycle);
+        let prior_reset_obligation =
+            Self::kernel_is_prior_reset_obligation(side_mode, asset_epoch, leg_epoch_snap);
+        let refresh = active && lifecycle_dispatchable;
+        let liquidatable = refresh && basis_pos_q != 0 && side_oi_q != 0 && !prior_reset_obligation;
+        (
+            active && leg_b_stale,
+            refresh,
+            liquidatable,
+            active && prior_reset_obligation,
+        )
+    }
+
+    /// PRODUCTION KERNEL: a refresh detaches at most one settled prior-reset
+    /// obligation. A pending close residual owns the account and blocks this
+    /// cleanup until its own continuation advances.
+    fn kernel_should_clear_prior_reset_obligation(
+        already_cleared: bool,
+        prior_reset_obligation: bool,
+        pending_close_residual: bool,
+    ) -> bool {
+        !already_cleared && prior_reset_obligation && !pending_close_residual
+    }
+
     /// PRODUCTION KERNEL (engine.md selection semantics): from the actionable
     /// summary and the ENGINE-selected assets, choose the single highest-priority
     /// bounded plan, carrying the engine-chosen asset (the caller chooses neither
@@ -10833,14 +10879,22 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             // K/F/B claims are settled above, detaching it is bookkeeping, not
             // a position close. Clear at most one per call to keep max-shape CU
             // bounded; the classifier keeps another obligation actionable.
-            if !reset_obligation_cleared
-                && Self::leg_is_prior_reset_obligation(asset, refreshed)
-                && !account
-                    .header
-                    .close_progress
-                    .try_to_runtime()?
-                    .has_pending_residual()
+            let should_clear_reset = if reset_obligation_cleared
+                || !Self::leg_is_prior_reset_obligation(asset, refreshed)
             {
+                false
+            } else {
+                V16Core::kernel_should_clear_prior_reset_obligation(
+                    false,
+                    true,
+                    account
+                        .header
+                        .close_progress
+                        .try_to_runtime()?
+                        .has_pending_residual(),
+                )
+            };
+            if should_clear_reset {
                 self.clear_leg(account, asset_index)?;
                 reset_obligation_cleared = true;
                 slot += 1;
@@ -11722,16 +11776,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     /// first_actionable_slot contract; the slot->asset_index and lifecycle filter
     /// are bound to production state here.
     fn leg_is_prior_reset_obligation(asset: AssetStateV16, leg: PortfolioLegV16) -> bool {
-        match leg.side {
-            SideV16::Long => {
-                asset.mode_long == SideModeV16::ResetPending
-                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_long)
-            }
-            SideV16::Short => {
-                asset.mode_short == SideModeV16::ResetPending
-                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_short)
-            }
-        }
+        let (side_mode, asset_epoch) = match leg.side {
+            SideV16::Long => (asset.mode_long, asset.epoch_long),
+            SideV16::Short => (asset.mode_short, asset.epoch_short),
+        };
+        V16Core::kernel_is_prior_reset_obligation(side_mode, asset_epoch, leg.epoch_snap)
     }
 
     fn auto_crank_selected_assets(
@@ -11749,23 +11798,26 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             let active = active_bitmap_get(bitmap, slot) && leg.active;
             if active {
                 let asset = self.asset_state(leg.asset_index as usize)?;
-                let lifecycle_dispatchable = matches!(
-                    asset.lifecycle,
-                    AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
-                );
-                refresh_flags[slot] = lifecycle_dispatchable;
-                let side_oi = match leg.side {
-                    SideV16::Long => asset.oi_eff_long_q,
-                    SideV16::Short => asset.oi_eff_short_q,
+                let (side_oi, side_mode, asset_epoch) = match leg.side {
+                    SideV16::Long => (asset.oi_eff_long_q, asset.mode_long, asset.epoch_long),
+                    SideV16::Short => (asset.oi_eff_short_q, asset.mode_short, asset.epoch_short),
                 };
-                let prior_reset_obligation = Self::leg_is_prior_reset_obligation(asset, leg);
-                reset_obligation_flags[slot] = prior_reset_obligation;
-                liquidation_flags[slot] = lifecycle_dispatchable
-                    && leg.basis_pos_q != 0
-                    && side_oi != 0
-                    && !prior_reset_obligation;
+                let (b_stale, refresh, liquidatable, reset_obligation) =
+                    V16Core::kernel_auto_crank_leg_flags(
+                        true,
+                        asset.lifecycle,
+                        leg.basis_pos_q,
+                        side_oi,
+                        side_mode,
+                        asset_epoch,
+                        leg.epoch_snap,
+                        leg.b_stale,
+                    );
+                b_stale_flags[slot] = b_stale;
+                refresh_flags[slot] = refresh;
+                liquidation_flags[slot] = liquidatable;
+                reset_obligation_flags[slot] = reset_obligation;
             }
-            b_stale_flags[slot] = active && leg.b_stale;
             slot += 1;
         }
         let asset_of = |s: Option<usize>| -> V16Result<Option<usize>> {

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -10752,6 +10752,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let bitmap = account.header.active_bitmap.map(V16PodU64::get);
         let mut seen_assets = [u32::MAX; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut seen_asset_count = 0usize;
+        let mut reset_obligation_cleared = false;
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
@@ -10827,6 +10828,23 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     ));
                 }
                 return Err(V16Error::BStale);
+            }
+            // A prior-reset leg no longer owns effective OI. Once its terminal
+            // K/F/B claims are settled above, detaching it is bookkeeping, not
+            // a position close. Clear at most one per call to keep max-shape CU
+            // bounded; the classifier keeps another obligation actionable.
+            if !reset_obligation_cleared
+                && Self::leg_is_prior_reset_obligation(asset, refreshed)
+                && !account
+                    .header
+                    .close_progress
+                    .try_to_runtime()?
+                    .has_pending_residual()
+            {
+                self.clear_leg(account, asset_index)?;
+                reset_obligation_cleared = true;
+                slot += 1;
+                continue;
             }
             let price = if let Some((override_asset, override_price)) = price_override {
                 if override_asset == asset_index {
@@ -11587,7 +11605,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     /// state to the ActionableState summary the self-classifying crank dispatches
     /// from. Each flag is exactly its production eligibility predicate, MODE-
     /// GATED so every flag that can be set has a currently-valid dispatch target:
-    ///   stale            — Live, health cert not current (kernel_cert_is_current==false)
+    ///   stale            — Live, health cert not current or a settled prior-reset
+    ///                      obligation still needs permissionless detachment
     ///   b_stale          — Live, some active leg flagged b-stale (has_b_stale_leg)
     ///   pending_close    — Live, a close-progress ledger is active
     ///   expired_close    — Live, that ledger is past its max-close slot
@@ -11617,13 +11636,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         );
         let ledger = account.header.close_progress.try_to_runtime()?;
 
-        let (_, dispatchable_active_asset) = self.auto_crank_selected_assets(account)?;
-        let has_open_risk = dispatchable_active_asset.is_some();
+        let (_, _, liquidatable_asset, reset_obligation_asset) =
+            self.auto_crank_selected_assets(account)?;
+        let has_open_risk = liquidatable_asset.is_some();
         // A close ledger with residual_remaining==0 is already fully booked/covered
         // (e.g. insurance absorbed the loss); only OUTSTANDING residual is real,
         // actionable close work. The `active` flag can linger past that.
         let close_outstanding = ledger.active && ledger.residual_remaining > 0;
-        let stale = live && !cert_current;
+        let stale = live && (!cert_current || reset_obligation_asset.is_some());
         let b_stale = live && Self::has_b_stale_leg(account)?;
         // pending_close is NOT proactively classified: the close-ledger residual is
         // booked ONLY inside the liquidation/resolved path that owns it
@@ -11638,11 +11658,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // Expired outstanding close -> terminal recovery (Recover needs no leg).
         let expired_close =
             live && close_outstanding && self.header.current_slot.get() > ledger.max_close_slot;
-        // liquidatable requires a current certified deficit AND actual open risk:
+        // liquidatable requires a current certified deficit AND actual open risk.
+        // Prior-reset obligations are settled/detached first through Refresh so
+        // they cannot block side finalization or poison liquidation dispatch:
         // a stale cert can still report a deficit after the position was already
         // closed, but with no active leg there is nothing to liquidate (the real
         // liquidate entrypoint requires an active leg), so the flag must be false.
-        let liquidatable = live && cert_current && cert.certified_liq_deficit != 0 && has_open_risk;
+        let liquidatable = live
+            && cert_current
+            && cert.certified_liq_deficit != 0
+            && has_open_risk
+            && reset_obligation_asset.is_none();
         // Permissionless recovery (declare_permissionless_recovery) is a LIVE-mode
         // action — it rejects Resolved mode with LockActive. The proactive Live
         // recovery condition the auto-crank declares is an EXPIRED outstanding
@@ -11685,29 +11711,59 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     /// dispatch target is valid in the mode that the classifier gated its flag to.
     /// ENGINE asset self-selection (engine.md): scan the account's bounded legs and
     /// return, for each asset-scoped continuation, the engine-chosen asset_index —
-    /// the FIRST active b-stale leg's asset (SettleBChunk), and the FIRST active
-    /// leg whose asset is currently accrual/reduction-dispatchable (Active or
-    /// DrainOnly, used for both Liquidate and the refresh accrual target). Recovery
-    /// legs remain refreshable as part of the account scan, but cannot be selected
-    /// as the action asset because both accrual and liquidation reject them. The
+    /// the FIRST active b-stale leg's asset (SettleBChunk), the FIRST active leg
+    /// whose asset is accrual-dispatchable (refresh), and the FIRST live-reducible
+    /// leg (liquidation). A prior-epoch ResetPending leg is still refreshable, but
+    /// its effective OI was already removed by ADL; selecting it for liquidation
+    /// would fail before a later current-epoch leg could make progress. Recovery
+    /// legs cannot be selected for refresh or liquidation because both reject
+    /// their lifecycle. The
     /// selection is proven in-range / actionable / first-match / complete by the
     /// first_actionable_slot contract; the slot->asset_index and lifecycle filter
     /// are bound to production state here.
+    fn leg_is_prior_reset_obligation(asset: AssetStateV16, leg: PortfolioLegV16) -> bool {
+        match leg.side {
+            SideV16::Long => {
+                asset.mode_long == SideModeV16::ResetPending
+                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_long)
+            }
+            SideV16::Short => {
+                asset.mode_short == SideModeV16::ResetPending
+                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_short)
+            }
+        }
+    }
+
     fn auto_crank_selected_assets(
         &self,
         account: &PortfolioV16View<'_>,
-    ) -> V16Result<(Option<usize>, Option<usize>)> {
+    ) -> V16Result<(Option<usize>, Option<usize>, Option<usize>, Option<usize>)> {
         let bitmap = account.header.active_bitmap.map(V16PodU64::get);
-        let mut dispatchable_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+        let mut refresh_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+        let mut liquidation_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+        let mut reset_obligation_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut b_stale_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
             let active = active_bitmap_get(bitmap, slot) && leg.active;
             if active {
-                dispatchable_flags[slot] = V16Core::kernel_auto_crank_lifecycle_dispatchable(
-                    self.asset_state(leg.asset_index as usize)?.lifecycle,
+                let asset = self.asset_state(leg.asset_index as usize)?;
+                let lifecycle_dispatchable = matches!(
+                    asset.lifecycle,
+                    AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
                 );
+                refresh_flags[slot] = lifecycle_dispatchable;
+                let side_oi = match leg.side {
+                    SideV16::Long => asset.oi_eff_long_q,
+                    SideV16::Short => asset.oi_eff_short_q,
+                };
+                let prior_reset_obligation = Self::leg_is_prior_reset_obligation(asset, leg);
+                reset_obligation_flags[slot] = prior_reset_obligation;
+                liquidation_flags[slot] = lifecycle_dispatchable
+                    && leg.basis_pos_q != 0
+                    && side_oi != 0
+                    && !prior_reset_obligation;
             }
             b_stale_flags[slot] = active && leg.b_stale;
             slot += 1;
@@ -11721,8 +11777,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
         };
         let b_stale_asset = asset_of(V16Core::first_actionable_slot(b_stale_flags))?;
-        let active_asset = asset_of(V16Core::first_actionable_slot(dispatchable_flags))?;
-        Ok((b_stale_asset, active_asset))
+        let refresh_asset = asset_of(V16Core::first_actionable_slot(refresh_flags))?;
+        let liquidatable_asset = asset_of(V16Core::first_actionable_slot(liquidation_flags))?;
+        let reset_obligation_asset =
+            asset_of(V16Core::first_actionable_slot(reset_obligation_flags))?;
+        Ok((
+            b_stale_asset,
+            refresh_asset,
+            liquidatable_asset,
+            reset_obligation_asset,
+        ))
     }
 
     /// THE SINGLE PUBLIC PERMISSIONLESS CRANK (engine.md): the only crank the
@@ -11756,7 +11820,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         work: AutoCrankWorkV16<'_>,
     ) -> V16Result<AutoCrankResultV16> {
         let summary = self.build_actionable_summary(&account.as_view())?;
-        let (b_stale_asset, active_asset) = self.auto_crank_selected_assets(&account.as_view())?;
+        let (b_stale_asset, refresh_asset, liquidatable_asset, _) =
+            self.auto_crank_selected_assets(&account.as_view())?;
         let recovery_reason = if summary.expired_close {
             PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
         } else {
@@ -11767,8 +11832,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let plan = V16Core::select_auto_crank_plan(
             summary,
             b_stale_asset.unwrap_or(0),
-            active_asset.unwrap_or(0),
-            active_asset,
+            liquidatable_asset.unwrap_or(0),
+            refresh_asset,
             recovery_reason,
         );
 

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -13,6 +13,40 @@ pub fn kani_auto_crank_lifecycle_dispatchable(lifecycle: AssetLifecycleV16) -> b
     V16Core::kernel_auto_crank_lifecycle_dispatchable(lifecycle)
 }
 
+pub fn kani_auto_crank_leg_flags(
+    active: bool,
+    lifecycle: AssetLifecycleV16,
+    basis_pos_q: i128,
+    side_oi_q: u128,
+    side_mode: SideModeV16,
+    asset_epoch: u64,
+    leg_epoch_snap: u64,
+    leg_b_stale: bool,
+) -> (bool, bool, bool, bool) {
+    V16Core::kernel_auto_crank_leg_flags(
+        active,
+        lifecycle,
+        basis_pos_q,
+        side_oi_q,
+        side_mode,
+        asset_epoch,
+        leg_epoch_snap,
+        leg_b_stale,
+    )
+}
+
+pub fn kani_should_clear_prior_reset_obligation(
+    already_cleared: bool,
+    prior_reset_obligation: bool,
+    pending_close_residual: bool,
+) -> bool {
+    V16Core::kernel_should_clear_prior_reset_obligation(
+        already_cleared,
+        prior_reset_obligation,
+        pending_close_residual,
+    )
+}
+
 pub fn kani_first_actionable_slot(flags: [bool; V16_MAX_PORTFOLIO_ASSETS_N]) -> Option<usize> {
     V16Core::first_actionable_slot(flags)
 }

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -5,7 +5,8 @@ use percolator::v16::{
     backing_domain_fee_split_for_lien_delta_num, kani_active_bitmap_set as active_bitmap_set,
     kani_add_open_interest_for_new_position, kani_apply_backing_provider_earnings_withdraw,
     kani_apply_backing_utilization_fee_charge, kani_apply_resolved_payout_receipt_payment,
-    kani_auto_crank_lifecycle_dispatchable, kani_available_backing_num_for_source_credit_state,
+    kani_auto_crank_leg_flags, kani_auto_crank_lifecycle_dispatchable,
+    kani_available_backing_num_for_source_credit_state,
     kani_backing_utilization_fee_quote_atoms_for_lien,
     kani_backing_utilization_rate_e9_for_source_state, kani_cert_is_current,
     kani_expected_source_credit_rate_num_for_state, kani_first_actionable_slot,
@@ -16,18 +17,18 @@ use percolator::v16::{
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
     kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
     kani_prepare_asset_recovery_transition, kani_select_auto_crank_plan,
-    kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
-    kani_trade_preexisting_oi_reduction_gate, kani_trade_preflight_risk_gate,
-    kani_validate_positive_pnl_source_attribution, ActionableSummaryV16, AssetLifecycleV16,
-    AssetStateV16, AssetStateV16Account, AutoCrankPlanV16, BackingBucketStatusV16,
-    BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
-    CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
-    HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
-    Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
-    PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
-    PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
-    PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
-    ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedCloseOutcomeV16,
+    kani_should_clear_prior_reset_obligation, kani_source_credit_state_realizable_support_for_face,
+    kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
+    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
+    ActionableSummaryV16, AssetLifecycleV16, AssetStateV16, AssetStateV16Account, AutoCrankPlanV16,
+    BackingBucketStatusV16, BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16,
+    CloseProgressLedgerV16, CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16,
+    HealthCertV16, HealthCertV16Account, InsuranceCreditReservationV16,
+    InsuranceCreditReservationV16Account, Market, MarketGroupV16HeaderAccount, MarketGroupV16View,
+    MarketGroupV16ViewMut, PermissionlessCrankActionV16, PermissionlessCrankRequestV16,
+    PermissionlessProgressOutcomeV16, PermissionlessRecoveryReasonV16, PortfolioAccountV16Account,
+    PortfolioLegV16, PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View,
+    PortfolioV16ViewMut, ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedCloseOutcomeV16,
     ResolvedPayoutLedgerV16, ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16,
     ResolvedPayoutReceiptV16Account, SideModeV16, SideV16, SourceCreditStateV16,
     SourceCreditStateV16Account, StockReconciliationProofV16, TokenValueClassV16,
@@ -41,7 +42,7 @@ use percolator::v16::{
     kani_eq_portfolio_account_v16_account,
 };
 use percolator::{
-    ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, MAX_ACCOUNT_NOTIONAL, MAX_MARGIN_BPS,
+    ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, MAX_ACCOUNT_NOTIONAL, MAX_MARGIN_BPS, MAX_OI_SIDE_Q,
     MAX_ORACLE_PRICE, MAX_POSITION_ABS_Q, MAX_TRADE_SIZE_Q, MAX_VAULT_TVL, POS_SCALE,
     SOCIAL_LOSS_DEN, V16_ACTIVE_BITMAP_WORDS,
 };
@@ -15545,4 +15546,185 @@ fn proof_v16_recovery_legs_cannot_starve_dispatchable_auto_crank_work() {
         dispatchable_mask == 0,
         "Recovery-only account has no fake liquidation target"
     );
+}
+
+// Permissionless liveness theorem for mixed prior-reset obligations and live
+// liquidation candidates. The two symbolic bitmasks cover every multiplicity
+// and ordering across the full production 16-leg account shape. Each refresh
+// removes exactly the first prior-reset obligation, so that rank reaches zero
+// within 16 calls; prior-reset legs are never selected as liquidation work, and
+// the first real live-risk leg is selected once cleanup completes.
+#[kani::proof]
+#[kani::unwind(18)]
+#[kani::solver(cadical)]
+fn proof_v16_prior_reset_cleanup_cannot_starve_live_liquidation() {
+    let reset_mask: u16 = kani::any();
+    let live_mask: u16 = kani::any();
+    let drain_only_mask: u16 = kani::any();
+    let basis_abs: u128 = kani::any();
+    let live_oi_q: u128 = kani::any();
+    let reset_epoch: u64 = kani::any();
+    let negative_basis: bool = kani::any();
+    kani::assume(reset_mask != 0);
+    kani::assume(live_mask != 0);
+    kani::assume(reset_mask & live_mask == 0);
+    kani::assume((1..=MAX_POSITION_ABS_Q).contains(&basis_abs));
+    kani::assume((1..=MAX_OI_SIDE_Q).contains(&live_oi_q));
+    kani::assume(reset_epoch > 0);
+
+    let basis_pos_q = if negative_basis {
+        -(basis_abs as i128)
+    } else {
+        basis_abs as i128
+    };
+    let mut reset_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+    let mut liquidation_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+    let mut refresh_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+    let mut slot = 0usize;
+    while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+        let bit = 1u16 << slot;
+        let is_reset = reset_mask & bit != 0;
+        let is_live = live_mask & bit != 0;
+        let active = is_reset || is_live;
+        let lifecycle = if drain_only_mask & bit != 0 {
+            AssetLifecycleV16::DrainOnly
+        } else {
+            AssetLifecycleV16::Active
+        };
+        let side_mode = if is_reset {
+            SideModeV16::ResetPending
+        } else {
+            SideModeV16::Normal
+        };
+        let asset_epoch = if is_reset { reset_epoch } else { 0 };
+        let leg_epoch_snap = if is_reset { reset_epoch - 1 } else { 0 };
+        let side_oi_q = if is_live { live_oi_q } else { 0 };
+        let (b_stale, refresh, liquidatable, reset_obligation) = kani_auto_crank_leg_flags(
+            active,
+            lifecycle,
+            basis_pos_q,
+            side_oi_q,
+            side_mode,
+            asset_epoch,
+            leg_epoch_snap,
+            false,
+        );
+
+        assert!(!b_stale);
+        assert_eq!(refresh, active);
+        assert_eq!(liquidatable, is_live);
+        assert_eq!(reset_obligation, is_reset);
+        assert!(!(liquidatable && reset_obligation));
+        refresh_flags[slot] = refresh;
+        liquidation_flags[slot] = liquidatable;
+        reset_flags[slot] = reset_obligation;
+        slot += 1;
+    }
+
+    let initial_reset_count = reset_mask.count_ones();
+    let first_reset = kani_first_actionable_slot(reset_flags).unwrap();
+    let first_live = kani_first_actionable_slot(liquidation_flags).unwrap();
+    kani::cover!(
+        initial_reset_count == 1,
+        "single reset obligation is reachable"
+    );
+    kani::cover!(
+        initial_reset_count > 1,
+        "multiple reset obligations are reachable"
+    );
+    kani::cover!(first_reset < first_live, "reset can precede live risk");
+    kani::cover!(first_live < first_reset, "live risk can precede reset");
+    kani::cover!(
+        drain_only_mask & (reset_mask | live_mask) != 0,
+        "DrainOnly legs share the bounded progress classification"
+    );
+
+    let mut calls = 0usize;
+    while calls < V16_MAX_PORTFOLIO_ASSETS_N {
+        let mut pre_reset_count = 0u32;
+        slot = 0;
+        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+            pre_reset_count += reset_flags[slot] as u32;
+            slot += 1;
+        }
+        if pre_reset_count != 0 {
+            let selected_reset = kani_first_actionable_slot(reset_flags).unwrap();
+            let refresh_asset = kani_first_actionable_slot(refresh_flags);
+            let plan = kani_select_auto_crank_plan(
+                ActionableSummaryV16 {
+                    stale: true,
+                    b_stale: false,
+                    pending_close: false,
+                    expired_close: false,
+                    liquidatable: false,
+                    recovery_eligible: false,
+                    resolved_winner: false,
+                },
+                0,
+                first_live,
+                refresh_asset,
+                PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+            );
+            assert_eq!(
+                plan,
+                AutoCrankPlanV16::RefreshAccount {
+                    asset_index: refresh_asset
+                }
+            );
+
+            let mut already_cleared = false;
+            slot = 0;
+            while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+                if kani_should_clear_prior_reset_obligation(
+                    already_cleared,
+                    reset_flags[slot],
+                    false,
+                ) {
+                    assert_eq!(slot, selected_reset);
+                    reset_flags[slot] = false;
+                    refresh_flags[slot] = false;
+                    already_cleared = true;
+                }
+                slot += 1;
+            }
+            assert!(already_cleared);
+
+            let mut post_reset_count = 0u32;
+            slot = 0;
+            while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+                post_reset_count += reset_flags[slot] as u32;
+                slot += 1;
+            }
+            assert_eq!(post_reset_count + 1, pre_reset_count);
+        }
+        calls += 1;
+    }
+
+    assert!(kani_first_actionable_slot(reset_flags).is_none());
+    let selected_live = kani_first_actionable_slot(liquidation_flags).unwrap();
+    assert_eq!(selected_live, first_live);
+    let final_plan = kani_select_auto_crank_plan(
+        ActionableSummaryV16 {
+            stale: false,
+            b_stale: false,
+            pending_close: false,
+            expired_close: false,
+            liquidatable: true,
+            recovery_eligible: false,
+            resolved_winner: false,
+        },
+        0,
+        selected_live,
+        kani_first_actionable_slot(refresh_flags),
+        PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+    );
+    assert_eq!(
+        final_plan,
+        AutoCrankPlanV16::Liquidate {
+            asset_index: first_live
+        }
+    );
+
+    assert!(!kani_should_clear_prior_reset_obligation(false, true, true));
+    assert!(!kani_should_clear_prior_reset_obligation(true, true, false));
 }

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3222,7 +3222,6 @@ fn v16_auto_crank_skips_prior_reset_obligation_for_live_liquidation() {
             AutoCrankWorkV16 {
                 now_slot: 10,
                 observations: &[],
-                liquidation_max_close_q: POS_SCALE,
                 resolved_close_fee_rate_per_slot: 0,
             },
         )
@@ -3243,7 +3242,6 @@ fn v16_auto_crank_skips_prior_reset_obligation_for_live_liquidation() {
             AutoCrankWorkV16 {
                 now_slot: 10,
                 observations: &[],
-                liquidation_max_close_q: POS_SCALE,
                 resolved_close_fee_rate_per_slot: 0,
             },
         )

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3136,6 +3136,127 @@ fn v16_auto_crank_skips_recovery_first_leg_for_live_refresh() {
     account.validate_with_market(&market.as_view()).unwrap();
 }
 
+#[test]
+fn v16_auto_crank_skips_prior_reset_obligation_for_live_liquidation() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut account_header = account_fixture(2, 23);
+    header.current_slot = V16PodU64::new(10);
+    header.slot_last = V16PodU64::new(10);
+
+    let mut asset0 = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset0.slot_last = 10;
+    asset0.epoch_long = 1;
+    asset0.mode_long = SideModeV16::ResetPending;
+    asset0.oi_eff_long_q = 0;
+    asset0.oi_eff_short_q = 0;
+    asset0.loss_weight_sum_long = 0;
+    asset0.loss_weight_sum_short = 0;
+    asset0.stored_pos_count_long = 1;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset0);
+
+    let mut asset1 = markets[1].engine.asset.try_to_runtime().unwrap();
+    asset1.slot_last = 10;
+    asset1.oi_eff_long_q = 2 * POS_SCALE;
+    asset1.oi_eff_short_q = 2 * POS_SCALE;
+    asset1.loss_weight_sum_long = 2 * POS_SCALE;
+    asset1.loss_weight_sum_short = 2 * POS_SCALE;
+    asset1.stored_pos_count_long = 2;
+    asset1.stored_pos_count_short = 2;
+    markets[1].engine.asset = AssetStateV16Account::from_runtime(&asset1);
+    header.resolved_payout_blocker_count = V16PodU64::new(5);
+
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset0.market_id,
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset0.k_epoch_start_long,
+        f_snap: asset0.f_epoch_start_long_num,
+        epoch_snap: 0,
+        loss_weight: POS_SCALE,
+        b_snap: asset0.b_epoch_start_long_num,
+        b_rem: 0,
+        b_epoch_snap: 0,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.legs[1] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 1,
+        market_id: asset1.market_id,
+        side: SideV16::Short,
+        basis_pos_q: -(POS_SCALE as i128),
+        a_basis: ADL_ONE,
+        k_snap: asset1.k_short,
+        f_snap: asset1.f_short_num,
+        epoch_snap: asset1.epoch_short,
+        loss_weight: POS_SCALE,
+        b_snap: asset1.b_short_num,
+        b_rem: 0,
+        b_epoch_snap: asset1.epoch_short,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(3);
+    account_header.health_cert = HealthCertV16Account::from_runtime(&HealthCertV16 {
+        certified_equity: 0,
+        certified_initial_req: 2,
+        certified_maintenance_req: 2,
+        certified_liq_deficit: 2,
+        certified_worst_case_loss: 200,
+        cert_oracle_epoch: header.oracle_epoch.get(),
+        cert_funding_epoch: header.funding_epoch.get(),
+        cert_risk_epoch: header.risk_epoch.get(),
+        cert_asset_set_epoch: header.asset_set_epoch.get(),
+        active_bitmap_at_cert: [3],
+        valid: true,
+    });
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let refresh = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &[],
+                liquidation_max_close_q: POS_SCALE,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the prior-reset first leg must be detached permissionlessly");
+
+    assert_eq!(
+        refresh.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    );
+    assert!(!account.header.legs[0].try_to_runtime().unwrap().active);
+    assert!(account.header.legs[1].try_to_runtime().unwrap().active);
+
+    let liquidation = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &[],
+                liquidation_max_close_q: POS_SCALE,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the next step must liquidate the remaining live asset");
+    assert_eq!(
+        liquidation.selected,
+        AutoCrankPlanV16::Liquidate { asset_index: 1 }
+    );
+    assert!(!account.header.legs[1].try_to_runtime().unwrap().active);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
 // ROADMAP 3C step 4 / NB2 finite-multi-step liveness via the self-classifying
 // crank: an uncertified, underwater account must be driven to a de-risked fixed
 // point by repeated auto-cranks — the classifier ESCALATES (stale -> refresh,


### PR DESCRIPTION
## Summary

- Make prior-reset obligations permissionlessly detachable without letting them starve a later live liquidation.
- Select refresh, liquidation, B-settlement, and reset-obligation assets from current engine state.
- Reuse that bounded leg selection during dispatch instead of scanning the portfolio twice.

## Public repro

Wrapper PR #201 constructs an account with an ADL-created prior-reset obligation before a separately liquidatable live leg. Before this change, every honest crank repeatedly selected the inert first leg and returned `EngineInvalidLeg`; the abandoned owner had to intervene before the live position could be liquidated.

The fixed route settles and detaches at most one prior-reset obligation per call, then exposes the later live liquidation to the next permissionless crank. Engine and wrapper calls remain one bounded action per transaction.

## CU integration correction

The first implementation scanned all bounded portfolio legs once while building the actionable summary and again before dispatch. Against current wrapper `main`, the existing issue-103 partial-liquidation crank rose from 295,076 CU to 328,570 CU and violated the 325,000-CU guard.

Commit `28a7338bd8c0dff7134ea0aa06404795bbb8557b` returns the already computed selections with the summary. The same public crank is now 318,594 CU and passes the existing guard without changing selection semantics.

## Validation

- `cargo test --all-targets`: 131 passed
- Kani `proof_v16_prior_reset_cleanup_cannot_starve_live_liquidation`: passed
- Kani `proof_v16_recovery_legs_cannot_starve_dispatchable_auto_crank_work`: passed
- paired wrapper aggregate: 6 unit + 568 serialized LiteSVM/CU tests passed
- existing issue-103 crank: 318,594 CU, below 325,000
- `cargo fmt --all -- --check`
- `git diff --check`

Head: `28a7338bd8c0dff7134ea0aa06404795bbb8557b`.
