### PR TITLE
[REAL DoS] Keep partially ADL-reduced positions exit-live

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -15552,6 +15552,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 if self.has_pending_domain_loss_barrier(asset_index, leg.side)? {
                     return Ok(());
                 }
+                let asset = self.asset_state(asset_index)?;
+                if Self::leg_has_exhausted_effective_oi(asset, leg) {
+                    // A legacy Live state may resolve before its next auto-crank.
+                    // Establish the same terminal reset epoch here so resolved
+                    // teardown does not subtract stored basis from zero OI.
+                    self.begin_full_drain_reset_inner(asset_index, leg.side)?;
+                }
                 let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;
                 if k_target != leg.k_snap || f_target != leg.f_snap {
                     return Ok(());

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -10825,7 +10825,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             if asset_index >= configured_assets || asset_index >= self.markets.len() {
                 return Err(V16Error::HiddenLeg);
             }
-            let asset = self.markets[asset_index].engine.asset.try_to_runtime()?;
+            let mut asset = self.markets[asset_index].engine.asset.try_to_runtime()?;
             if leg.market_id != asset.market_id
                 || !matches!(
                     asset.lifecycle,
@@ -10846,6 +10846,21 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
             seen_assets[seen_asset_count] = leg.asset_index;
             seen_asset_count += 1;
+            // Older states can contain a nonzero stored basis after ADL has
+            // exhausted the side's effective OI. Move that terminal residue
+            // behind the normal reset epoch before settling it; otherwise a
+            // clear would subtract stored basis from zero effective OI forever.
+            if Self::leg_has_exhausted_effective_oi(asset, leg)
+                && !account
+                    .header
+                    .close_progress
+                    .try_to_runtime()?
+                    .has_pending_residual()
+                && !self.has_pending_domain_loss_barrier(asset_index, leg.side)?
+            {
+                self.begin_full_drain_reset_inner(asset_index, leg.side)?;
+                asset = self.asset_state(asset_index)?;
+            }
             self.settle_leg_kf_effects_at_slot_with_asset(account, slot, asset)?;
             let mut refreshed = account.header.legs[slot].try_to_runtime()?;
             let target = Self::b_target_for_leg_from_asset(asset, refreshed)?;
@@ -10875,10 +10890,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 }
                 return Err(V16Error::BStale);
             }
-            // A prior-reset leg no longer owns effective OI. Once its terminal
-            // K/F/B claims are settled above, detaching it is bookkeeping, not
-            // a position close. Clear at most one per call to keep max-shape CU
-            // bounded; the classifier keeps another obligation actionable.
+            // A prior-reset leg no longer owns effective OI. This includes a
+            // legacy Normal-mode residue migrated into a reset above. Once its
+            // terminal K/F/B claims are settled, detaching it is bookkeeping,
+            // not a position close. Clear at most one per call to keep max-shape
+            // CU bounded; the classifier keeps another obligation actionable.
             let should_clear_reset = if reset_obligation_cleared
                 || !Self::leg_is_prior_reset_obligation(asset, refreshed)
             {
@@ -11767,11 +11783,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     /// return, for each asset-scoped continuation, the engine-chosen asset_index —
     /// the FIRST active b-stale leg's asset (SettleBChunk), the FIRST active leg
     /// whose asset is accrual-dispatchable (refresh), and the FIRST live-reducible
-    /// leg (liquidation). A prior-epoch ResetPending leg is still refreshable, but
-    /// its effective OI was already removed by ADL; selecting it for liquidation
-    /// would fail before a later current-epoch leg could make progress. Recovery
-    /// legs cannot be selected for refresh or liquidation because both reject
-    /// their lifecycle. The
+    /// leg with matched effective OI (liquidation). A prior-epoch ResetPending leg,
+    /// or a legacy stored-basis residue whose effective OI was exhausted by ADL,
+    /// is refreshable bookkeeping but not a liquidation candidate. Selecting one
+    /// for liquidation would fail before a later current-epoch leg could make
+    /// progress. Recovery legs cannot be selected for refresh or liquidation
+    /// because both reject their lifecycle. The
     /// selection is proven in-range / actionable / first-match / complete by the
     /// first_actionable_slot contract; the slot->asset_index and lifecycle filter
     /// are bound to production state here.
@@ -11781,6 +11798,43 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             SideV16::Short => (asset.mode_short, asset.epoch_short),
         };
         V16Core::kernel_is_prior_reset_obligation(side_mode, asset_epoch, leg.epoch_snap)
