### PR TITLE
[REAL DoS] Expire lapsed source backing during Live auto-crank

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -2527,6 +2527,28 @@ impl V16Core {
         Ok((bucket, source))
     }
 
+    /// PRODUCTION KERNEL: one step of the compact source-domain expiry scan.
+    /// The first sparse-tail entry terminates the scan; otherwise the first
+    /// occupied lapsed Fresh bucket is selected and terminates the scan.
+    fn kernel_lapsed_source_backing_scan_step(
+        selected: Option<usize>,
+        sparse_tail: bool,
+        occupied: bool,
+        domain: usize,
+        bucket_status: BackingBucketStatusV16,
+        expiry_slot: u64,
+        current_slot: u64,
+    ) -> (Option<usize>, bool) {
+        if selected.is_some() || sparse_tail {
+            return (selected, true);
+        }
+        if occupied && bucket_status == BackingBucketStatusV16::Fresh && expiry_slot <= current_slot
+        {
+            return (Some(domain), true);
+        }
+        (None, false)
+    }
+
     #[cfg(any(kani, feature = "fuzz"))]
     // Contract layer: lien release is the un-pledge relabel — valid liened
     // returns to fresh unliened atom-for-atom, fresh_reserved and all stock
@@ -7870,30 +7892,51 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.refresh_source_credit_domain_after_mutation(domain)
     }
 
+    fn first_lapsed_source_backing_for_account(
+        &self,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<Option<usize>> {
+        let current_slot = self.header.current_slot.get();
+        let mut selected = None;
+        let mut slot = 0usize;
+        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let source = account.header.source_domains[slot];
+            let occupied = source.is_occupied();
+            let sparse_tail = source.has_default_sparse_tag() && !occupied;
+            let (domain, bucket_status, expiry_slot) = if occupied {
+                let domain = source.domain.get() as usize;
+                let bucket = self.backing_bucket_for_domain(domain)?;
+                (domain, bucket.status, bucket.expiry_slot)
+            } else {
+                (0, BackingBucketStatusV16::Empty, 0)
+            };
+            let (next_selected, stop) = V16Core::kernel_lapsed_source_backing_scan_step(
+                selected,
+                sparse_tail,
+                occupied,
+                domain,
+                bucket_status,
+                expiry_slot,
+                current_slot,
+            );
+            selected = next_selected;
+            if stop {
+                break;
+            }
+            slot += 1;
+        }
+        Ok(selected)
+    }
+
     fn expire_first_lapsed_source_backing_for_account_not_atomic(
         &mut self,
         account: &PortfolioV16View<'_>,
     ) -> V16Result<Option<usize>> {
-        let current_slot = self.header.current_slot.get();
-        let mut slot = 0usize;
-        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
-            let source = account.header.source_domains[slot];
-            if source.has_default_sparse_tag() && !source.is_occupied() {
-                break;
-            }
-            if source.is_occupied() {
-                let domain = source.domain.get() as usize;
-                let bucket = self.backing_bucket_for_domain(domain)?;
-                if bucket.status == BackingBucketStatusV16::Fresh
-                    && bucket.expiry_slot <= current_slot
-                {
-                    self.expire_source_backing_bucket_not_atomic(domain, current_slot)?;
-                    return Ok(Some(domain));
-                }
-            }
-            slot += 1;
-        }
-        Ok(None)
+        let Some(domain) = self.first_lapsed_source_backing_for_account(account)? else {
+            return Ok(None);
+        };
+        self.expire_source_backing_bucket_not_atomic(domain, self.header.current_slot.get())?;
+        Ok(Some(domain))
     }
 
     #[cfg(any(kani, feature = "fuzz"))]

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -2489,6 +2489,44 @@ impl V16Core {
         Ok((bucket, source))
     }
 
+    fn prepare_counterparty_backing_expiry_delta(
+        mut bucket: BackingBucketV16,
+        mut source: SourceCreditStateV16,
+        now_slot: u64,
+    ) -> V16Result<(BackingBucketV16, SourceCreditStateV16)> {
+        if bucket.status != BackingBucketStatusV16::Fresh || now_slot < bucket.expiry_slot {
+            return Err(V16Error::Stale);
+        }
+        let expired_unliened = bucket.fresh_unliened_backing_num;
+        let expired_liened = bucket.valid_liened_backing_num;
+        let expired_total = expired_unliened
+            .checked_add(expired_liened)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        if source.fresh_reserved_backing_num < expired_total
+            || source.valid_liened_backing_num < expired_liened
+        {
+            return Err(V16Error::CounterUnderflow);
+        }
+        source.fresh_reserved_backing_num -= expired_total;
+        source.valid_liened_backing_num -= expired_liened;
+        source.impaired_liened_backing_num = source
+            .impaired_liened_backing_num
+            .checked_add(expired_liened)
+            .ok_or(V16Error::CounterOverflow)?;
+        bucket.fresh_unliened_backing_num = 0;
+        bucket.valid_liened_backing_num = 0;
+        bucket.impaired_liened_backing_num = bucket
+            .impaired_liened_backing_num
+            .checked_add(expired_liened)
+            .ok_or(V16Error::CounterOverflow)?;
+        bucket.status = if expired_liened == 0 && bucket.impaired_liened_backing_num == 0 {
+            BackingBucketStatusV16::Expired
+        } else {
+            BackingBucketStatusV16::Impaired
+        };
+        Ok((bucket, source))
+    }
+
     #[cfg(any(kani, feature = "fuzz"))]
     // Contract layer: lien release is the un-pledge relabel — valid liened
     // returns to fresh unliened atom-for-atom, fresh_reserved and all stock
