### PR TITLE
[REAL DoS] Bound resolved active-leg teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 244 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 249 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -276,6 +276,23 @@ fn active_bitmap_with_cleared(
 }
 
 #[inline]
+fn first_active_bitmap_slot(bitmap: V16ActiveBitmap) -> V16Result<Option<usize>> {
+    let mut word_index = 0usize;
+    while word_index < V16_ACTIVE_BITMAP_WORDS {
+        let word = bitmap[word_index];
+        if word != 0 {
+            let slot = word_index * 64 + word.trailing_zeros() as usize;
+            if slot >= V16_MAX_PORTFOLIO_ASSETS_N {
+                return Err(V16Error::InvalidLeg);
+            }
+            return Ok(Some(slot));
+        }
+        word_index += 1;
+    }
+    Ok(None)
+}
+
+#[inline]
 fn liquidation_remaining_active_bitmap_after_close(
     active_bitmap: V16ActiveBitmap,
     leg_slot_index: usize,
@@ -13140,9 +13157,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let asset = V16Core::kernel_clear_leg(leg, asset)?;
         account.header.legs[leg_slot] =
             PortfolioLegV16Account::from_runtime(&PortfolioLegV16::EMPTY);
-        let mut bitmap = account.header.active_bitmap.map(V16PodU64::get);
-        active_bitmap_clear(&mut bitmap, leg_slot)?;
-        account.header.active_bitmap = bitmap.map(V16PodU64::new);
+        account.header.active_bitmap =
+            active_bitmap_with_cleared(account.header.active_bitmap.map(V16PodU64::get), leg_slot)?
+                .map(V16PodU64::new);
         account.header.health_cert.valid = 0;
         self.set_asset_state(asset_index, asset)?;
         Ok(())
@@ -13184,9 +13201,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let asset = V16Core::kernel_clear_leg(leg, asset)?;
         account.header.legs[leg_slot] =
             PortfolioLegV16Account::from_runtime(&PortfolioLegV16::EMPTY);
-        let mut bitmap = account.header.active_bitmap.map(V16PodU64::get);
-        active_bitmap_clear(&mut bitmap, leg_slot)?;
-        account.header.active_bitmap = bitmap.map(V16PodU64::new);
+        account.header.active_bitmap =
+            active_bitmap_with_cleared(account.header.active_bitmap.map(V16PodU64::get), leg_slot)?
+                .map(V16PodU64::new);
         account.header.health_cert.valid = 0;
         self.set_asset_state(asset_index, asset)?;
         Ok(())
@@ -15772,43 +15789,40 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Ok(false);
         }
 
-        let configured_max = self.header.config.max_market_slots.get() as usize;
-        // Readiness and teardown are account-local but potentially expensive per
-        // leg. Inspect only the deterministic first active leg in this step.
-        let mut slot = 0usize;
-        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
-            let leg = account.header.legs[slot].try_to_runtime()?;
-            if leg.active {
-                if leg.b_stale || leg.stale {
-                    return Ok(false);
-                }
-                let asset_index = leg.asset_index as usize;
-                if asset_index >= configured_max {
-                    return Err(V16Error::InvalidLeg);
-                }
-                if self.has_pending_domain_loss_barrier(asset_index, leg.side)? {
-                    return Ok(false);
-                }
-                let asset = self.asset_state(asset_index)?;
-                if Self::leg_has_exhausted_effective_oi(asset, leg) {
-                    // A legacy Live state may resolve before its next auto-crank.
-                    // Establish the same terminal reset epoch here so resolved
-                    // teardown does not subtract stored basis from zero OI.
-                    self.begin_full_drain_reset_inner(asset_index, leg.side)?;
-                }
-                let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;
-                if k_target != leg.k_snap || f_target != leg.f_snap {
-                    return Ok(false);
-                }
-                if self.b_target_for_leg(asset_index, leg)? != leg.b_snap {
-                    return Ok(false);
-                }
-                self.clear_resolved_close_leg(account, asset_index)?;
-                return Ok(true);
-            }
-            slot += 1;
+        let bitmap = account.header.active_bitmap.map(V16PodU64::get);
+        let Some(slot) = first_active_bitmap_slot(bitmap)? else {
+            return Ok(false);
+        };
+        let leg = account.header.legs[slot].try_to_runtime()?;
+        if !leg.active {
+            return Err(V16Error::HiddenLeg);
         }
