### PR TITLE
Invalidate health certificates when oracle targets change

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 232 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 242 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |
 | Production `kernel_*` helpers in `src/v16.rs` | 17 |
-| Public `*_not_atomic` engine APIs in `src/v16.rs` | 54 |
+| Public `*_not_atomic` engine APIs in `src/v16.rs` | 55 |
 
 Spot-check the inventory directly:
 

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -11245,8 +11245,23 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         self.require_asset_mark_pushable(asset_index)?;
         let mut asset = self.asset_state(asset_index)?;
+        let target_changed = asset.raw_oracle_target_price != raw_oracle_target_price;
+        let next_oracle_epoch = if target_changed {
+            Some(
+                self.header
+                    .oracle_epoch
+                    .get()
+                    .checked_add(1)
+                    .ok_or(V16Error::CounterOverflow)?,
+            )
+        } else {
+            None
+        };
         asset.raw_oracle_target_price = raw_oracle_target_price;
         self.set_asset_state(asset_index, asset)?;
+        if let Some(next) = next_oracle_epoch {
+            self.header.oracle_epoch = V16PodU64::new(next);
+        }
         self.validate_shape()
     }
 

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -40,6 +40,24 @@ pub fn kani_health_cert_after_capital_debit(
     health_cert_after_capital_debit(cert, amount)
 }
 