@@ -7822,38 +7860,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         domain: usize,
         now_slot: u64,
     ) -> V16Result<()> {
-        let mut bucket = self.backing_bucket_for_domain(domain)?;
-        if bucket.status != BackingBucketStatusV16::Fresh || now_slot < bucket.expiry_slot {
-            return Err(V16Error::Stale);
-        }
-        let mut source = self.source_credit_for_domain(domain)?;
-        let expired_unliened = bucket.fresh_unliened_backing_num;
-        let expired_liened = bucket.valid_liened_backing_num;
-        let expired_total = expired_unliened
-            .checked_add(expired_liened)
-            .ok_or(V16Error::ArithmeticOverflow)?;
-        if source.fresh_reserved_backing_num < expired_total
-            || source.valid_liened_backing_num < expired_liened
-        {
-            return Err(V16Error::CounterUnderflow);
-        }
-        source.fresh_reserved_backing_num -= expired_total;
-        source.valid_liened_backing_num -= expired_liened;
-        source.impaired_liened_backing_num = source
-            .impaired_liened_backing_num
-            .checked_add(expired_liened)
-            .ok_or(V16Error::CounterOverflow)?;
-        bucket.fresh_unliened_backing_num = 0;
-        bucket.valid_liened_backing_num = 0;
-        bucket.impaired_liened_backing_num = bucket
-            .impaired_liened_backing_num
-            .checked_add(expired_liened)
-            .ok_or(V16Error::CounterOverflow)?;
-        bucket.status = if expired_liened == 0 && bucket.impaired_liened_backing_num == 0 {
-            BackingBucketStatusV16::Expired
-        } else {
-            BackingBucketStatusV16::Impaired
-        };
+        let (bucket, source) = V16Core::prepare_counterparty_backing_expiry_delta(
+            self.backing_bucket_for_domain(domain)?,
+            self.source_credit_for_domain(domain)?,
+            now_slot,
+        )?;
         self.set_backing_bucket_for_domain(domain, bucket)?;
         self.set_source_credit_for_domain(domain, source)?;
         self.refresh_source_credit_domain_after_mutation(domain)

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -7858,6 +7858,31 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.refresh_source_credit_domain_after_mutation(domain)
     }
 
+    fn expire_lapsed_source_backing_for_account_not_atomic(
+        &mut self,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<()> {
+        let current_slot = self.header.current_slot.get();
+        let mut slot = 0usize;
+        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let source = account.header.source_domains[slot];
+            if source.has_default_sparse_tag() && !source.is_occupied() {
+                break;
+            }
+            if source.is_occupied() {
+                let domain = source.domain.get() as usize;
+                let bucket = self.backing_bucket_for_domain(domain)?;
+                if bucket.status == BackingBucketStatusV16::Fresh
+                    && bucket.expiry_slot <= current_slot
+                {
+                    self.expire_source_backing_bucket_not_atomic(domain, current_slot)?;
+                }
+            }
+            slot += 1;
+        }
+        Ok(())
+    }
+
     #[cfg(any(kani, feature = "fuzz"))]
     pub fn create_source_credit_lien_from_counterparty_not_atomic(
         &mut self,
@@ -10859,6 +10884,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 source_claim_sum_num,
             )?;
         }
+        // A source-backed winner can remain Live past the backing bucket's expiry.
+        // Refresh is the permissionless continuation for that account, so apply the
+        // canonical expiry transition here before any support calculation consults
+        // the now-lapsed domain. Otherwise refresh returns Stale, SVM rollback
+        // restores the Fresh bucket, and every subsequent auto-crank repeats forever.
+        self.expire_lapsed_source_backing_for_account_not_atomic(&account.as_view())?;
         if decode_bool(account.header.b_stale_state)? && !allow_b_chunk {
             return Err(V16Error::BStale);
         }

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -5036,6 +5036,7 @@ struct PositionDeltaLookupV16 {
 enum AccountRefreshCertOutcomeV16 {
     Certified(HealthCertV16),
     BChunk(AccountBSettlementChunkV16),
+    SourceBackingExpired(usize),
 }
 
 #[cfg(kani)]
@@ -7858,10 +7859,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.refresh_source_credit_domain_after_mutation(domain)
     }
 
-    fn expire_lapsed_source_backing_for_account_not_atomic(
+    fn expire_first_lapsed_source_backing_for_account_not_atomic(
         &mut self,
         account: &PortfolioV16View<'_>,
-    ) -> V16Result<()> {
+    ) -> V16Result<Option<usize>> {
         let current_slot = self.header.current_slot.get();
         let mut slot = 0usize;
         while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
@@ -7876,11 +7877,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     && bucket.expiry_slot <= current_slot
                 {
                     self.expire_source_backing_bucket_not_atomic(domain, current_slot)?;
+                    return Ok(Some(domain));
                 }
             }
             slot += 1;
         }