-        Ok(false)
+        if leg.b_stale || leg.stale {
+            return Ok(false);
+        }
+        let asset_index = leg.asset_index as usize;
+        if asset_index >= self.header.config.max_market_slots.get() as usize {
+            return Err(V16Error::InvalidLeg);
+        }
+        if self.has_pending_domain_loss_barrier(asset_index, leg.side)? {
+            return Ok(false);
+        }
+        let asset = self.asset_state(asset_index)?;
+        if Self::leg_has_exhausted_effective_oi(asset, leg) {
+            // A legacy Live state may resolve before its next auto-crank.
+            // Establish the same terminal reset epoch here so resolved
+            // teardown does not subtract stored basis from zero OI.
+            self.begin_full_drain_reset_inner(asset_index, leg.side)?;
+        }
+        let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;
+        if k_target != leg.k_snap || f_target != leg.f_snap {
+            return Ok(false);
+        }
+        if self.b_target_for_leg(asset_index, leg)? != leg.b_snap {
+            return Ok(false);
+        }
+        self.clear_resolved_close_leg(account, asset_index)?;
+        Ok(true)
     }
 
     pub fn deposit_not_atomic(

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -15679,7 +15679,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if account.header.pnl.get() < 0 {
             self.settle_resolved_bankruptcy_negative_pnl(account)?;
         }
-        self.detach_solvent_active_legs_for_resolved_close(account)?;
+        if self.detach_one_solvent_active_leg_for_resolved_close(account)? {
+            self.validate_shape()?;
+            self.validate_account_audit_scan(&account.as_view())?;
+            return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
+        }
         if !active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get))
             || account.header.pnl.get() < 0
             || decode_bool(account.header.b_stale_state)?
@@ -15752,10 +15756,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(ResolvedCloseOutcomeV16::Closed { payout })
     }
 
