### PR TITLE
[REAL DoS] Bound resolved source-domain close work

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 244 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 249 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -14759,8 +14759,19 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if decode_bool(account.header.resolved_payout_receipt.present)? {
             return Ok(());
         }
-        self.initialize_resolved_payout_ledger_if_needed()?;
         let terminal_positive_claim_face = account.header.pnl.get().max(0) as u128;
+        self.append_resolved_payout_receipt_face_not_atomic(account, terminal_positive_claim_face)
+    }
+
+    fn append_resolved_payout_receipt_face_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        terminal_positive_claim_face: u128,
+    ) -> V16Result<()> {
+        if terminal_positive_claim_face == 0 {
+            return Ok(());
+        }
+        self.initialize_resolved_payout_ledger_if_needed()?;
         let prior_bound_contribution_num =
             V16Core::bound_num_from_amount(terminal_positive_claim_face)?;
         let mut ledger = self.header.resolved_payout_ledger.try_to_runtime()?;
@@ -14784,15 +14795,25 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             )?)
             .ok_or(V16Error::ArithmeticOverflow)?;
         self.header.resolved_payout_ledger = ResolvedPayoutLedgerV16Account::from_runtime(&ledger);
+        let mut receipt = account.header.resolved_payout_receipt.try_to_runtime()?;
+        if !receipt.present {
+            if !receipt.is_empty() {
+                return Err(V16Error::InvalidLeg);
+            }
+            receipt.present = true;
+        }
+        receipt.prior_bound_contribution_num = receipt
+            .prior_bound_contribution_num
+            .checked_add(prior_bound_contribution_num)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        receipt.terminal_positive_claim_face = receipt
+            .terminal_positive_claim_face
+            .checked_add(terminal_positive_claim_face)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        receipt.finalized = receipt.paid_effective == receipt.terminal_positive_claim_face;
+        validate_resolved_payout_receipt_value(receipt)?;
         account.header.resolved_payout_receipt =
-            ResolvedPayoutReceiptV16Account::from_runtime(&ResolvedPayoutReceiptV16 {
-                present: true,
-                prior_bound_contribution_num,
-                live_released_face_at_receipt: 0,
-                terminal_positive_claim_face,
-                paid_effective: 0,
-                finalized: false,
-            });
+            ResolvedPayoutReceiptV16Account::from_runtime(&receipt);
         self.recompute_resolved_payout_rate()
     }
 