+    }
+
+    fn side_effective_oi(asset: AssetStateV16, side: SideV16) -> u128 {
+        match side {
+            SideV16::Long => asset.oi_eff_long_q,
+            SideV16::Short => asset.oi_eff_short_q,
+        }
+    }
+
+    fn side_stored_position_count(asset: AssetStateV16, side: SideV16) -> u64 {
+        match side {
+            SideV16::Long => asset.stored_pos_count_long,
+            SideV16::Short => asset.stored_pos_count_short,
+        }
+    }
+
+    fn side_pending_obligation_count(asset: AssetStateV16, side: SideV16) -> u64 {
+        match side {
+            SideV16::Long => asset.pending_obligation_count_long,
+            SideV16::Short => asset.pending_obligation_count_short,
+        }
+    }
+
+    fn side_mode(asset: AssetStateV16, side: SideV16) -> SideModeV16 {
+        match side {
+            SideV16::Long => asset.mode_long,
+            SideV16::Short => asset.mode_short,
+        }
+    }
+
+    fn leg_has_exhausted_effective_oi(asset: AssetStateV16, leg: PortfolioLegV16) -> bool {
+        leg.active
+            && leg.basis_pos_q != 0
+            && Self::side_effective_oi(asset, leg.side) == 0
+            && Self::side_stored_position_count(asset, leg.side) != 0
+            && Self::side_pending_obligation_count(asset, leg.side) == 0
+            && Self::side_mode(asset, leg.side) != SideModeV16::ResetPending
     }
 
     fn auto_crank_selected_assets(
@@ -11798,16 +11852,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             let active = active_bitmap_get(bitmap, slot) && leg.active;
             if active {
                 let asset = self.asset_state(leg.asset_index as usize)?;
-                let (side_oi, side_mode, asset_epoch) = match leg.side {
-                    SideV16::Long => (asset.oi_eff_long_q, asset.mode_long, asset.epoch_long),
-                    SideV16::Short => (asset.oi_eff_short_q, asset.mode_short, asset.epoch_short),
+                let (side_mode, asset_epoch) = match leg.side {
+                    SideV16::Long => (asset.mode_long, asset.epoch_long),
+                    SideV16::Short => (asset.mode_short, asset.epoch_short),
                 };
+                let matched_oi = asset.oi_eff_long_q.min(asset.oi_eff_short_q);
                 let (b_stale, refresh, liquidatable, reset_obligation) =
                     V16Core::kernel_auto_crank_leg_flags(
                         true,
                         asset.lifecycle,
                         leg.basis_pos_q,
-                        side_oi,
+                        matched_oi,
                         side_mode,
                         asset_epoch,
                         leg.epoch_snap,
@@ -11816,7 +11871,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 b_stale_flags[slot] = b_stale;
                 refresh_flags[slot] = refresh;
                 liquidation_flags[slot] = liquidatable;
-                reset_obligation_flags[slot] = reset_obligation;
+                reset_obligation_flags[slot] =
+                    reset_obligation || Self::leg_has_exhausted_effective_oi(asset, leg);
             }
             slot += 1;
         }
@@ -13633,6 +13689,30 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
+    fn unilateral_close_capacity(&self, asset_index: usize, stored_abs: u128) -> V16Result<u128> {
+        let asset = self.asset_state(asset_index)?;
+        Ok(stored_abs
+            .min(asset.oi_eff_long_q)
+            .min(asset.oi_eff_short_q))
+    }
+
+    fn begin_side_reset_if_effective_oi_exhausted(
+        &mut self,
+        asset_index: usize,
+        side: SideV16,
+    ) -> V16Result<()> {
+        let asset = self.asset_state(asset_index)?;
+        if Self::side_effective_oi(asset, side) == 0
+            && Self::side_stored_position_count(asset, side) != 0
+            && Self::side_pending_obligation_count(asset, side) == 0
+            && Self::side_mode(asset, side) != SideModeV16::ResetPending
+            && !self.has_pending_domain_loss_barrier(asset_index, side)?
+        {
+            self.begin_full_drain_reset_inner(asset_index, side)?;
+        }
+        Ok(())
+    }
+
     fn reduce_position(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
@@ -13654,6 +13734,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             SideV16::Short => close_i128,
         };
         self.apply_position_delta(account, asset_index, delta)?;
+        self.begin_side_reset_if_effective_oi_exhausted(asset_index, leg.side)?;
         self.reduce_matching_open_interest_for_unilateral_close(asset_index, leg.side, close_q)
     }
 
@@ -13708,9 +13789,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // risk-reduction kernel rebalance uses, so A5.dec's strict-progress
         // contract now governs the real liquidation route (3C). Liquidation size
         // is engine-selected: close just enough to restore maintenance health
-        // when possible, otherwise close the selected leg fully.
+        // when possible, otherwise close the selected leg fully. The matched-OI
+        // capacity prevents a partially ADL-reduced stored basis from subtracting
+        // more effective OI than remains on the two-sided market.
+        let close_budget = close_request_q.min(
+            self.unilateral_close_capacity(request.asset_index, leg.basis_pos_q.unsigned_abs())?,
+        );
+        if close_budget == 0 {
+            return Err(V16Error::NonProgress);
+        }
         let (close_q, close_delta) =
-            V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, close_request_q)?;
+            V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, close_budget)?;
         if self.position_delta_touches_pending_domain_loss_barrier(
             &account.as_view(),
             request.asset_index,
@@ -13834,8 +13923,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         // PRODUCTION KERNEL: clamp + toward-zero reduction delta (rank decrease,
         // never over-closes, full close clears).
+        let reduce_budget = request.reduce_q.min(
+            self.unilateral_close_capacity(request.asset_index, leg.basis_pos_q.unsigned_abs())?,
+        );
         let (reduce_q, reduce_delta) =
-            V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, request.reduce_q)?;
+            V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, reduce_budget)?;
         if reduce_q == 0 {
             return Err(V16Error::NonProgress);
         }

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1436,6 +1436,17 @@ impl V16Core {
         Ok((long_reduction_q, short_reduction_q))
     }
 