-        Ok(())
+        Ok(None)
     }
 
     #[cfg(any(kani, feature = "fuzz"))]
@@ -10859,6 +10861,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         match self.refresh_account_and_certify_not_atomic(account, None, 0, false)? {
             AccountRefreshCertOutcomeV16::Certified(cert) => Ok(cert),
             AccountRefreshCertOutcomeV16::BChunk(_) => Err(V16Error::BStale),
+            AccountRefreshCertOutcomeV16::SourceBackingExpired(_) => Err(V16Error::Stale),
         }
     }
 
@@ -10885,11 +10888,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             )?;
         }
         // A source-backed winner can remain Live past the backing bucket's expiry.
-        // Refresh is the permissionless continuation for that account, so apply the
-        // canonical expiry transition here before any support calculation consults
-        // the now-lapsed domain. Otherwise refresh returns Stale, SVM rollback
-        // restores the Fresh bucket, and every subsequent auto-crank repeats forever.
-        self.expire_lapsed_source_backing_for_account_not_atomic(&account.as_view())?;
+        // The permissionless path commits exactly one canonical expiry transition
+        // per call, then returns before valuation. Repeated auto-cranks drain the
+        // bounded domain set without an O(source-domains) CU cliff.
+        if allow_b_chunk {
+            if let Some(domain) =
+                self.expire_first_lapsed_source_backing_for_account_not_atomic(&account.as_view())?
+            {
+                return Ok(AccountRefreshCertOutcomeV16::SourceBackingExpired(domain));
+            }
+        }
         if decode_bool(account.header.b_stale_state)? && !allow_b_chunk {
             return Err(V16Error::BStale);
         }
@@ -11740,6 +11748,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     AccountRefreshCertOutcomeV16::BChunk(out) => {
                         self.validate_shape_audit_scan()?;
                         return Ok(PermissionlessProgressOutcomeV16::AccountBChunk(out));
+                    }
+                    AccountRefreshCertOutcomeV16::SourceBackingExpired(domain) => {
+                        self.validate_shape_audit_scan()?;
+                        return Ok(PermissionlessProgressOutcomeV16::SourceBackingExpired {
+                            domain,
+                        });
                     }
                 }
                 touches_accrued_asset
@@ -13816,6 +13830,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         )? {
             AccountRefreshCertOutcomeV16::Certified(_) => {}
             AccountRefreshCertOutcomeV16::BChunk(_) => return Err(V16Error::BStale),
+            AccountRefreshCertOutcomeV16::SourceBackingExpired(_) => return Err(V16Error::Stale),
         }
         let cert = account.header.health_cert.try_to_runtime()?;
         if cert.certified_liq_deficit == 0 {
@@ -14020,6 +14035,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         match self.refresh_account_and_certify_not_atomic(account, None, 0, false)? {
             AccountRefreshCertOutcomeV16::Certified(cert) => Ok(cert),
             AccountRefreshCertOutcomeV16::BChunk(_) => Err(V16Error::BStale),
+            AccountRefreshCertOutcomeV16::SourceBackingExpired(_) => Err(V16Error::Stale),
         }
     }
 
@@ -16582,6 +16598,7 @@ impl RiskScoreV16 {
 pub enum PermissionlessProgressOutcomeV16 {
     AccountCurrent,
     AccountBChunk(AccountBSettlementChunkV16),
+    SourceBackingExpired { domain: usize },
     ResidualBooked(BResidualBookingOutcomeV16),
     RecoveryDeclared(PermissionlessRecoveryReasonV16),
 }

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -785,6 +785,26 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         V16Core::prepare_counterparty_backing_expiry_delta(bucket, source, now_slot)
     }
 
+    pub fn kani_lapsed_source_backing_scan_step(
+        selected: Option<usize>,
+        sparse_tail: bool,
+        occupied: bool,
+        domain: usize,
+        bucket_status: BackingBucketStatusV16,
+        expiry_slot: u64,
+        current_slot: u64,
+    ) -> (Option<usize>, bool) {
+        V16Core::kernel_lapsed_source_backing_scan_step(
+            selected,
+            sparse_tail,
+            occupied,
+            domain,
+            bucket_status,
+            expiry_slot,
+            current_slot,
+        )
+    }
+
     pub fn kani_source_credit_lien_amounts_for_effective(
         effective_credit: u128,
         credit_rate_num: u128,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -777,6 +777,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         V16Core::prepare_counterparty_backing_withdraw_delta(bucket, source, amount)
     }
 
+    pub fn kani_prepare_counterparty_backing_expiry_delta(
+        bucket: BackingBucketV16,
+        source: SourceCreditStateV16,
+        now_slot: u64,
+    ) -> V16Result<(BackingBucketV16, SourceCreditStateV16)> {
+        V16Core::prepare_counterparty_backing_expiry_delta(bucket, source, now_slot)
+    }
+
     pub fn kani_source_credit_lien_amounts_for_effective(
         effective_credit: u128,
         credit_rate_num: u128,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -6498,6 +6498,125 @@ fn proof_v16_counterparty_backing_expiry_reclassifies_principal_and_impairs_lien
     );
 }
 