@@ -15345,43 +15366,20 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
-    /// Terminal realization for a source-backed winner: realize the account's
-    /// outstanding source-credit claims against their domain backing at the
-    /// current credit rate (lien consumption -> capital credit) BEFORE the claim
-    /// face enters the junior receipt pool. A settlement-quality claim is
-    /// realizable at rate in Live (convert_released_pnl_to_capital); resolution
-    /// must not strip that entitlement -- without this step the wind-down
-    /// RELEASES the backing to the provider while the winner is haircut from a
-    /// residual pool that (correctly) excludes the very backing underwriting the
-    /// claim. Residual-neutral: capital/c_tot grow by exactly the consumed
-    /// backing atoms, so the payout snapshot does not depend on realization
-    /// order.
-    fn realize_source_backed_claims_for_resolved_close_not_atomic(
+    /// Perform at most one preparatory source-domain mutation before terminal
+    /// realization. Source claims cannot be removed piecemeal while their face
+    /// remains positive PnL: the persisted representation requires any nonempty
+    /// source roster to cover the account's full positive PnL. Lien release and
+    /// backing expiry preserve that invariant, so expose those as bounded
+    /// `ProgressOnly` steps and leave the existing aggregate realization intact.
+    fn prepare_one_source_domain_for_resolved_close_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
-    ) -> V16Result<u128> {
-        if decode_bool(account.header.resolved_payout_receipt.present)? {
-            // The face is already frozen into the receipt pool.
-            return Ok(0);
-        }
+    ) -> V16Result<Option<usize>> {
         if !Self::account_has_source_claims(&account.as_view())? {
-            return Ok(0);
+            return Ok(None);
         }
-        let pos = account.header.pnl.get().max(0) as u128;
-        if pos == 0 {
-            return Ok(0);
-        }
-        // Release the account's persisted liens first (the terminal burn would do
-        // this anyway): the conversion consumes only UNLIENED claims, so a still-
-        // liened claim would make the realizable estimate exceed what consumption
-        // can deliver and dead-lock the close with LockActive. In the same sweep,
-        // expire any domain whose backing bucket has lapsed (status Fresh but
-        // expiry_slot <= current_slot): realization is best-effort, and querying
-        // realizable support against a past-expiry bucket would otherwise return
-        // Stale and strand the winner's close. Expiry forfeits the lapsed
-        // principal to the junior pool (the documented expiry semantics), drops
-        // the domain's credit rate to zero, and lets this step fall through to
-        // the junior receipt path instead of reverting.
+        account.compact_source_domains();
         let current_slot = self.header.current_slot.get();
         let mut slot = 0usize;
         while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
@@ -15389,44 +15387,170 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             if source.has_default_sparse_tag() && !source.is_occupied() {
                 break;
             }
-            if source.is_occupied() {
-                let d = source.domain.get() as usize;
-                if source.source_claim_liened_num.get() != 0 {
-                    self.release_account_source_credit_lien_for_domain_not_atomic(account, d)?;
-                }
-                let bucket = self.backing_bucket_for_domain(d)?;
-                if bucket.status == BackingBucketStatusV16::Fresh
-                    && bucket.expiry_slot <= current_slot
-                {
-                    self.expire_source_backing_bucket_not_atomic(d, current_slot)?;
-                }
+            if !source.is_occupied() {
+                slot += 1;
+                continue;
+            }
+
+            let domain = source.domain.get() as usize;
+            self.domain_asset_side(domain)?;
+            if source.source_claim_liened_num.get() != 0 {
+                self.release_account_source_credit_lien_for_domain_not_atomic(account, domain)?;
+                account.header.health_cert.valid = 0;
+                self.validate_shape()?;
+                account.validate_with_market(&self.as_view())?;
+                return Ok(Some(domain));
+            }
+
+            let bucket = self.backing_bucket_for_domain(domain)?;
+            if bucket.status == BackingBucketStatusV16::Fresh && bucket.expiry_slot <= current_slot
+            {
+                self.expire_source_backing_bucket_not_atomic(domain, current_slot)?;
+                account.header.health_cert.valid = 0;
+                self.validate_shape()?;
+                account.validate_with_market(&self.as_view())?;
+                return Ok(Some(domain));
             }
             slot += 1;
         }
-        if self.account_source_realizable_support(&account.as_view(), pos)? == 0 {
-            return Ok(0);
+        Ok(None)
+    }
+
+    /// Settle exactly one prepared source domain. Realizable source support
+    /// becomes capital; any remaining face moves into the exact resolved payout
+    /// receipt. PnL falls by the full processed face, so the remaining source
+    /// roster still covers all remaining positive PnL at every committed step.
+    fn process_one_source_claim_for_resolved_close_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+    ) -> V16Result<Option<usize>> {
+        if !Self::account_has_source_claims(&account.as_view())? {
+            return Ok(None);
         }
-        // Terminal: PnL reservations no longer gate realization.
-        account.header.reserved_pnl = V16PodU128::new(0);
-        let converted = self.convert_released_pnl_to_capital_core_not_atomic(account)?;
-        // If the payout snapshot was captured before this account realized (another
-        // winner closed first), the realized face is still counted in the ledger's
-        // unreceipted bound. Refine it out, or the stale bound dilutes the payout
-        // rate forever and blocks every remaining receipt from reaching the
-        // terminal rate (never finalized, never clearable).
-        if decode_bool(self.header.payout_snapshot_captured)? {
-            let pos_after = account.header.pnl.get().max(0) as u128;
-            let face_burned = pos
-                .checked_sub(pos_after)
+
+        account.compact_source_domains();
+        let source = account.header.source_domains[0];
+        if !source.is_occupied() || source.source_claim_bound_num.get() == 0 {
+            return Err(V16Error::InvalidLeg);
+        }
+        let domain = source.domain.get() as usize;
+        self.domain_asset_side(domain)?;
+        if source.source_claim_liened_num.get() != 0 {
+            return Err(V16Error::LockActive);
+        }
+
+        let pos_before = account.header.pnl.get().max(0) as u128;
+        let pos_bound_num = V16Core::bound_num_from_amount(pos_before)?;
+        let realizable_claim_num =
+            Self::source_claim_unliened_num(&account.as_view(), domain)?.min(pos_bound_num);
+        let source_credit = self.source_credit_for_domain(domain)?;
+        self.validate_source_domain_ledger_current(domain)?;
+        let credited_num = U256::from_u128(realizable_claim_num)
+            .checked_mul(U256::from_u128(source_credit.credit_rate_num))
+            .and_then(|v| v.checked_div(U256::from_u128(CREDIT_RATE_SCALE)))
+            .and_then(|v| v.try_into_u128())
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        let effective = (credited_num / BOUND_SCALE)
+            .min(self.source_credit_available_backing_num(domain)? / BOUND_SCALE)
+            .min(pos_before);
+
+        if effective != 0 {
+            account.header.reserved_pnl = V16PodU128::new(0);
+            let vault_before = self.header.vault.get();
+            let consumption =
+                self.consume_source_domain_credit_for_effective_not_atomic(domain, effective)?;
+            let face_burn = consumption.face_burn.min(pos_before);
+            let face_i128 = i128::try_from(face_burn).map_err(|_| V16Error::ArithmeticOverflow)?;
+            let new_pnl = account
+                .header
+                .pnl
+                .get()
+                .checked_sub(face_i128)
+                .ok_or(V16Error::ArithmeticOverflow)?;
+            self.set_account_pnl(account, new_pnl)?;
+            account.header.capital = V16PodU128::new(
+                account
+                    .header
+                    .capital
+                    .get()
+                    .checked_add(effective)
+                    .ok_or(V16Error::ArithmeticOverflow)?,
+            );
+            self.header.c_tot = V16PodU128::new(
+                self.header
+                    .c_tot
+                    .get()
+                    .checked_add(effective)
+                    .ok_or(V16Error::ArithmeticOverflow)?,
+            );
+            self.header.pnl_matured_pos_tot = V16PodU128::new(
+                self.header
+                    .pnl_matured_pos_tot
+                    .get()
+                    .saturating_sub(face_burn),
+            );
+            let protocol_surplus_consumed = effective
+                .checked_sub(consumption.counterparty_credit_consumed)
+                .and_then(|v| v.checked_sub(consumption.insurance_credit_consumed))
                 .ok_or(V16Error::CounterUnderflow)?;
-            let ledger = self.header.resolved_payout_ledger.try_to_runtime()?;
-            let decrease_num = V16Core::bound_num_from_amount(face_burned)?
-                .min(ledger.terminal_claim_bound_unreceipted_num);
-            if decrease_num != 0 {
-                self.refine_resolved_unreceipted_bound_not_atomic(decrease_num)?;
+            TokenValueFlowProofV16::support_to_account_capital(
+                effective,
+                consumption.counterparty_credit_consumed,
+                consumption.insurance_credit_consumed,
+                protocol_surplus_consumed,
+                vault_before,
+                self.header.vault.get(),
+            )?
+            .validate()?;
+
+            if decode_bool(self.header.payout_snapshot_captured)? {
+                let ledger = self.header.resolved_payout_ledger.try_to_runtime()?;
+                let decrease_num = V16Core::bound_num_from_amount(face_burn)?
+                    .min(ledger.terminal_claim_bound_unreceipted_num);
+                if decrease_num != 0 {
+                    self.refine_resolved_unreceipted_bound_not_atomic(decrease_num)?;
+                }
             }
         }
-        Ok(converted)
+
+        let pnl_after_source = account.header.pnl.get().max(0) as u128;
+        let remaining_domain_claim_num = account
+            .as_view()
+            .source_domain(domain)?
+            .source_claim_bound_num
+            .get();
+        let total_claim_num = Self::account_source_claim_bound_sum_num(&account.as_view())?;
+        let claims_after_domain_num = total_claim_num
+            .checked_sub(remaining_domain_claim_num)
+            .ok_or(V16Error::CounterUnderflow)?;
+        let target_pnl = if claims_after_domain_num == 0 {
+            0
+        } else {
+            pnl_after_source.min(claims_after_domain_num / BOUND_SCALE)
+        };
+        let junior_face = pnl_after_source
+            .checked_sub(target_pnl)
+            .ok_or(V16Error::CounterUnderflow)?;
+        if junior_face != 0 {
+            self.initialize_resolved_payout_ledger_if_needed()?;
+            let target_i128 =
+                i128::try_from(target_pnl).map_err(|_| V16Error::ArithmeticOverflow)?;
+            self.set_account_pnl(account, target_i128)?;
+        }
+        if let Some(slot) = account.source_domain_slot(domain)? {
+            let remainder_num = account.header.source_domains[slot]
+                .source_claim_bound_num
+                .get();
+            self.burn_account_source_claim_bound_num(account, remainder_num)?;
+        }
+        if junior_face != 0 {
+            self.append_resolved_payout_receipt_face_not_atomic(account, junior_face)?;
+        }
+
+        account.header.health_cert.valid = 0;
+        self.validate_shape()?;
+        account.validate_with_market(&self.as_view())?;
+        Ok(Some(domain))
     }
 
     fn claim_resolved_payout_topup_core_not_atomic(
@@ -15539,7 +15663,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if account.header.pnl.get() > 0 && !self.resolved_positive_payout_ready()? {
             return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
         }
-        self.realize_source_backed_claims_for_resolved_close_not_atomic(account)?;
+        if self
+            .prepare_one_source_domain_for_resolved_close_not_atomic(account)?
+            .is_some()
+        {
+            return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
+        }
+        if self
+            .process_one_source_claim_for_resolved_close_not_atomic(account)?
+            .is_some()
+        {
+            return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
+        }
         let mut payout_receipt = None;
         let pnl_payout = if account.header.pnl.get() > 0
             || decode_bool(account.header.resolved_payout_receipt.present)?

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1373,6 +1373,33 @@ impl V16Core {
         (payout, new_vault)
     }
 
+    fn resolved_close_terminal_payout_delta(
+        account_capital: u128,
+        resolved_claimable: u128,
+        vault: u128,
+        c_tot: u128,
+    ) -> V16Result<(u128, u128, u128, u128, u128)> {
+        let payout = account_capital
+            .checked_add(resolved_claimable)
+            .ok_or(V16Error::ArithmeticOverflow)?
+            .min(vault);
+        let capital_paid = account_capital.min(payout);
+        let resolved_paid = payout
+            .checked_sub(capital_paid)
+            .ok_or(V16Error::CounterUnderflow)?;
+        let vault_after = vault
+            .checked_sub(payout)
+            .ok_or(V16Error::CounterUnderflow)?;
+        let c_tot_after = c_tot.saturating_sub(account_capital.min(c_tot));
+        Ok((
+            payout,
+            capital_paid,
+            resolved_paid,
+            vault_after,
+            c_tot_after,
+        ))
+    }
+
     /// PRODUCTION KERNEL (roadmap 3A.1 trade spine): classify a position change
     /// from (current signed, new signed) into its leg route — the EXACT total
     /// decision the position-delta body dispatches on. `delta != 0` is enforced
@@ -15688,14 +15715,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             0
         };
         let account_capital = account.header.capital.get();
-        let payout = account_capital
-            .checked_add(pnl_payout)
-            .ok_or(V16Error::ArithmeticOverflow)?
-            .min(self.header.vault.get());
-        let capital_paid = account_capital.min(payout);
-        let resolved_paid = payout
-            .checked_sub(capital_paid)
-            .ok_or(V16Error::CounterUnderflow)?;
+        let vault_before = self.header.vault.get();
+        let (payout, capital_paid, resolved_paid, vault_after, c_tot_after) =
+            V16Core::resolved_close_terminal_payout_delta(
+                account_capital,
+                pnl_payout,
+                vault_before,
+                self.header.c_tot.get(),
+            )?;
         if let Some(mut receipt) = payout_receipt {
             receipt = apply_resolved_payout_receipt_payment(receipt, resolved_paid)?;
             account.header.resolved_payout_receipt =
@@ -15705,20 +15732,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // (insolvency bad-debt shortfall is not an open obligation) so this close fully
         // settles instead of leaving the portfolio stuck present-but-unfinalized.
         self.clear_fully_diluted_resolved_receipt_if_terminal(account)?;
-        let vault_before = self.header.vault.get();
-        self.header.vault = V16PodU128::new(
-            self.header
-                .vault
-                .get()
-                .checked_sub(payout)
-                .ok_or(V16Error::CounterUnderflow)?,
-        );
-        self.header.c_tot = V16PodU128::new(
-            self.header
-                .c_tot
-                .get()
-                .saturating_sub(account_capital.min(self.header.c_tot.get())),
-        );
+        self.header.vault = V16PodU128::new(vault_after);
+        self.header.c_tot = V16PodU128::new(c_tot_after);
         self.set_account_pnl(account, 0)?;
         account.header.capital = V16PodU128::new(0);
         account.header.reserved_pnl = V16PodU128::new(0);

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -635,9 +635,34 @@ pub fn active_bitmap_count_ones(bitmap: V16ActiveBitmap) -> u32 {
     total
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ResolvedSourceClosePhaseV16 {
+    ReleaseLien,
+    ExpireBacking,
+    ProcessClaim,
+}
+
 struct V16Core;
 
 impl V16Core {
+    #[inline]
+    fn resolved_source_close_phase(
+        source_claim_liened_num: u128,
+        bucket_status: BackingBucketStatusV16,
+        bucket_expiry_slot: u64,
+        current_slot: u64,
+    ) -> ResolvedSourceClosePhaseV16 {
+        if source_claim_liened_num != 0 {
+            ResolvedSourceClosePhaseV16::ReleaseLien
+        } else if bucket_status == BackingBucketStatusV16::Fresh
+            && bucket_expiry_slot <= current_slot
+        {
+            ResolvedSourceClosePhaseV16::ExpireBacking
+        } else {
+            ResolvedSourceClosePhaseV16::ProcessClaim
+        }
+    }
+
     fn loss_stale_trade_scope_allowed(
         market_loss_stale_active: bool,
         trade_asset_loss_stale: bool,
@@ -15408,39 +15433,35 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         account.compact_source_domains();
         let current_slot = self.header.current_slot.get();
-        let mut slot = 0usize;
-        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
-            let source = account.header.source_domains[slot];
-            if source.has_default_sparse_tag() && !source.is_occupied() {
-                break;
-            }
-            if !source.is_occupied() {
-                slot += 1;
-                continue;
-            }
-
-            let domain = source.domain.get() as usize;
-            self.domain_asset_side(domain)?;
-            if source.source_claim_liened_num.get() != 0 {
+        let source = account.header.source_domains[0];
+        if !source.is_occupied() || source.source_claim_bound_num.get() == 0 {
+            return Err(V16Error::InvalidLeg);
+        }
+        let domain = source.domain.get() as usize;
+        self.domain_asset_side(domain)?;
+        let bucket = self.backing_bucket_for_domain(domain)?;
+        match V16Core::resolved_source_close_phase(
+            source.source_claim_liened_num.get(),
+            bucket.status,
+            bucket.expiry_slot,
+            current_slot,
+        ) {
+            ResolvedSourceClosePhaseV16::ReleaseLien => {
                 self.release_account_source_credit_lien_for_domain_not_atomic(account, domain)?;
                 account.header.health_cert.valid = 0;
                 self.validate_shape()?;
                 account.validate_with_market(&self.as_view())?;
-                return Ok(Some(domain));
+                Ok(Some(domain))
             }
-
-            let bucket = self.backing_bucket_for_domain(domain)?;
-            if bucket.status == BackingBucketStatusV16::Fresh && bucket.expiry_slot <= current_slot
-            {
+            ResolvedSourceClosePhaseV16::ExpireBacking => {
                 self.expire_source_backing_bucket_not_atomic(domain, current_slot)?;
                 account.header.health_cert.valid = 0;
                 self.validate_shape()?;
                 account.validate_with_market(&self.as_view())?;
-                return Ok(Some(domain));
+                Ok(Some(domain))
             }
-            slot += 1;
+            ResolvedSourceClosePhaseV16::ProcessClaim => Ok(None),
         }
-        Ok(None)
     }
 
     /// Settle exactly one prepared source domain. Realizable source support

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -9,6 +9,24 @@
 use super::*;
 use crate::wide_math::U256;
 
+pub fn kani_resolved_source_close_phase(
+    source_claim_liened_num: u128,
+    bucket_status: BackingBucketStatusV16,
+    bucket_expiry_slot: u64,
+    current_slot: u64,
+) -> u8 {
+    match V16Core::resolved_source_close_phase(
+        source_claim_liened_num,
+        bucket_status,
+        bucket_expiry_slot,
+        current_slot,
+    ) {
+        ResolvedSourceClosePhaseV16::ReleaseLien => 0,
+        ResolvedSourceClosePhaseV16::ExpireBacking => 1,
+        ResolvedSourceClosePhaseV16::ProcessClaim => 2,
+    }
+}
+
 pub fn kani_auto_crank_lifecycle_dispatchable(lifecycle: AssetLifecycleV16) -> bool {
     V16Core::kernel_auto_crank_lifecycle_dispatchable(lifecycle)
 }

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -1139,6 +1139,20 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.create_resolved_payout_receipt_if_needed(account)
     }
 
+    pub fn kani_resolved_close_terminal_payout_delta(
+        account_capital: u128,
+        resolved_claimable: u128,
+        vault: u128,
+        c_tot: u128,
+    ) -> V16Result<(u128, u128, u128, u128, u128)> {
+        V16Core::resolved_close_terminal_payout_delta(
+            account_capital,
+            resolved_claimable,
+            vault,
+            c_tot,
+        )
+    }
+
     pub fn kani_claim_resolved_payout_topup_core_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -1118,11 +1118,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Self::resolved_receipt_claimable_against_ledger(receipt, ledger)
     }
 
-    pub fn kani_realize_source_backed_claims_for_resolved_close_not_atomic(
+    pub fn kani_prepare_one_source_domain_for_resolved_close_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
-    ) -> V16Result<u128> {
-        self.realize_source_backed_claims_for_resolved_close_not_atomic(account)
+    ) -> V16Result<Option<usize>> {
+        self.prepare_one_source_domain_for_resolved_close_not_atomic(account)
+    }
+
+    pub fn kani_process_one_source_claim_for_resolved_close_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+    ) -> V16Result<Option<usize>> {
+        self.process_one_source_claim_for_resolved_close_not_atomic(account)
     }
 
     pub fn kani_create_resolved_payout_receipt_if_needed(

--- a/tests/backing_double_claim_fuzz.rs
+++ b/tests/backing_double_claim_fuzz.rs
@@ -16,7 +16,7 @@ use percolator::{
     Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PortfolioAccountV16Account,
     PortfolioV16ViewMut, ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedCloseOutcomeV16,
     SourceCreditStateV16, SourceCreditStateV16Account, V16Config, V16PodI128, V16PodU128,
-    V16PodU32, V16PodU64, CREDIT_RATE_SCALE,
+    V16PodU32, V16PodU64, CREDIT_RATE_SCALE, PORTFOLIO_SOURCE_DOMAIN_CAP,
 };
 use proptest::prelude::*;
 
@@ -88,6 +88,26 @@ fn winner_account(capital: u128, pnl: u128) -> PortfolioAccountV16Account {
     account_header
 }
 
+/// Drive the bounded resolved-close state machine to its terminal outcome.
+/// A source domain needs at most three successful mutations: release a lien,
+/// expire lapsed backing, and settle its source/junior claim split.
+fn close_resolved_to_completion(
+    market: &mut MarketGroupV16ViewMut<'_, u64>,
+    account: &mut PortfolioV16ViewMut<'_>,
+) -> (u128, usize) {
+    let max_progress_steps = 3 * PORTFOLIO_SOURCE_DOMAIN_CAP;
+    for progress_steps in 0..=max_progress_steps {
+        match market
+            .close_resolved_account_not_atomic(account, 0)
+            .expect("resolved close step must not revert")
+        {
+            ResolvedCloseOutcomeV16::ProgressOnly => {}
+            ResolvedCloseOutcomeV16::Closed { payout } => return (payout, progress_steps),
+        }
+    }
+    panic!("resolved close exceeded its bounded source-domain progress rank")
+}
+
 /// Close the winner, then (optionally first) withdraw the provider principal.
 /// Returns (winner_payout, vault_after_everything).
 fn run_order(
@@ -110,11 +130,7 @@ fn run_order(
             .withdraw_fresh_counterparty_backing_not_atomic(0, backing)
             .expect("provider principal must be withdrawable before the winner closes");
     }
-    let outcome = market
-        .close_resolved_account_not_atomic(&mut account, 0)
-        .expect("winner close must not revert");
-    let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { .. });
-    assert!(closed, "winner did not fully close");
+    close_resolved_to_completion(&mut market, &mut account);
     if !provider_first {
         market
             .withdraw_fresh_counterparty_backing_not_atomic(0, backing)
@@ -230,11 +246,8 @@ proptest! {
         prop_assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
 
         let vault_before = market.header.vault.get();
-        let outcome = market
-            .close_resolved_account_not_atomic(&mut account, 0)
-            .expect("backed winner close must not revert");
-        let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { payout: _ });
-        prop_assert!(closed, "backed winner did not fully close");
+        let (_, progress_steps) = close_resolved_to_completion(&mut market, &mut account);
+        prop_assert!(progress_steps >= 1);
         let paid = vault_before - market.header.vault.get();
 
         // The Live-realizable portion of the claim must reach the winner...
@@ -325,11 +338,8 @@ proptest! {
         prop_assume!(account.validate_with_market(&market.as_view()) == Ok(()));
 
         let vault_before = market.header.vault.get();
-        let outcome = market
-            .close_resolved_account_not_atomic(&mut account, 0)
-            .expect("liened backed winner close must not revert");
-        let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { payout: _ });
-        prop_assert!(closed, "liened backed winner did not fully close");
+        let (_, progress_steps) = close_resolved_to_completion(&mut market, &mut account);
+        prop_assert!(progress_steps >= 2);
         let paid = vault_before - market.header.vault.get();
 
         // Fully backed claim realizes in full after the terminal lien release.
@@ -406,7 +416,8 @@ fn realization_after_snapshot_refines_unreceipted_bound() {
 
     // B realizes against its backing at terminal close.
     let vault_before_b = market.header.vault.get();
-    market.close_resolved_account_not_atomic(&mut b, 0).unwrap();
+    let (_, progress_steps) = close_resolved_to_completion(&mut market, &mut b);
+    assert!(progress_steps >= 1);
     assert_eq!(vault_before_b - market.header.vault.get(), pnl_b);
     assert_eq!(b.header.pnl.get(), 0);
     assert_eq!(b.header.capital.get(), 0);
@@ -457,11 +468,8 @@ fn terminal_close_with_expired_backing_does_not_strand() {
     assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
 
     let vault_before = market.header.vault.get();
-    let outcome = market
-        .close_resolved_account_not_atomic(&mut account, 0)
-        .expect("expired-backing winner close must not revert (liveness)");
-    let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { payout: _ });
-    assert!(closed, "expired-backing winner did not fully close");
+    let (_, progress_steps) = close_resolved_to_completion(&mut market, &mut account);
+    assert!(progress_steps >= 2);
     let paid = vault_before - market.header.vault.get();
 
     // Expiry forfeits the lapsed principal to the junior pool: the winner is
@@ -481,6 +489,91 @@ fn terminal_close_with_expired_backing_does_not_strand() {
     assert!(market
         .withdraw_fresh_counterparty_backing_not_atomic(0, backing)
         .is_err());
+    assert_eq!(market.validate_shape(), Ok(()));
+}
+
+#[test]
+fn resolved_close_receipts_two_source_domains_one_bounded_step_at_a_time() {
+    let claim_per_domain = 10u128;
+    let total_claim = 2 * claim_per_domain;
+    let cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_id(), cfg, 1, 0).unwrap();
+    let mut markets = [Market::new(0u64, EngineAssetSlotV16Account::default())];
+    header
+        .activate_empty_asset_slot_not_atomic(0, &mut markets[0].engine, 100, 1)
+        .unwrap();
+    header.mode = 1;
+    header.resolved_slot = V16PodU64::new(1);
+    header.current_slot = V16PodU64::new(1);
+    header.vault = V16PodU128::new(total_claim);
+    header.pnl_pos_tot = V16PodU128::new(total_claim);
+    header.pnl_matured_pos_tot = V16PodU128::new(total_claim);
+    header.pnl_pos_bound_tot = V16PodU128::new(total_claim);
+    header.pnl_pos_bound_tot_num = V16PodU128::new(total_claim * BOUND_SCALE);
+    header.source_claim_bound_total_num = V16PodU128::new(total_claim * BOUND_SCALE);
+
+    let domain_claim_num = claim_per_domain * BOUND_SCALE;
+    let source = SourceCreditStateV16 {
+        positive_claim_bound_num: domain_claim_num,
+        exact_positive_claim_num: domain_claim_num,
+        credit_rate_num: 0,
+        ..SourceCreditStateV16::EMPTY
+    };
+    markets[0].engine.source_credit_long = SourceCreditStateV16Account::from_runtime(&source);
+    markets[0].engine.source_credit_short = SourceCreditStateV16Account::from_runtime(&source);
+
+    let engine_market_id = markets[0].engine.asset.market_id.get();
+    let mut account_header = winner_account(0, total_claim);
+    for domain in 0..2usize {
+        account_header.source_domains[domain].domain = V16PodU32::new(domain as u32);
+        account_header.source_domains[domain].source_claim_market_id =
+            V16PodU64::new(engine_market_id);
+        account_header.source_domains[domain].source_claim_bound_num =
+            V16PodU128::new(domain_claim_num);
+    }
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    assert_eq!(market.validate_shape(), Ok(()));
+    assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
+
+    for remaining_domains in [1usize, 0usize] {
+        assert_eq!(
+            market.close_resolved_account_not_atomic(&mut account, 0),
+            Ok(ResolvedCloseOutcomeV16::ProgressOnly),
+        );
+        let occupied = account
+            .header
+            .source_domains
+            .iter()
+            .filter(|source| source.source_claim_bound_num.get() != 0)
+            .count();
+        assert_eq!(occupied, remaining_domains);
+        assert_eq!(
+            account.header.pnl.get(),
+            (remaining_domains as i128) * (claim_per_domain as i128),
+        );
+        let receipt = account
+            .header
+            .resolved_payout_receipt
+            .try_to_runtime()
+            .unwrap();
+        assert_eq!(
+            receipt.terminal_positive_claim_face,
+            (2 - remaining_domains as u128) * claim_per_domain,
+        );
+        assert_eq!(market.validate_shape(), Ok(()));
+        assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
+    }
+
+    assert_eq!(
+        market.close_resolved_account_not_atomic(&mut account, 0),
+        Ok(ResolvedCloseOutcomeV16::Closed {
+            payout: total_claim,
+        }),
+    );
+    assert_eq!(market.header.vault.get(), 0);
+    assert_eq!(account.header.pnl.get(), 0);
     assert_eq!(market.validate_shape(), Ok(()));
 }
 
@@ -511,12 +604,8 @@ proptest! {
         prop_assume!(account.validate_with_market(&market.as_view()) == Ok(()));
 
         let vault_before = market.header.vault.get();
-        let outcome = market
-            .close_resolved_account_not_atomic(&mut account, 0)
-            .expect("backed winner close must not revert at any backing level (no DoS)");
-        // No DoS: the close fully settles rather than stalling.
-        let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { payout: _ });
-        prop_assert!(closed, "close did not finalize at backing={}", backing);
+        let (_, progress_steps) = close_resolved_to_completion(&mut market, &mut account);
+        prop_assert!(progress_steps >= 1);
         let paid = vault_before - market.header.vault.get();
 
         // No LoF: value conserved (paid out of the vault, nothing minted),

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -32,7 +32,7 @@ use percolator::v16::{
     ResolvedPayoutLedgerV16, ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16,
     ResolvedPayoutReceiptV16Account, SideModeV16, SideV16, SourceCreditStateV16,
     SourceCreditStateV16Account, StockReconciliationProofV16, TokenValueClassV16,
-    TokenValueFlowProofV16, V16Config, V16ConfigAccount, V16Error,
+    TokenValueFlowProofV16, TradeRequestV16, V16Config, V16ConfigAccount, V16Error,
     V16OptionalRecoveryReasonAccount, V16PodI128, V16PodU128, V16PodU32, V16PodU64,
     BACKING_FEE_RATE_DEN_E9, MAX_BACKING_FEE_RATE_E9_PER_SLOT, MAX_BACKING_FEE_UTIL_BPS,
     PORTFOLIO_SOURCE_DOMAIN_CAP, V16_EMPTY_ACTIVE_BITMAP, V16_MAX_PORTFOLIO_ASSETS_N,
@@ -8649,37 +8649,51 @@ fn proof_v16_two_resolved_receipts_are_order_independent_when_snapshot_funded() 
 }
 
 #[kani::proof]
-#[kani::unwind(40)]
+#[kani::unwind(8)]
 #[kani::solver(cadical)]
-fn proof_v16_public_resolved_close_flat_account_pays_only_capital_and_vault() {
-    let capital_raw: u8 = kani::any();
-    kani::assume((1..=5).contains(&capital_raw));
-    let capital = capital_raw as u128;
-    let (mut header, mut markets, mut account_header) = one_market_view_fixture();
-    header.mode = 1;
-    header.current_slot = V16PodU64::new(2);
-    header.resolved_slot = V16PodU64::new(2);
-    header.vault = V16PodU128::new(capital);
-    header.c_tot = V16PodU128::new(capital);
-    account_header.capital = V16PodU128::new(capital);
-    account_header.pnl = V16PodI128::new(0);
-    account_header.last_fee_slot = V16PodU64::new(2);
-    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
-    let mut account = PortfolioV16ViewMut::new(&mut account_header);
-
-    let outcome = market
-        .close_resolved_account_not_atomic(&mut account, 0)
+fn proof_v16_resolved_close_terminal_payout_conserves_vault_and_value_classes() {
+    let account_capital = kani::any::<u64>() as u128;
+    let resolved_claimable = kani::any::<u64>() as u128;
+    let vault = kani::any::<u64>() as u128;
+    let c_tot = kani::any::<u64>() as u128;
+    kani::assume(account_capital <= MAX_VAULT_TVL);
+    kani::assume(resolved_claimable <= MAX_VAULT_TVL);
+    kani::assume(vault <= MAX_VAULT_TVL);
+    kani::assume(c_tot <= MAX_VAULT_TVL);
+    let (payout, capital_paid, resolved_paid, vault_after, c_tot_after) =
+        MarketGroupV16ViewMut::<u64>::kani_resolved_close_terminal_payout_delta(
+            account_capital,
+            resolved_claimable,
+            vault,
+            c_tot,
+        )
         .unwrap();
 
-    kani::cover!(capital > 1, "resolved flat close pays nontrivial capital");
-    assert_eq!(outcome, ResolvedCloseOutcomeV16::Closed { payout: capital });
-    assert_eq!(market.header.vault.get(), 0);
-    assert_eq!(market.header.c_tot.get(), 0);
-    assert_eq!(account.header.capital.get(), 0);
-    assert_eq!(account.header.pnl.get(), 0);
-    assert_eq!(account.header.reserved_pnl.get(), 0);
-    assert_eq!(market.validate_shape(), Ok(()));
-    assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
+    kani::cover!(
+        vault < account_capital && vault > 0,
+        "scarce vault pays only part of account capital"
+    );
+    kani::cover!(
+        vault > account_capital && vault < account_capital + resolved_claimable,
+        "scarce vault pays capital plus part of the resolved claim"
+    );
+    kani::cover!(
+        vault >= account_capital + resolved_claimable
+            && account_capital > 0
+            && resolved_claimable > 0,
+        "funded vault pays both value classes in full"
+    );
+
+    assert_eq!(payout, (account_capital + resolved_claimable).min(vault));
+    assert_eq!(capital_paid + resolved_paid, payout);
+    assert!(capital_paid <= account_capital);
+    assert!(resolved_paid <= resolved_claimable);
+    assert_eq!(vault_after + payout, vault);
+    assert_eq!(c_tot_after + account_capital.min(c_tot), c_tot);
+    if vault >= account_capital + resolved_claimable {
+        assert_eq!(capital_paid, account_capital);
+        assert_eq!(resolved_paid, resolved_claimable);
+    }
 }
 
 #[kani::proof]

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -16,26 +16,27 @@ use percolator::v16::{
     kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
     kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
-    kani_prepare_asset_recovery_transition, kani_select_auto_crank_plan,
-    kani_should_clear_prior_reset_obligation, kani_source_credit_state_realizable_support_for_face,
-    kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
-    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
-    ActionableSummaryV16, AssetLifecycleV16, AssetStateV16, AssetStateV16Account, AutoCrankPlanV16,
-    BackingBucketStatusV16, BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16,
-    CloseProgressLedgerV16, CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16,
-    HealthCertV16, HealthCertV16Account, InsuranceCreditReservationV16,
-    InsuranceCreditReservationV16Account, Market, MarketGroupV16HeaderAccount, MarketGroupV16View,
-    MarketGroupV16ViewMut, PermissionlessCrankActionV16, PermissionlessCrankRequestV16,
-    PermissionlessProgressOutcomeV16, PermissionlessRecoveryReasonV16, PortfolioAccountV16Account,
-    PortfolioLegV16, PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View,
-    PortfolioV16ViewMut, ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedCloseOutcomeV16,
-    ResolvedPayoutLedgerV16, ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16,
-    ResolvedPayoutReceiptV16Account, SideModeV16, SideV16, SourceCreditStateV16,
-    SourceCreditStateV16Account, StockReconciliationProofV16, TokenValueClassV16,
-    TokenValueFlowProofV16, TradeRequestV16, V16Config, V16ConfigAccount, V16Error,
-    V16OptionalRecoveryReasonAccount, V16PodI128, V16PodU128, V16PodU32, V16PodU64,
-    BACKING_FEE_RATE_DEN_E9, MAX_BACKING_FEE_RATE_E9_PER_SLOT, MAX_BACKING_FEE_UTIL_BPS,
-    PORTFOLIO_SOURCE_DOMAIN_CAP, V16_EMPTY_ACTIVE_BITMAP, V16_MAX_PORTFOLIO_ASSETS_N,
+    kani_prepare_asset_recovery_transition, kani_resolved_source_close_phase,
+    kani_select_auto_crank_plan, kani_should_clear_prior_reset_obligation,
+    kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
+    kani_trade_preexisting_oi_reduction_gate, kani_trade_preflight_risk_gate,
+    kani_validate_positive_pnl_source_attribution, ActionableSummaryV16, AssetLifecycleV16,
+    AssetStateV16, AssetStateV16Account, AutoCrankPlanV16, BackingBucketStatusV16,
+    BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
+    CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
+    HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
+    Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
+    PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
+    PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
+    PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
+    ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedPayoutLedgerV16,
+    ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16, ResolvedPayoutReceiptV16Account,
+    SideModeV16, SideV16, SourceCreditStateV16, SourceCreditStateV16Account,
+    StockReconciliationProofV16, TokenValueClassV16, TokenValueFlowProofV16, V16Config,
+    V16ConfigAccount, V16Error, V16OptionalRecoveryReasonAccount, V16PodI128, V16PodU128,
+    V16PodU32, V16PodU64, BACKING_FEE_RATE_DEN_E9, MAX_BACKING_FEE_RATE_E9_PER_SLOT,
+    MAX_BACKING_FEE_UTIL_BPS, PORTFOLIO_SOURCE_DOMAIN_CAP, V16_EMPTY_ACTIVE_BITMAP,
+    V16_MAX_PORTFOLIO_ASSETS_N,
 };
 use percolator::v16::{
     kani_eq_engine_asset_slot_v16_account, kani_eq_market_group_v16_header_account,
@@ -8694,6 +8695,75 @@ fn proof_v16_resolved_close_terminal_payout_conserves_vault_and_value_classes() 
         assert_eq!(capital_paid, account_capital);
         assert_eq!(resolved_paid, resolved_claimable);
     }
+}
+
+// Inductive liveness theorem for the production resolved-source phase selector. Every domain has
+// one terminal claim step plus at most one lien release and one backing expiry. The untouched tail
+// rank represents every remaining domain, so this proves the full 28-domain bound rather than a
+// fixture-sized trace. Public max-shape regressions bind the selector to the close route and CU cap.
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_resolved_source_close_phase_strictly_decreases_global_rank() {
+    let liened: bool = kani::any();
+    let status_raw: u8 = kani::any();
+    let expiry_slot: u8 = kani::any();
+    let current_slot: u8 = kani::any();
+    let remaining_domains: u8 = kani::any();
+    let tail_rank: u8 = kani::any();
+    kani::assume(status_raw <= 3);
+    kani::assume(remaining_domains >= 1);
+    kani::assume(remaining_domains as usize <= PORTFOLIO_SOURCE_DOMAIN_CAP);
+    let min_tail_rank = remaining_domains - 1;
+    let max_tail_rank = 3 * (remaining_domains - 1);
+    kani::assume(tail_rank >= min_tail_rank && tail_rank <= max_tail_rank);
+
+    let status = match status_raw {
+        0 => BackingBucketStatusV16::Empty,
+        1 => BackingBucketStatusV16::Fresh,
+        2 => BackingBucketStatusV16::Expired,
+        _ => BackingBucketStatusV16::Impaired,
+    };
+    let lapsed = status == BackingBucketStatusV16::Fresh && expiry_slot <= current_slot;
+    let phase = kani_resolved_source_close_phase(
+        if liened { BOUND_SCALE } else { 0 },
+        status,
+        expiry_slot as u64,
+        current_slot as u64,
+    );
+    let current_rank = 1u8 + u8::from(liened) + u8::from(lapsed);
+    let rank_before = tail_rank + current_rank;
+    let rank_after = match phase {
+        0 => tail_rank + 1 + u8::from(lapsed),
+        1 => tail_rank + 1,
+        2 => tail_rank,
+        _ => unreachable!(),
+    };
+
+    kani::cover!(
+        liened && lapsed && remaining_domains as usize == PORTFOLIO_SOURCE_DOMAIN_CAP,
+        "max-domain close releases a lien before retaining its pending expiry"
+    );
+    kani::cover!(
+        !liened && lapsed && remaining_domains > 1,
+        "an expired first domain progresses while a nonempty tail remains"
+    );
+    kani::cover!(
+        !liened && !lapsed && remaining_domains > 1 && tail_rank > min_tail_rank,
+        "a prepared claim is processed with nontrivial later obligations"
+    );
+    kani::cover!(
+        !liened && !lapsed && remaining_domains == 1 && tail_rank == 0,
+        "the final prepared claim reaches the zero-rank base case"
+    );
+
+    assert_eq!(phase == 0, liened);
+    assert_eq!(phase == 1, !liened && lapsed);
+    assert_eq!(phase == 2, !liened && !lapsed);
+    assert_eq!(rank_after + 1, rank_before);
+    assert!(rank_after < rank_before);
+    assert!(rank_before >= remaining_domains);
+    assert!(rank_before <= 3 * remaining_domains);
 }
 
 #[kani::proof]


### PR DESCRIPTION
## What changed

- Split resolved source-domain teardown into bounded committed continuations.
- Release at most one source lien or expire at most one lapsed backing bucket per call.
- Settle one prepared source claim per call, realizing backed value into capital and receipting the remaining junior face.
- Keep final capital and receipt payout in the terminal close call.
- Route terminal payout arithmetic through a production kernel proved over the configured value range.

## Root cause

A public max-shape account can accumulate 28 historical source domains through ordinary trades across 14 assets. Resolved close previously swept all domains in one call. Both fresh and lapsed variants consumed the SVM ceiling of 1,400,000 CU, aborted, and rolled back forever.

## Broad proof-driven validation

`proof_v16_resolved_source_close_phase_strictly_decreases_global_rank` proves the production phase selector over every lien/lapsed/prepared state and an inductive tail representing all remaining domains. Every successful continuation decreases the exact global source-close rank by one, preserves the remaining obligations, reaches zero, and requires at most three steps per domain across the full 28-domain bound. Covers include max-domain lien release, expiry with a nonempty tail, prepared-claim progress, and the terminal zero-rank case.

`proof_v16_resolved_close_terminal_payout_conserves_vault_and_value_classes` quantifies account capital, resolved claim, vault, and `c_tot` through `MAX_VAULT_TVL`. It proves payout is exactly bounded by claim and custody, capital/receipt sources remain disjoint, and vault/value ledgers debit consistently across scarce and fully funded states.

The public fresh/lapsed parent scenarios fail at exactly 1,400,000 CU; fixed production continuations reduce the proved rank and converge. Production regressions bind the phase kernel to the public close route, so this is not only a model of intended behavior.

Additional checks:

- terminal payout theorem: 35 checks, 3/3 scarcity/funding covers;
- fresh and expired counterparty terminal-lien proofs;
- impaired-insurance terminal-lien proof;
- `cargo test --all-targets --quiet`: all engine tests pass;
- public wrapper PDD: https://github.com/aeyakovenko/percolator-prog/pull/205.