+    /// PRODUCTION KERNEL: cap unilateral close work by the account's stored
+    /// basis and by matched effective OI. Liquidation and owner rebalance share
+    /// this bound so neither can subtract more OI than either side contains.
+    fn kernel_unilateral_close_capacity(
+        stored_abs: u128,
+        oi_eff_long_q: u128,
+        oi_eff_short_q: u128,
+    ) -> u128 {
+        stored_abs.min(oi_eff_long_q).min(oi_eff_short_q)
+    }
+
     /// PRODUCTION KERNEL (roadmap 3A.2 risk-reduction / S-L3, A5.dec rank): the
     /// position-reduction core of liquidation/rebalance. Clamps the requested
     /// close to the leg and produces the toward-zero signed delta:
@@ -13691,9 +13702,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
 
     fn unilateral_close_capacity(&self, asset_index: usize, stored_abs: u128) -> V16Result<u128> {
         let asset = self.asset_state(asset_index)?;
-        Ok(stored_abs
-            .min(asset.oi_eff_long_q)
-            .min(asset.oi_eff_short_q))
+        Ok(V16Core::kernel_unilateral_close_capacity(
+            stored_abs,
+            asset.oi_eff_long_q,
+            asset.oi_eff_short_q,
+        ))
     }
 
     fn begin_side_reset_if_effective_oi_exhausted(

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -512,6 +512,26 @@ impl MarketGroupV16HeaderAccount {
 }
 
 impl<'a, T> MarketGroupV16ViewMut<'a, T> {
+    pub fn kani_kernel_unilateral_close_capacity(
+        stored_abs: u128,
+        oi_eff_long_q: u128,
+        oi_eff_short_q: u128,
+    ) -> u128 {
+        V16Core::kernel_unilateral_close_capacity(stored_abs, oi_eff_long_q, oi_eff_short_q)
+    }
+
+    pub fn kani_kernel_reduce_position_delta(
+        pre_basis_signed: i128,
+        side: SideV16,
+        requested: u128,
+    ) -> V16Result<(u128, i128)> {
+        V16Core::kernel_reduce_position_delta(pre_basis_signed, side, requested)
+    }
+
+    pub fn kani_leg_has_exhausted_effective_oi(asset: AssetStateV16, leg: PortfolioLegV16) -> bool {
+        Self::leg_has_exhausted_effective_oi(asset, leg)
+    }
+
     pub fn kani_clear_leg(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -15728,3 +15728,89 @@ fn proof_v16_prior_reset_cleanup_cannot_starve_live_liquidation() {
     assert!(!kani_should_clear_prior_reset_obligation(false, true, true));
     assert!(!kani_should_clear_prior_reset_obligation(true, true, false));
 }
+
+// Shared liquidation/rebalance theorem for partially ADL-reduced positions.
+// Live assets have equal effective OI on both sides, while an account's stored
+// basis can be larger. The production capacity must prevent OI underflow and
+// make the resulting zero-OI residue permissionlessly actionable.
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_unilateral_close_capacity_is_safe_progress_and_residue_complete() {
+    let side = if kani::any::<bool>() {
+        SideV16::Long
+    } else {
+        SideV16::Short
+    };
+    let stored_abs: u128 = kani::any();
+    let matched_oi: u128 = kani::any();
+    let request: u128 = kani::any();
+    kani::assume((1..=MAX_POSITION_ABS_Q).contains(&stored_abs));
+    kani::assume((1..=MAX_OI_SIDE_Q).contains(&matched_oi));
+    kani::assume(request > 0);
+
+    let capacity = MarketGroupV16ViewMut::<u64>::kani_kernel_unilateral_close_capacity(
+        stored_abs, matched_oi, matched_oi,
+    );
+    let work = request.min(capacity);
+    let pre_basis_signed = match side {
+        SideV16::Long => stored_abs as i128,
+        SideV16::Short => -(stored_abs as i128),
+    };
+    let (reduced_q, delta) = MarketGroupV16ViewMut::<u64>::kani_kernel_reduce_position_delta(
+        pre_basis_signed,
+        side,
+        work,
+    )
+    .unwrap();
+    let expected = request.min(stored_abs).min(matched_oi);
+    let post_basis_signed = pre_basis_signed.checked_add(delta).unwrap();
+    let long_oi_after = matched_oi.checked_sub(reduced_q).unwrap();
+    let short_oi_after = matched_oi.checked_sub(reduced_q).unwrap();
+
+    assert_eq!(capacity, stored_abs.min(matched_oi));
+    assert_eq!(reduced_q, expected);
+    assert!(reduced_q > 0);
+    assert!(reduced_q <= stored_abs);
+    assert!(reduced_q <= matched_oi);
+    assert_eq!(post_basis_signed.unsigned_abs(), stored_abs - reduced_q);
+    assert!(
+        post_basis_signed == 0 || post_basis_signed.signum() == pre_basis_signed.signum(),
+        "risk reduction cannot flip the user's side"
+    );
+
+    if request >= capacity && stored_abs > matched_oi {
+        assert_eq!(long_oi_after, 0);
+        assert_eq!(short_oi_after, 0);
+        assert_ne!(post_basis_signed, 0);
+        let mut asset = AssetStateV16::default();
+        asset.oi_eff_long_q = long_oi_after;
+        asset.oi_eff_short_q = short_oi_after;
+        match side {
+            SideV16::Long => asset.stored_pos_count_long = 1,
+            SideV16::Short => asset.stored_pos_count_short = 1,
+        }
+        let leg = PortfolioLegV16 {
+            active: true,
+            side,
+            basis_pos_q: post_basis_signed,
+            ..PortfolioLegV16::EMPTY
+        };
+        assert!(
+            MarketGroupV16ViewMut::<u64>::kani_leg_has_exhausted_effective_oi(asset, leg),
+            "a nonzero basis after matched OI exhaustion must remain crank-actionable"
+        );
+    }
+
+    kani::cover!(side == SideV16::Long, "capacity covers long reductions");
+    kani::cover!(side == SideV16::Short, "capacity covers short reductions");
+    kani::cover!(request < capacity, "capacity covers partial requested work");
+    kani::cover!(
+        request >= capacity && stored_abs > matched_oi,
+        "capacity covers an ADL terminal residue"
+    );
+    kani::cover!(
+        request >= capacity && stored_abs <= matched_oi,
+        "capacity covers a full account close"
+    );
+}

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3321,7 +3321,6 @@ fn v16_adl_reduced_basis_caps_exit_to_effective_oi_then_detaches_residue() {
             AutoCrankWorkV16 {
                 now_slot: 1,
                 observations: &[],
-                liquidation_max_close_q: 2 * POS_SCALE,
                 resolved_close_fee_rate_per_slot: 0,
             },
         )
@@ -3378,7 +3377,6 @@ fn v16_auto_crank_migrates_legacy_normal_adl_residue_into_reset_cleanup() {
             AutoCrankWorkV16 {
                 now_slot: 1,
                 observations: &[],
-                liquidation_max_close_q: POS_SCALE,
                 resolved_close_fee_rate_per_slot: 0,
             },
         )

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -10,7 +10,7 @@ use percolator::{
     PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
-    ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedPayoutLedgerV16,
+    ProvenanceHeaderV16, ProvenanceHeaderV16Account, RebalanceRequestV16, ResolvedPayoutLedgerV16,
     ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16, ResolvedPayoutReceiptV16Account,
     SideModeV16, SideV16, SourceCreditStateV16, SourceCreditStateV16Account, TradeRequestV16,
     V16Config, V16Error, V16PodI128, V16PodU128, V16PodU32, V16PodU64, V16_EMPTY_ACTIVE_BITMAP,
@@ -3251,6 +3251,149 @@ fn v16_auto_crank_skips_prior_reset_obligation_for_live_liquidation() {
         AutoCrankPlanV16::Liquidate { asset_index: 1 }
     );
     assert!(!account.header.legs[1].try_to_runtime().unwrap().active);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_adl_reduced_basis_caps_exit_to_effective_oi_then_detaches_residue() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 24);
+
+    // A partial ADL can leave a winner's stored basis larger than the side's
+    // remaining effective OI. This is the exact state reached by the public
+    // wrapper regression: basis=2 lots, matched effective OI=1 lot.
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.oi_eff_long_q = POS_SCALE;
+    asset.oi_eff_short_q = POS_SCALE;
+    asset.a_long = ADL_ONE / 2;
+    asset.loss_weight_sum_long = 2 * POS_SCALE;
+    asset.loss_weight_sum_short = POS_SCALE;
+    asset.stored_pos_count_long = 1;
+    asset.stored_pos_count_short = 1;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(2);
+
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Long,
+        basis_pos_q: (2 * POS_SCALE) as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset.k_long,
+        f_snap: asset.f_long_num,
+        epoch_snap: asset.epoch_long,
+        loss_weight: 2 * POS_SCALE,
+        b_snap: asset.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(1);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market.deposit_not_atomic(&mut account, 1_000).unwrap();
+
+    let reduced = market
+        .rebalance_reduce_position_not_atomic(
+            &mut account,
+            RebalanceRequestV16 {
+                asset_index: 0,
+                reduce_q: 2 * POS_SCALE,
+            },
+        )
+        .expect("max-work exit must clamp to matched effective OI");
+    assert_eq!(reduced.reduced_q, POS_SCALE);
+    let residue = account.header.legs[0].try_to_runtime().unwrap();
+    assert_eq!(residue.basis_pos_q, POS_SCALE as i128);
+    let reset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(reset.oi_eff_long_q, 0);
+    assert_eq!(reset.oi_eff_short_q, 0);
+    assert_eq!(reset.mode_long, SideModeV16::ResetPending);
+    assert_eq!(reset.mode_short, SideModeV16::ResetPending);
+
+    let cleanup = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 1,
+                observations: &[],
+                liquidation_max_close_q: 2 * POS_SCALE,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("terminal ADL residue must be permissionlessly detachable");
+    assert_eq!(
+        cleanup.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    );
+    assert!(!account.header.legs[0].try_to_runtime().unwrap().active);
+    assert_eq!(account.header.active_bitmap[0].get(), 0);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_auto_crank_migrates_legacy_normal_adl_residue_into_reset_cleanup() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 25);
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.oi_eff_long_q = 0;
+    asset.oi_eff_short_q = 0;
+    asset.a_long = ADL_ONE / 2;
+    asset.loss_weight_sum_long = POS_SCALE;
+    asset.stored_pos_count_long = 1;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(1);
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset.k_long,
+        f_snap: asset.f_long_num,
+        epoch_snap: asset.epoch_long,
+        loss_weight: POS_SCALE,
+        b_snap: asset.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(1);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market.deposit_not_atomic(&mut account, 1_000).unwrap();
+    let result = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 1,
+                observations: &[],
+                liquidation_max_close_q: POS_SCALE,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("a legacy zero-effective-OI residue must remain crankable after upgrade");
+    assert_eq!(
+        result.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    );
+    assert_eq!(account.header.active_bitmap[0].get(), 0);
+    assert!(!account.header.legs[0].try_to_runtime().unwrap().active);
+    let reset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(reset.mode_long, SideModeV16::ResetPending);
+    assert_eq!(reset.stored_pos_count_long, 0);
     market.validate_shape().unwrap();
     account.validate_with_market(&market.as_view()).unwrap();
 }

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3398,6 +3398,58 @@ fn v16_auto_crank_migrates_legacy_normal_adl_residue_into_reset_cleanup() {
     account.validate_with_market(&market.as_view()).unwrap();
 }
 
+#[test]
+fn v16_resolved_close_migrates_legacy_normal_adl_residue_before_detach() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 26);
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.oi_eff_long_q = 0;
+    asset.oi_eff_short_q = 0;
+    asset.a_long = ADL_ONE / 2;
+    asset.loss_weight_sum_long = POS_SCALE;
+    asset.stored_pos_count_long = 1;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(1);
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset.k_long,
+        f_snap: asset.f_long_num,
+        epoch_snap: asset.epoch_long,
+        loss_weight: POS_SCALE,
+        b_snap: asset.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(1);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market.deposit_not_atomic(&mut account, 1_000).unwrap();
+    market.resolve_market_not_atomic(1).unwrap();
+    let outcome = market
+        .close_resolved_account_not_atomic(&mut account, 0)
+        .expect("resolution must not strand an upgraded zero-effective-OI residue");
+    assert_eq!(
+        outcome,
+        percolator::ResolvedCloseOutcomeV16::Closed { payout: 1_000 }
+    );
+    assert_eq!(account.header.active_bitmap[0].get(), 0);
+    assert_eq!(account.header.capital.get(), 0);
+    assert_eq!(market.header.vault.get(), 0);
+    let reset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(reset.mode_long, SideModeV16::ResetPending);
+    assert_eq!(reset.stored_pos_count_long, 0);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
 // ROADMAP 3C step 4 / NB2 finite-multi-step liveness via the self-classifying
 // crank: an uncertified, underwater account must be driven to a de-risked fixed
 // point by repeated auto-cranks — the classifier ESCALATES (stale -> refresh,