+pub fn kani_cert_is_current(
+    cert: HealthCertV16,
+    oracle_epoch: u64,
+    funding_epoch: u64,
+    risk_epoch: u64,
+    asset_set_epoch: u64,
+    account_bitmap: V16ActiveBitmap,
+) -> bool {
+    V16Core::kernel_cert_is_current(
+        cert,
+        oracle_epoch,
+        funding_epoch,
+        risk_epoch,
+        asset_set_epoch,
+        account_bitmap,
+    )
+}
+
 pub fn kani_active_bitmap_set(
     bitmap: &mut V16ActiveBitmap,
     leg_slot_index: usize,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -7,7 +7,7 @@ use percolator::v16::{
     kani_apply_backing_utilization_fee_charge, kani_apply_resolved_payout_receipt_payment,
     kani_available_backing_num_for_source_credit_state,
     kani_backing_utilization_fee_quote_atoms_for_lien,
-    kani_backing_utilization_rate_e9_for_source_state,
+    kani_backing_utilization_rate_e9_for_source_state, kani_cert_is_current,
     kani_expected_source_credit_rate_num_for_state, kani_health_cert_after_capital_debit,
     kani_health_requirements_from_base_and_target_lag,
     kani_liquidation_close_would_leave_uncovered_loss_with_open_risk,
@@ -788,6 +788,90 @@ fn proof_v16_public_raw_oracle_target_update_is_value_neutral() {
     // Junior-pool isolation: this transition must not move the junior
     // residual pool (haircut/payout funding).
     assert_eq!(market.kani_residual(), residual_before);
+}
+
+#[kani::proof]
+#[kani::unwind(64)]
+#[kani::solver(cadical)]
+fn proof_v16_raw_oracle_target_change_invalidates_all_prior_certificates() {
+    let target: u64 = kani::any();
+    let epoch: u64 = kani::any();
+    kani::assume(target > 0 && target <= MAX_ORACLE_PRICE);
+    kani::assume(epoch < u64::MAX);
+
+    let (mut header, mut markets, _) = one_market_view_fixture();
+    header.oracle_epoch = V16PodU64::new(epoch);
+    let old_target = markets[0].engine.asset.raw_oracle_target_price.get();
+    let header_before = header;
+    let slot_before = markets[0].engine;
+    let cert = HealthCertV16 {
+        cert_oracle_epoch: header.oracle_epoch.get(),
+        cert_funding_epoch: header.funding_epoch.get(),
+        cert_risk_epoch: header.risk_epoch.get(),
+        cert_asset_set_epoch: header.asset_set_epoch.get(),
+        active_bitmap_at_cert: V16_EMPTY_ACTIVE_BITMAP,
+        valid: true,
+        ..HealthCertV16::default()
+    };
+    assert!(kani_cert_is_current(
+        cert,
+        header.oracle_epoch.get(),
+        header.funding_epoch.get(),
+        header.risk_epoch.get(),
+        header.asset_set_epoch.get(),
+        V16_EMPTY_ACTIVE_BITMAP,
+    ));
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    market
+        .set_asset_raw_oracle_target_not_atomic(0, target)
+        .unwrap();
+
+    let changed = target != old_target;
+    kani::cover!(
+        target < old_target,
+        "downward raw-target change invalidates an existing certificate"
+    );
+    kani::cover!(
+        target > old_target,
+        "upward raw-target change invalidates an existing certificate"
+    );
+    kani::cover!(
+        target == old_target,
+        "idempotent raw-target update preserves certificate currentness"
+    );
+
+    assert_eq!(
+        market.header.oracle_epoch.get(),
+        header_before.oracle_epoch.get() + u64::from(changed)
+    );
+    assert_eq!(
+        kani_cert_is_current(
+            cert,
+            market.header.oracle_epoch.get(),
+            market.header.funding_epoch.get(),
+            market.header.risk_epoch.get(),
+            market.header.asset_set_epoch.get(),
+            V16_EMPTY_ACTIVE_BITMAP,
+        ),
+        !changed
+    );
+
+    let mut expected_header = header_before;
+    expected_header.oracle_epoch =
+        V16PodU64::new(header_before.oracle_epoch.get() + u64::from(changed));
+    assert!(kani_eq_market_group_v16_header_account(
+        &expected_header,
+        market.header
+    ));
+    let mut expected_slot = slot_before;
+    let mut expected_asset = expected_slot.asset.try_to_runtime().unwrap();
+    expected_asset.raw_oracle_target_price = target;
+    expected_slot.asset = AssetStateV16Account::from_runtime(&expected_asset);
+    assert!(kani_eq_engine_asset_slot_v16_account(
+        &expected_slot,
+        &market.markets[0].engine
+    ));
 }
 
 #[kani::proof]
@@ -14626,8 +14710,8 @@ fn proof_v16_frame_fee_charge_touches_only_declared_state() {
     assert!(kani_eq_portfolio_account_v16_account(&ea, &account_header));
 }
 
-// oracle-target-update frame: exactly {asset.raw_oracle_target_price} — one
-// field in the whole state.
+// oracle-target-update frame: exactly {asset.raw_oracle_target_price,
+// header.oracle_epoch}, with the epoch changing iff the target changes.
 #[kani::proof]
 #[kani::unwind(40)]
 #[kani::solver(cadical)]
@@ -14644,8 +14728,12 @@ fn proof_v16_frame_oracle_target_update_touches_only_declared_state() {
             .set_asset_raw_oracle_target_not_atomic(0, target)
             .unwrap();
     }
-    kani::cover!(true, "oracle target frame reached");
-    assert!(kani_eq_market_group_v16_header_account(&h0, &header));
+    let changed = target != s0.asset.raw_oracle_target_price.get();
+    kani::cover!(changed, "oracle target frame covers a target change");
+    kani::cover!(!changed, "oracle target frame covers an idempotent update");
+    let mut eh = h0;
+    eh.oracle_epoch = V16PodU64::new(h0.oracle_epoch.get() + u64::from(changed));
+    assert!(kani_eq_market_group_v16_header_account(&eh, &header));
     let mut es = s0;
     let mut asset = s0.asset.try_to_runtime().unwrap();
     asset.raw_oracle_target_price = target;

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1063,6 +1063,7 @@ fn v16_public_raw_oracle_target_update_is_value_neutral_and_lifecycle_gated() {
     let vault_before = header.vault.get();
     let c_tot_before = header.c_tot.get();
     let insurance_before = header.insurance.get();
+    let oracle_epoch_before = header.oracle_epoch.get();
 
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
     market
@@ -1072,9 +1073,14 @@ fn v16_public_raw_oracle_target_update_is_value_neutral_and_lifecycle_gated() {
 
     assert_eq!(asset.raw_oracle_target_price, 111);
     assert_eq!(asset.effective_price, 100);
+    assert_eq!(market.header.oracle_epoch.get(), oracle_epoch_before + 1);
     assert_eq!(market.header.vault.get(), vault_before);
     assert_eq!(market.header.c_tot.get(), c_tot_before);
     assert_eq!(market.header.insurance.get(), insurance_before);
+    market
+        .set_asset_raw_oracle_target_not_atomic(0, 111)
+        .unwrap();
+    assert_eq!(market.header.oracle_epoch.get(), oracle_epoch_before + 1);
     market.validate_shape().unwrap();
 }
 


### PR DESCRIPTION
Closes #93.

A raw oracle target can change while the clamped effective price remains unchanged. Previously that transition did not advance `oracle_epoch`, so a certificate computed before an unrelated asset developed target/effective lag could still appear current and the single-trade incremental recertifier could retain stale health requirements.

This change advances `oracle_epoch` exactly once when the raw target actually changes. Idempotent target writes do not advance it. The update remains O(1), zero-copy, and value-neutral.

PDD evidence:
- The new production-path Kani theorem failed on the old implementation at the missing epoch increment, with all upward/downward/no-op covers reached.
- `proof_v16_raw_oracle_target_change_invalidates_all_prior_certificates`: PASS over every valid oracle target and every non-overflowing `u64` epoch, 3/3 covers, 155.09s.
- `proof_v16_frame_oracle_target_update_touches_only_declared_state`: PASS, 2/2 covers, 110.38s.
- `proof_v16_public_raw_oracle_target_update_is_value_neutral`: PASS, 1/1 cover, 150.02s.
- `cargo test --tests --features fuzz`: PASS (155 tests).
- `cargo fmt --all -- --check` and `git diff --check`: PASS.