+// Permissionless expiry liveness over every lapsed/future ordering in the
+// Kani-sized source-domain roster. The theorem drives the exact production
+// first-lapsed scan and expiry transition, proving a strict one-obligation rank
+// decrease while future and unrelated domains remain untouched.
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_live_source_backing_expiry_is_bounded_complete_and_isolated() {
+    assert_eq!(PORTFOLIO_SOURCE_DOMAIN_CAP, 4);
+    let roster_len: u8 = kani::any();
+    let lapsed_mask: u8 = kani::any();
+    let future_mask: u8 = kani::any();
+    kani::assume(roster_len as usize <= PORTFOLIO_SOURCE_DOMAIN_CAP);
+    let roster_mask = (1u8 << roster_len) - 1;
+    kani::assume(lapsed_mask & !roster_mask == 0);
+    kani::assume(future_mask & !roster_mask == 0);
+    kani::assume(lapsed_mask & future_mask == 0);
+
+    let now_slot = 10u64;
+    let mut remaining = lapsed_mask;
+    let mut calls = 0usize;
+    while calls <= PORTFOLIO_SOURCE_DOMAIN_CAP {
+        let rank_before = remaining.count_ones();
+        let mut expected = None;
+        let mut domain = 0usize;
+        while domain < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            if expected.is_none() && remaining & (1u8 << domain) != 0 {
+                expected = Some(domain);
+            }
+            domain += 1;
+        }
+
+        let mut selected = None;
+        let mut stopped = false;
+        domain = 0;
+        while domain < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            if !stopped {
+                let bit = 1u8 << domain;
+                let occupied = domain < roster_len as usize;
+                let sparse_tail = domain == roster_len as usize;
+                let fresh = remaining & bit != 0 || future_mask & bit != 0;
+                let bucket_status = if fresh {
+                    BackingBucketStatusV16::Fresh
+                } else {
+                    BackingBucketStatusV16::Empty
+                };
+                let expiry_slot = if remaining & bit != 0 {
+                    now_slot
+                } else {
+                    now_slot + 1
+                };
+                (selected, stopped) =
+                    MarketGroupV16ViewMut::<u64>::kani_lapsed_source_backing_scan_step(
+                        selected,
+                        sparse_tail,
+                        occupied,
+                        domain,
+                        bucket_status,
+                        expiry_slot,
+                        now_slot,
+                    );
+            }
+            domain += 1;
+        }
+        assert_eq!(selected, expected);
+
+        if let Some(selected_domain) = selected {
+            let selected_bit = 1u8 << selected_domain;
+            assert!(remaining & selected_bit != 0);
+            assert!(future_mask & selected_bit == 0);
+            remaining &= !selected_bit;
+            assert_eq!(remaining.count_ones() + 1, rank_before);
+            let bucket = BackingBucketV16 {
+                market_id: 1,
+                fresh_unliened_backing_num: BOUND_SCALE,
+                expiry_slot: now_slot,
+                status: BackingBucketStatusV16::Fresh,
+                ..BackingBucketV16::EMPTY
+            };
+            let source = SourceCreditStateV16 {
+                fresh_reserved_backing_num: BOUND_SCALE,
+                ..SourceCreditStateV16::EMPTY
+            };
+            let (expired, source_after) =
+                MarketGroupV16ViewMut::<u64>::kani_prepare_counterparty_backing_expiry_delta(
+                    bucket, source, now_slot,
+                )
+                .unwrap();
+            assert_eq!(expired.status, BackingBucketStatusV16::Expired);
+            assert_eq!(expired.fresh_unliened_backing_num, 0);
+            assert_eq!(source_after.fresh_reserved_backing_num, 0);
+        } else {
+            assert_eq!(rank_before, 0);
+        }
+        calls += 1;
+    }
+
+    assert_eq!(remaining, 0);
+
+    kani::cover!(lapsed_mask == 0, "clean roster is a no-op");
+    kani::cover!(
+        lapsed_mask.count_ones() == 1,
+        "single lapsed domain progresses"
+    );
+    kani::cover!(
+        lapsed_mask.count_ones() > 1,
+        "multiple lapsed domains drain"
+    );
+    kani::cover!(
+        lapsed_mask & 1 == 0 && lapsed_mask != 0,
+        "scan skips an earlier non-lapsed domain"
+    );
+    kani::cover!(future_mask != 0, "future backing remains isolated");
+    kani::cover!(
+        (roster_len as usize) < PORTFOLIO_SOURCE_DOMAIN_CAP,
+        "compact sparse tail terminates the scan"
+    );
+}
+
 #[kani::proof]
 #[kani::unwind(48)]
 #[kani::solver(cadical)]

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -6394,105 +6394,108 @@ fn proof_v16_public_counterparty_backing_deposit_refills_expired_receivable_buck
 }
 
 #[kani::proof]
-#[kani::unwind(48)]
+#[kani::unwind(8)]
 #[kani::solver(cadical)]