### PR DESCRIPTION
## Problem

A public partial liquidation can ADL a winning side so that an account retains two lots of stored basis while the market has only one lot of matched effective OI. A keeper or owner using the normal max-work amount then reaches `CounterUnderflow`. Reducing exactly one lot consumes all effective OI but leaves a nonzero leg in `Normal`, so every later reduction fails and no reset cleanup is actionable.

The LiteSVM reproduction uses only deposits, a public trade, authenticated mark updates, permissionless cranks, and owner `RebalanceReduce`.

## Fix

- Cap unilateral liquidation/rebalance work by matched effective OI.
- When a successful reduction exhausts a side's effective OI, enter the existing reset epoch.
- Classify and migrate legacy `Normal` zero-effective-OI residues so an unsigned auto-crank settles terminal K/F/B value and detaches them.
- Never start this migration while a loss barrier or pending obligation owns the side.

## Proof-driven validation

`proof_v16_unilateral_close_capacity_is_safe_progress_and_residue_complete` quantifies both sides, symbolic nonzero stored basis, matched effective OI, and arbitrary positive requested work over the production bounds. Through the exact production capacity, reduction, and exhausted-OI classifier kernels it proves:

- Unilateral work never exceeds either side's matched effective OI.
- Effective-OI subtraction cannot underflow.
- Reduction strictly decreases absolute basis and never flips the user's side.
- Partial requests, full account closes, and ADL terminal residues are all reachable.
- Any nonzero stored residue after matched OI reaches zero is classified as permissionlessly actionable.

Result: 109 checks, 5/5 covers, 1.48s.

Mutation sensitivity:

- Removing the matched-OI cap produces both a capacity assertion failure and checked-subtraction underflow.
- Disabling exhausted-OI residue classification fails the crank-actionability assertion with 4/5 covers still reachable.

Additional validation:

- Parent `a9baa08`: production regression fails with `CounterUnderflow`.
- Patched: 50 unit + 9 backing fuzz + 2 resolved fuzz + 65 spec tests pass.
- `cargo test --features fuzz`: 69 spec tests plus all differential/fuzz suites pass.
- Frozen `spec.md` unchanged.