-    fn detach_solvent_active_legs_for_resolved_close(
+    fn detach_one_solvent_active_leg_for_resolved_close(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
-    ) -> V16Result<()> {
+    ) -> V16Result<bool> {
         if account.header.pnl.get() < 0
             || decode_bool(account.header.b_stale_state)?
             || decode_bool(account.header.stale_state)?
@@ -15765,23 +15769,25 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .try_to_runtime()?
                 .has_pending_residual()
         {
-            return Ok(());
+            return Ok(false);
         }
 
         let configured_max = self.header.config.max_market_slots.get() as usize;
+        // Readiness and teardown are account-local but potentially expensive per
+        // leg. Inspect only the deterministic first active leg in this step.
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
             if leg.active {
                 if leg.b_stale || leg.stale {
-                    return Ok(());
+                    return Ok(false);
                 }
                 let asset_index = leg.asset_index as usize;
                 if asset_index >= configured_max {
                     return Err(V16Error::InvalidLeg);
                 }
                 if self.has_pending_domain_loss_barrier(asset_index, leg.side)? {
-                    return Ok(());
+                    return Ok(false);
                 }
                 let asset = self.asset_state(asset_index)?;
                 if Self::leg_has_exhausted_effective_oi(asset, leg) {
@@ -15792,24 +15798,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 }
                 let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;
                 if k_target != leg.k_snap || f_target != leg.f_snap {
-                    return Ok(());
+                    return Ok(false);
                 }
                 if self.b_target_for_leg(asset_index, leg)? != leg.b_snap {
-                    return Ok(());
+                    return Ok(false);
                 }
+                self.clear_resolved_close_leg(account, asset_index)?;
+                return Ok(true);
             }
             slot += 1;
         }
-
-        let mut slot = 0usize;
-        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
-            let leg = account.header.legs[slot].try_to_runtime()?;
-            if leg.active {
-                self.clear_resolved_close_leg(account, leg.asset_index as usize)?;
-            }
-            slot += 1;
-        }
-        Ok(())
+        Ok(false)
     }
 
     pub fn deposit_not_atomic(

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -123,6 +123,35 @@ pub fn kani_active_bitmap_set(
     active_bitmap_set(bitmap, leg_slot_index)
 }
 
+pub fn kani_active_bitmap_with_cleared(
+    bitmap: V16ActiveBitmap,
+    leg_slot_index: usize,
+) -> V16Result<V16ActiveBitmap> {
+    active_bitmap_with_cleared(bitmap, leg_slot_index)
+}
+
+pub fn kani_first_active_bitmap_slot(bitmap: V16ActiveBitmap) -> V16Result<Option<usize>> {
+    first_active_bitmap_slot(bitmap)
+}
+
+pub fn kani_build_resolved_close_rank(
+    b_stale: bool,
+    pnl: i128,
+    active_bitmap: V16ActiveBitmap,
+    capital: u128,
+    receipt_present: bool,
+    recovery_required: bool,
+) -> ResolvedCloseRankV16 {
+    V16Core::build_resolved_close_rank(
+        b_stale,
+        pnl,
+        active_bitmap,
+        capital,
+        receipt_present,
+        recovery_required,
+    )
+}
+
 pub fn kani_liquidation_close_would_leave_uncovered_loss_with_open_risk(
     pnl: i128,
     capital: u128,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -1770,7 +1770,7 @@ pub enum TradeRejectReasonV16 {
 pub struct ResolvedCloseRankV16 {
     pub b_stale: bool,           // outstanding B settlement
     pub negative_pnl: bool,      // unsettled negative PnL
-    pub active_leg: bool,        // an open leg remains
+    pub active_leg_count: u32,   // exact number of open legs remaining
     pub receipt_claim: bool,     // an unpaid resolved receipt claim
     pub capital: bool,           // residual capital to disburse
     pub recovery_required: bool, // the explicit recovery predicate holds
@@ -1779,7 +1779,11 @@ pub struct ResolvedCloseRankV16 {
 impl ResolvedCloseRankV16 {
     #[cfg_attr(not(kani), allow(dead_code))] // PROOF-ONLY: used by kernel_resolved_close_progress (fidelity model)
     pub fn has_pending(self) -> bool {
-        self.b_stale || self.negative_pnl || self.active_leg || self.receipt_claim || self.capital
+        self.b_stale
+            || self.negative_pnl
+            || self.active_leg_count != 0
+            || self.receipt_claim
+            || self.capital
     }
 }
 
@@ -2022,14 +2026,14 @@ impl V16Core {
     /// PRODUCTION FIDELITY BUILDER (roadmap 3C step 3, A7 close-rank): map the
     /// real resolved-close per-component signals to the compact rank summary that
     /// kernel_resolved_close_progress classifies. Each rank flag is EXACTLY its
-    /// production predicate — b-stale bit, negative PnL, a live leg (non-empty
-    /// active bitmap), residual capital, an open receipt, and the explicit
+    /// production predicate — b-stale bit, negative PnL, the exact active-bitmap
+    /// population count, residual capital, an open receipt, and the explicit
     /// recovery predicate — so the close-rank summary faithfully represents the
     /// real account/market state (no hidden pending component outside it). Pure.
     #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|r: &ResolvedCloseRankV16| {
         r.b_stale == b_stale
             && r.negative_pnl == (pnl < 0)
-            && r.active_leg == !active_bitmap_is_empty(active_bitmap)
+            && r.active_leg_count == active_bitmap_count_ones(active_bitmap)
             && r.capital == (capital > 0)
             && r.receipt_claim == receipt_present
             && r.recovery_required == recovery_required
@@ -2046,7 +2050,7 @@ impl V16Core {
         ResolvedCloseRankV16 {
             b_stale,
             negative_pnl: pnl < 0,
-            active_leg: !active_bitmap_is_empty(active_bitmap),
+            active_leg_count: active_bitmap_count_ones(active_bitmap),
             capital: capital > 0,
             receipt_claim: receipt_present,
             recovery_required,

--- a/src/v16_proofs.rs
+++ b/src/v16_proofs.rs
@@ -2488,8 +2488,8 @@ fn contract_check_kernel_cert_is_current() {
 
 // ROADMAP 3C step 3 (A7 close-rank fidelity): full-domain contract check that
 // build_resolved_close_rank maps each real per-component signal to its rank flag
-// (b-stale, negative PnL, live leg via non-empty bitmap, capital, receipt,
-// recovery). unwind(16): the active-bitmap is-empty scan / memcmp.
+// (b-stale, negative PnL, exact live-leg count, capital, receipt,
+// recovery). unwind(16): the active-bitmap population scan.
 #[cfg(all(kani, feature = "contracts"))]
 #[kani::proof_for_contract(V16Core::build_resolved_close_rank)]
 #[kani::unwind(16)]

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -3,13 +3,14 @@
 use percolator::v16::{
     active_bitmap_count_ones, active_bitmap_get, active_bitmap_is_empty,
     backing_domain_fee_split_for_lien_delta_num, kani_active_bitmap_set as active_bitmap_set,
-    kani_add_open_interest_for_new_position, kani_apply_backing_provider_earnings_withdraw,
-    kani_apply_backing_utilization_fee_charge, kani_apply_resolved_payout_receipt_payment,
-    kani_auto_crank_leg_flags, kani_auto_crank_lifecycle_dispatchable,
-    kani_available_backing_num_for_source_credit_state,
+    kani_active_bitmap_with_cleared, kani_add_open_interest_for_new_position,
+    kani_apply_backing_provider_earnings_withdraw, kani_apply_backing_utilization_fee_charge,
+    kani_apply_resolved_payout_receipt_payment, kani_auto_crank_leg_flags,
+    kani_auto_crank_lifecycle_dispatchable, kani_available_backing_num_for_source_credit_state,
     kani_backing_utilization_fee_quote_atoms_for_lien,
-    kani_backing_utilization_rate_e9_for_source_state, kani_cert_is_current,
-    kani_expected_source_credit_rate_num_for_state, kani_first_actionable_slot,
+    kani_backing_utilization_rate_e9_for_source_state, kani_build_resolved_close_rank,
+    kani_cert_is_current, kani_expected_source_credit_rate_num_for_state,
+    kani_first_actionable_slot, kani_first_active_bitmap_slot,
     kani_health_cert_after_capital_debit, kani_health_requirements_from_base_and_target_lag,
     kani_liquidation_close_would_leave_uncovered_loss_with_open_risk,
     kani_liquidation_engine_close_request_q, kani_liquidation_fee_from_raw_fee,
@@ -237,6 +238,100 @@ fn proof_v16_active_bitmap_set_get_count_is_exact_and_bounds_checked() {
         assert!(!active_bitmap_get(bitmap, slot));
         assert_eq!(after_count, before_count);
     }
+}
+
+#[kani::proof]
+#[kani::unwind(17)]
+#[kani::solver(cadical)]
+fn proof_v16_resolved_leg_detach_exhausts_exact_rank_and_frames_other_obligations() {
+    assert_eq!(V16_ACTIVE_BITMAP_WORDS, 1);
+    assert!(V16_MAX_PORTFOLIO_ASSETS_N < 64);
+
+    let raw_bitmap: u64 = kani::any();
+    let valid_mask = (1u64 << V16_MAX_PORTFOLIO_ASSETS_N) - 1;
+    let mut bitmap = V16_EMPTY_ACTIVE_BITMAP;
+    bitmap[0] = raw_bitmap & valid_mask;
+
+    let b_stale: bool = kani::any();
+    let negative_pnl: bool = kani::any();
+    let capital_pending: bool = kani::any();
+    let receipt_present: bool = kani::any();
+    let recovery_required: bool = kani::any();
+    let pnl = if negative_pnl { -1 } else { 0 };
+    let capital = u128::from(capital_pending);
+    let initial_count = active_bitmap_count_ones(bitmap);
+    let mut steps = 0u32;
+
+    kani::cover!(
+        initial_count == 0,
+        "resolved account can begin without active legs"
+    );
+    kani::cover!(
+        initial_count == 1,
+        "resolved account can begin with one active leg"
+    );
+    kani::cover!(
+        initial_count == V16_MAX_PORTFOLIO_ASSETS_N as u32,
+        "resolved account can begin at the maximum active-leg shape"
+    );
+    kani::cover!(
+        initial_count >= 2 && bitmap[0] & 1 == 0,
+        "sparse active-leg sets require deterministic repeated teardown"
+    );
+    kani::cover!(
+        initial_count > 0
+            && b_stale
+            && negative_pnl
+            && capital_pending
+            && receipt_present
+            && recovery_required,
+        "leg teardown frames every unrelated resolved-close obligation"
+    );
+
+    loop {
+        let Some(slot) = kani_first_active_bitmap_slot(bitmap).unwrap() else {
+            break;
+        };
+        let before = kani_build_resolved_close_rank(
+            b_stale,
+            pnl,
+            bitmap,
+            capital,
+            receipt_present,
+            recovery_required,
+        );
+        assert_eq!(slot, bitmap[0].trailing_zeros() as usize);
+        assert!(active_bitmap_get(bitmap, slot));
+
+        let after_bitmap = kani_active_bitmap_with_cleared(bitmap, slot).unwrap();
+        let after = kani_build_resolved_close_rank(
+            b_stale,
+            pnl,
+            after_bitmap,
+            capital,
+            receipt_present,
+            recovery_required,
+        );
+
+        assert_eq!(after.active_leg_count + 1, before.active_leg_count);
+        assert_eq!(after.b_stale, before.b_stale);
+        assert_eq!(after.negative_pnl, before.negative_pnl);
+        assert_eq!(after.capital, before.capital);
+        assert_eq!(after.receipt_claim, before.receipt_claim);
+        assert_eq!(after.recovery_required, before.recovery_required);
+        assert_eq!(after_bitmap[0], bitmap[0] & !(1u64 << slot));
+        assert_eq!(
+            active_bitmap_count_ones(after_bitmap) + steps + 1,
+            initial_count
+        );
+
+        bitmap = after_bitmap;
+        steps += 1;
+    }
+
+    assert!(active_bitmap_is_empty(bitmap));
+    assert_eq!(steps, initial_count);
+    assert!(steps <= V16_MAX_PORTFOLIO_ASSETS_N as u32);
 }
 
 #[kani::proof]

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1,6 +1,6 @@
 use percolator::{
-    auto_crank_plan_requires_caller_observation, AutoCrankObservationV16, AutoCrankOutcomeV16,
-    AutoCrankPlanV16, AutoCrankWorkV16,
+    active_bitmap_is_empty, auto_crank_plan_requires_caller_observation, AutoCrankObservationV16,
+    AutoCrankOutcomeV16, AutoCrankPlanV16, AutoCrankWorkV16,
 };
 use percolator::{
     v16_domain_count_for_market_slots, AssetLifecycleV16, AssetStateV16Account,
@@ -856,6 +856,75 @@ fn v16_batch_trade_applies_multiple_fills_after_inline_refresh() {
     );
     market.validate_shape().unwrap();
     long.validate_with_market(&market.as_view()).unwrap();
+    short.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_resolved_close_detaches_one_active_leg_per_progress_step() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut long_header = account_fixture(2, 203);
+    let mut short_header = account_fixture(2, 204);
+    let requests = [
+        TradeRequestV16 {
+            asset_index: 0,
+            size_q: signed_q(POS_SCALE),
+            exec_price: 100,
+            fee_bps: 0,
+        },
+        TradeRequestV16 {
+            asset_index: 1,
+            size_q: signed_q(POS_SCALE),
+            exec_price: 100,
+            fee_bps: 0,
+        },
+    ];
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market.deposit_not_atomic(&mut long, 1_000).unwrap();
+    market.deposit_not_atomic(&mut short, 1_000).unwrap();
+    market
+        .execute_batch_with_fee_loss_stale_scoped_not_atomic(&mut long, &mut short, &requests)
+        .unwrap();
+    market.resolve_market_not_atomic(2).unwrap();
+
+    assert_eq!(
+        market
+            .close_resolved_account_not_atomic(&mut short, 0)
+            .unwrap(),
+        percolator::ResolvedCloseOutcomeV16::ProgressOnly,
+    );
+    assert_eq!(
+        short
+            .header
+            .active_bitmap
+            .iter()
+            .map(|word| word.get().count_ones())
+            .sum::<u32>(),
+        1,
+        "one successful close continuation must detach exactly one active leg",
+    );
+    assert_eq!(short.header.capital.get(), 1_000);
+
+    assert_eq!(
+        market
+            .close_resolved_account_not_atomic(&mut short, 0)
+            .unwrap(),
+        percolator::ResolvedCloseOutcomeV16::ProgressOnly,
+    );
+    assert!(active_bitmap_is_empty(
+        short.header.active_bitmap.map(V16PodU64::get)
+    ));
+    assert_eq!(short.header.capital.get(), 1_000);
+
+    assert_eq!(
+        market
+            .close_resolved_account_not_atomic(&mut short, 0)
+            .unwrap(),
+        percolator::ResolvedCloseOutcomeV16::Closed { payout: 1_000 },
+    );
+    market.validate_shape().unwrap();
     short.validate_with_market(&market.as_view()).unwrap();
 }
 
@@ -3594,9 +3663,13 @@ fn v16_resolved_close_migrates_legacy_normal_adl_residue_before_detach() {
     let mut account = PortfolioV16ViewMut::new(&mut account_header);
     market.deposit_not_atomic(&mut account, 1_000).unwrap();
     market.resolve_market_not_atomic(1).unwrap();
-    let outcome = market
+    let progress = market
         .close_resolved_account_not_atomic(&mut account, 0)
         .expect("resolution must not strand an upgraded zero-effective-OI residue");
+    assert_eq!(progress, percolator::ResolvedCloseOutcomeV16::ProgressOnly);
+    let outcome = market
+        .close_resolved_account_not_atomic(&mut account, 0)
+        .expect("the next bounded continuation must pay the detached account");
     assert_eq!(
         outcome,
         percolator::ResolvedCloseOutcomeV16::Closed { payout: 1_000 }


### PR DESCRIPTION
## What changed

- Resolve at most one ready active portfolio leg per `close_resolved_account_not_atomic` continuation.
- Inspect only the deterministic first active leg instead of preflighting and clearing the entire 14-leg portfolio.
- Return `ProgressOnly` immediately after every leg detach, including the final leg, so leg work never composes with source-domain settlement in the same transaction.
- Replace the proof-only Boolean `active_leg` rank with the exact active-leg count.
- Add a production-path engine test proving a two-leg account takes two strict progress steps before payout.

## Root cause

A public account can reach resolution with all 14 legs active and 28 historical source domains. The prior close path scanned and cleared every active leg, then entered source-domain settlement in the same call. Both direct close and resolved auto-crank exhausted the SVM hard ceiling, rolled back, and could never reduce state.

The old Boolean proof rank hid this frontier: it represented one active leg and fourteen active legs identically.

## Broad proof-driven validation

`proof_v16_resolved_leg_detach_exhausts_exact_rank_and_frames_other_obligations` quantifies every active-leg bitmap over the full 14-slot account, including sparse and maximum shapes. It repeatedly applies the production first-leg/rank kernels and proves:

- exactly one deterministic active leg is removed per continuation;
- active-leg rank decreases by one and reaches zero in exactly the initial popcount;
- the sequence is bounded by the account capacity;
- B-stale state, negative PnL, pending capital, receipt claims, and recovery requirements are framed unchanged while legs remain.

Five covers establish empty, singleton, maximum, sparse, and all-unrelated-obligations states. The production two-leg regression binds the theorem to the real zero-copy close path and requires two distinct committed steps before payout. The parent max-shape public scenario demonstrates the rollback DoS.

## Verification

- `cargo test --all-targets`
- `cargo kani --tests --features fuzz --harness proof_v16_resolved_leg_detach_exhausts_exact_rank_and_frames_other_obligations`
- `contract_check_build_resolved_close_rank`
- `contract_check_kernel_resolved_close_progress`
- Public max-shape LiteSVM TDD is in the stacked wrapper PR.