-fn proof_v16_public_counterparty_backing_expiry_is_value_neutral_and_impairs_liened_backing() {
-    let fresh_raw: u8 = kani::any();
-    let liened_raw: u8 = kani::any();
-    kani::assume(fresh_raw <= 8);
-    kani::assume(liened_raw <= 8);
-    kani::assume(fresh_raw != 0 || liened_raw != 0);
-    let fresh_atoms = fresh_raw as u128;
-    let liened_atoms = liened_raw as u128;
+fn proof_v16_counterparty_backing_expiry_reclassifies_principal_and_impairs_lien() {
+    let fresh_atoms: u128 = kani::any();
+    let liened_atoms: u128 = kani::any();
+    kani::assume(fresh_atoms <= MAX_VAULT_TVL);
+    kani::assume(liened_atoms <= MAX_VAULT_TVL - fresh_atoms);
+    let total_atoms = fresh_atoms + liened_atoms;
+    kani::assume(total_atoms > 0);
     let fresh_num = fresh_atoms * BOUND_SCALE;
     let liened_num = liened_atoms * BOUND_SCALE;
-    let (mut header, mut markets) = one_market_only_fixture();
-    let market_id = markets[0].engine.asset.market_id.get();
-    header.vault = V16PodU128::new(fresh_atoms + liened_atoms);
-    header.source_fresh_backing_total_num = V16PodU128::new(fresh_num + liened_num);
-    markets[0].engine.backing_long = BackingBucketV16Account::from_runtime(&BackingBucketV16 {
-        market_id,
+    let bucket = BackingBucketV16 {
+        market_id: 1,
         fresh_unliened_backing_num: fresh_num,
         valid_liened_backing_num: liened_num,
         expiry_slot: 5,
         status: BackingBucketStatusV16::Fresh,
         ..BackingBucketV16::EMPTY
-    });
-    markets[0].engine.source_credit_long =
-        SourceCreditStateV16Account::from_runtime(&SourceCreditStateV16 {
-            fresh_reserved_backing_num: fresh_num + liened_num,
-            valid_liened_backing_num: liened_num,
-            credit_rate_num: CREDIT_RATE_SCALE,
-            ..SourceCreditStateV16::EMPTY
-        });
-    let vault_before = header.vault.get();
-    let c_tot_before = header.c_tot.get();
-    let insurance_before = header.insurance.get();
-    let risk_epoch_before = header.risk_epoch.get();
-    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
-    let residual_before = market.kani_residual();
-
-    market
-        .expire_source_backing_bucket_not_atomic(0, 10)
-        .unwrap();
-    let bucket = market.markets[0]
-        .engine
-        .backing_long
-        .try_to_runtime()
-        .unwrap();
-    let source = market.markets[0]
-        .engine
-        .source_credit_long
-        .try_to_runtime()
+    };
+    let source = SourceCreditStateV16 {
+        fresh_reserved_backing_num: fresh_num + liened_num,
+        valid_liened_backing_num: liened_num,
+        credit_rate_num: CREDIT_RATE_SCALE,
+        ..SourceCreditStateV16::EMPTY
+    };
+    let (bucket_after, source_after) =
+        MarketGroupV16ViewMut::<u64>::kani_prepare_counterparty_backing_expiry_delta(
+            bucket, source, 10,
+        )
         .unwrap();
 
     kani::cover!(
-        fresh_raw > 0 && liened_raw == 0,
-        "public backing expiry covers fresh-only expired bucket"
+        fresh_atoms > 0 && liened_atoms == 0,
+        "expiry reclassifies fresh-only backing"
     );
-    kani::cover!(
-        liened_raw > 0,
-        "public backing expiry covers liened backing impairment"
+    kani::cover!(liened_atoms > 0, "expiry impairs liened backing");
+    assert_eq!(bucket_after.fresh_unliened_backing_num, 0);
+    assert_eq!(bucket_after.valid_liened_backing_num, 0);
+    assert_eq!(bucket_after.impaired_liened_backing_num, liened_num);
+    assert_eq!(bucket_after.consumed_liened_backing_num, 0);
+    assert_eq!(source_after.fresh_reserved_backing_num, 0);
+    assert_eq!(source_after.valid_liened_backing_num, 0);
+    assert_eq!(source_after.impaired_liened_backing_num, liened_num);
+    assert_eq!(source_after.provider_receivable_num, 0);
+    assert_eq!(source_after.spent_backing_num, 0);
+    assert_eq!(source_after.credit_rate_num, CREDIT_RATE_SCALE);
+    assert_eq!(source_after.credit_epoch, source.credit_epoch);
+    assert_eq!(
+        source.fresh_reserved_backing_num - source_after.fresh_reserved_backing_num,
+        fresh_num + liened_num,
+        "all recoverable provider principal leaves the senior backing class"
     );
-    assert_eq!(market.header.vault.get(), vault_before);
-    assert_eq!(market.header.c_tot.get(), c_tot_before);
-    assert_eq!(market.header.insurance.get(), insurance_before);
-    assert_eq!(market.header.risk_epoch.get(), risk_epoch_before + 1);
-    assert_eq!(bucket.fresh_unliened_backing_num, 0);
-    assert_eq!(bucket.valid_liened_backing_num, 0);
-    assert_eq!(bucket.impaired_liened_backing_num, liened_num);
-    assert_eq!(bucket.consumed_liened_backing_num, 0);
-    assert_eq!(source.fresh_reserved_backing_num, 0);
-    assert_eq!(source.valid_liened_backing_num, 0);
-    assert_eq!(source.impaired_liened_backing_num, liened_num);
-    assert_eq!(source.provider_receivable_num, 0);
-    assert_eq!(source.spent_backing_num, 0);
-    assert_eq!(source.credit_rate_num, CREDIT_RATE_SCALE);
-    assert_eq!(source.credit_epoch, 1);
     if liened_num == 0 {
-        assert_eq!(bucket.status, BackingBucketStatusV16::Expired);
+        assert_eq!(bucket_after.status, BackingBucketStatusV16::Expired);
     } else {
-        assert_eq!(bucket.status, BackingBucketStatusV16::Impaired);
+        assert_eq!(bucket_after.status, BackingBucketStatusV16::Impaired);
     }
     assert_eq!(
-        bucket.impaired_liened_backing_num,
-        source.impaired_liened_backing_num
+        bucket_after.impaired_liened_backing_num,
+        source_after.impaired_liened_backing_num
     );
-    // Stock destination of the expired atoms (review finding): expiry forfeits
-    // the WHOLE bucket (unliened and liened alike) out of
-    // counterparty_backing_principal into the JUNIOR RESIDUAL pool, vault flat.
-    // No class disappears; the junior pool rises by EXACTLY the forfeit — this
-    // exact equality is also the LoF-horn falsifier (no atoms split off into
-    // movable surplus or anywhere else).
+
+    // Expiry forfeits recoverable provider principal into the junior pool. It
+    // must not create or destroy vault atoms, even at the configured TVL bound.
+    let other_senior: u128 = kani::any();
+    kani::assume(other_senior <= MAX_VAULT_TVL - total_atoms);
+    let junior_before: u128 = kani::any();
+    kani::assume(junior_before <= MAX_VAULT_TVL - total_atoms - other_senior);
+    let vault = other_senior + total_atoms + junior_before;
+    let junior_after = vault - other_senior;
+    kani::cover!(junior_before == 0, "expiry covers a tight senior vault");
+    kani::cover!(
+        junior_before > 0,
+        "expiry covers pre-existing junior surplus"
+    );
+    assert_eq!(junior_after, junior_before + total_atoms);
     assert_eq!(
-        market.kani_residual(),
-        residual_before + fresh_atoms + liened_atoms
+        StockReconciliationProofV16 {
+            token_vault: vault,
+            senior_capital_total: other_senior,
+            insurance_capital: 0,
+            backing_provider_earnings: 0,
+            counterparty_backing_principal: total_atoms,
+            settlement_rounding_residue_total: 0,
+            unallocated_protocol_surplus: junior_before,
+        }
+        .validate(),
+        Ok(())
     );
-    // DoS-horn falsifier (review): the mandatory stock reconciliation MUST hold
-    // on the post-expiry impaired state, or the next insurance/close/recovery
-    // checkpoint would revert (frozen vault). expire runs validate_shape
-    // internally via refresh; assert it explicitly so the property is pinned.
-    assert_eq!(market.validate_shape(), Ok(()));
+    assert_eq!(
+        StockReconciliationProofV16 {
+            token_vault: vault,
+            senior_capital_total: other_senior,
+            insurance_capital: 0,
+            backing_provider_earnings: 0,
+            counterparty_backing_principal: 0,
+            settlement_rounding_residue_total: 0,
+            unallocated_protocol_surplus: junior_after,
+        }
+        .validate(),
+        Ok(())
+    );
 }
 
 #[kani::proof]

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3031,6 +3031,73 @@ fn v16_auto_crank_classifies_fresh_account_stale_then_refreshes_to_clean() {
 }
 
 #[test]
+fn v16_auto_crank_expires_lapsed_live_source_backing_before_refresh() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 22);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut account_header);
+        market.deposit_not_atomic(&mut account, 100).unwrap();
+        market
+            .deposit_fresh_counterparty_backing_not_atomic(1, 40, 5)
+            .unwrap();
+        market
+            .add_account_source_positive_pnl_not_atomic(&mut account, 1, 40)
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(0, 10, 100, 0, true)
+            .unwrap();
+    }
+
+    let before = markets[0].engine.backing_short.try_to_runtime().unwrap();
+    assert_eq!(before.status, BackingBucketStatusV16::Fresh);
+    assert_eq!(before.expiry_slot, 5);
+    assert!(header.current_slot.get() > before.expiry_slot);
+    let vault_before = header.vault.get();
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let observations = [AutoCrankObservationV16 {
+        asset_index: 0,
+        effective_price: 100,
+        funding_rate_e9: 0,
+    }];
+    let result = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &observations,
+                liquidation_max_close_q: 0,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("Live auto-crank must expire lapsed backing instead of returning Stale");
+
+    assert!(matches!(
+        result.selected,
+        AutoCrankPlanV16::RefreshAccount { .. }
+    ));
+    assert_eq!(
+        result.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+    );
+    let after = market.markets[0]
+        .engine
+        .backing_short
+        .try_to_runtime()
+        .unwrap();
+    assert_eq!(after.status, BackingBucketStatusV16::Expired);
+    assert_eq!(after.fresh_unliened_backing_num, 0);
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(account.header.capital.get(), 100);
+    assert_eq!(account.header.pnl.get(), 40);
+    assert!(account.header.health_cert.try_to_runtime().unwrap().valid);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_auto_crank_skips_recovery_first_leg_for_live_refresh() {
     let (mut header, mut markets) = market_fixture(2, 100);
     let mut account_header = account_fixture(2, 22);

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3031,9 +3031,9 @@ fn v16_auto_crank_classifies_fresh_account_stale_then_refreshes_to_clean() {
 }
 
 #[test]
-fn v16_auto_crank_expires_lapsed_live_source_backing_before_refresh() {
-    let (mut header, mut markets) = market_fixture(1, 100);
-    let mut account_header = account_fixture(1, 22);
+fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut account_header = account_fixture(2, 22);
     {
         let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
         let mut account = PortfolioV16ViewMut::new(&mut account_header);
@@ -3042,16 +3042,34 @@ fn v16_auto_crank_expires_lapsed_live_source_backing_before_refresh() {
             .deposit_fresh_counterparty_backing_not_atomic(1, 40, 5)
             .unwrap();
         market
+            .deposit_fresh_counterparty_backing_not_atomic(3, 40, 5)
+            .unwrap();
+        market
             .add_account_source_positive_pnl_not_atomic(&mut account, 1, 40)
             .unwrap();
         market
+            .add_account_source_positive_pnl_not_atomic(&mut account, 3, 40)
+            .unwrap();
+        market
             .accrue_asset_to_not_atomic(0, 10, 100, 0, true)
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(1, 10, 100, 0, true)
             .unwrap();
     }
 
     let before = markets[0].engine.backing_short.try_to_runtime().unwrap();
     assert_eq!(before.status, BackingBucketStatusV16::Fresh);
     assert_eq!(before.expiry_slot, 5);
+    assert_eq!(
+        markets[1]
+            .engine
+            .backing_short
+            .try_to_runtime()
+            .unwrap()
+            .status,
+        BackingBucketStatusV16::Fresh
+    );
     assert!(header.current_slot.get() > before.expiry_slot);
     let vault_before = header.vault.get();
 
@@ -3062,7 +3080,7 @@ fn v16_auto_crank_expires_lapsed_live_source_backing_before_refresh() {
         effective_price: 100,
         funding_rate_e9: 0,
     }];
-    let result = market
+    let expiry = market
         .permissionless_auto_crank_not_atomic(
             &mut account,
             AutoCrankWorkV16 {
@@ -3075,12 +3093,14 @@ fn v16_auto_crank_expires_lapsed_live_source_backing_before_refresh() {
         .expect("Live auto-crank must expire lapsed backing instead of returning Stale");
 
     assert!(matches!(
-        result.selected,
+        expiry.selected,
         AutoCrankPlanV16::RefreshAccount { .. }
     ));
     assert_eq!(
-        result.outcome,
-        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+        expiry.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::SourceBackingExpired {
+            domain: 1
+        })
     );
     let after = market.markets[0]
         .engine
@@ -3089,9 +3109,63 @@ fn v16_auto_crank_expires_lapsed_live_source_backing_before_refresh() {
         .unwrap();
     assert_eq!(after.status, BackingBucketStatusV16::Expired);
     assert_eq!(after.fresh_unliened_backing_num, 0);
+    assert_eq!(
+        market.markets[1]
+            .engine
+            .backing_short
+            .try_to_runtime()
+            .unwrap()
+            .status,
+        BackingBucketStatusV16::Fresh,
+        "one auto-crank expires exactly one source domain"
+    );
     assert_eq!(market.header.vault.get(), vault_before);
     assert_eq!(account.header.capital.get(), 100);
-    assert_eq!(account.header.pnl.get(), 40);
+    assert_eq!(account.header.pnl.get(), 80);
+    assert!(!account.header.health_cert.try_to_runtime().unwrap().valid);
+
+    let second_expiry = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &observations,
+                liquidation_max_close_q: 0,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the next bounded auto-crank must expire the next domain");
+    assert_eq!(
+        second_expiry.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::SourceBackingExpired {
+            domain: 3
+        })
+    );
+    assert_eq!(
+        market.markets[1]
+            .engine
+            .backing_short
+            .try_to_runtime()
+            .unwrap()
+            .status,
+        BackingBucketStatusV16::Expired
+    );
+
+    let refresh = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &observations,
+                liquidation_max_close_q: 0,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the final bounded auto-crank must finish account refresh");
+    assert_eq!(
+        refresh.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+    );
     assert!(account.header.health_cert.try_to_runtime().unwrap().valid);
     market.validate_shape().unwrap();
     account.validate_with_market(&market.as_view()).unwrap();

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3072,6 +3072,11 @@ fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
     );
     assert!(header.current_slot.get() > before.expiry_slot);
     let vault_before = header.vault.get();
+    let c_tot_before = header.c_tot.get();
+    let insurance_before = header.insurance.get();
+    let earnings_before = header.backing_provider_earnings_total.get();
+    let source_backing_before = header.source_fresh_backing_total_num.get();
+    let risk_epoch_before = header.risk_epoch.get();
 
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
     let mut account = PortfolioV16ViewMut::new(&mut account_header);
@@ -3086,7 +3091,6 @@ fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
             AutoCrankWorkV16 {
                 now_slot: 10,
                 observations: &observations,
-                liquidation_max_close_q: 0,
                 resolved_close_fee_rate_per_slot: 0,
             },
         )
@@ -3120,6 +3124,17 @@ fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
         "one auto-crank expires exactly one source domain"
     );
     assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), c_tot_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
+    assert_eq!(
+        market.header.backing_provider_earnings_total.get(),
+        earnings_before
+    );
+    assert_eq!(
+        market.header.source_fresh_backing_total_num.get(),
+        source_backing_before - 40 * BOUND_SCALE
+    );
+    assert_eq!(market.header.risk_epoch.get(), risk_epoch_before + 1);
     assert_eq!(account.header.capital.get(), 100);
     assert_eq!(account.header.pnl.get(), 80);
     assert!(!account.header.health_cert.try_to_runtime().unwrap().valid);
@@ -3130,7 +3145,6 @@ fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
             AutoCrankWorkV16 {
                 now_slot: 10,
                 observations: &observations,
-                liquidation_max_close_q: 0,
                 resolved_close_fee_rate_per_slot: 0,
             },
         )
@@ -3150,6 +3164,15 @@ fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
             .status,
         BackingBucketStatusV16::Expired
     );
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), c_tot_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
+    assert_eq!(
+        market.header.backing_provider_earnings_total.get(),
+        earnings_before
+    );
+    assert_eq!(market.header.source_fresh_backing_total_num.get(), 0);
+    assert_eq!(market.header.risk_epoch.get(), risk_epoch_before + 2);
 
     let refresh = market
         .permissionless_auto_crank_not_atomic(
@@ -3157,7 +3180,6 @@ fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
             AutoCrankWorkV16 {
                 now_slot: 10,
                 observations: &observations,
-                liquidation_max_close_q: 0,
                 resolved_close_fee_rate_per_slot: 0,
             },
         )


### PR DESCRIPTION
## Finding

A fully public trade/partial-ADL sequence creates Fresh source backing for the winning account. Once that automatically-created bucket expires, a later adverse price move makes account refresh value the source claim. `validate_source_domain_ledger_current` returns `Stale`, but Live auto-crank had no expiry continuation. SVM rollback restores the expired bucket as `Fresh`, so every user or keeper crank repeats the same error and the position cannot make progress without privileged intervention or terminal resolution.

## Fix

The permissionless Refresh path scans the account's bounded source-domain roster and applies the existing canonical `expire_source_backing_bucket_not_atomic` transition to exactly the first lapsed Fresh bucket. It returns the explicit `SourceBackingExpired { domain }` progress outcome immediately. Repeated auto-cranks drain at most one domain per transaction, then the final call certifies the account.

The streaming selector now uses a small production scan-step kernel, preserving early exit and bounded CU while making its liveness semantics directly provable.

## Proof-driven validation

`proof_v16_live_source_backing_expiry_is_bounded_complete_and_isolated` quantifies compact roster length and every disjoint lapsed/future mask over the Kani-sized four-domain table. It composes the exact production scan-step kernel with the exact production expiry delta and proves:

- The first lapsed occupied domain is selected regardless of ordering.
- Clean rosters are no-ops and sparse tails terminate scanning.
- Every successful crank decreases the lapsed-domain rank by exactly one.
- All lapsed obligations are exhausted within the table bound.
- Future backing is never selected or mutated.
- Six clean/single/multiple/ordering/future/sparse-tail classes are reachable.

Result: 83 checks, 6/6 covers, 1.24s.

`proof_v16_counterparty_backing_expiry_reclassifies_principal_and_impairs_lien` independently quantifies fresh/liened backing and stock state through `MAX_VAULT_TVL`. It proves exact principal removal, exact lien impairment, no receivable/spent mutation, status classification, and pre/post vault-stock reconciliation.

Result: 172 checks, 4/4 covers, 3.30s.

Mutation sensitivity:

- Disabling lapsed-bucket selection fails first-match/rank progress.
- Selecting any Fresh bucket regardless of expiry fails future-domain isolation with 5/6 covers reachable.

## Additional validation

- Persisted two-domain production test proves one-domain-per-crank progress, unchanged vault/capital/insurance/earnings, aggregate backing release, risk-epoch advancement, recertification, and final shape validation.
- `cargo test --all-targets`: 136 passed (50 + 9 + 2 + 75).
- `cargo fmt --all`
- `git diff --check`
- Frozen `spec.md` unchanged.
- The stacked wrapper PR carries the public LiteSVM exploit, per-step CU, custody, and owner-exit assertions.