### PR TITLE
Block fresh risk during side recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 242 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 243 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -11913,12 +11913,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
-    fn require_asset_active_for_risk_increase(&self, asset_index: usize) -> V16Result<()> {
-        let asset = self.asset_state(asset_index)?;
-        if asset.lifecycle != AssetLifecycleV16::Active {
-            return Err(V16Error::LockActive);
+    fn require_asset_risk_change_allowed(
+        &self,
+        asset_index: usize,
+        risk_increasing: bool,
+    ) -> V16Result<()> {
+        if !risk_increasing {
+            return Ok(());
         }
-        Ok(())
+        let asset = self.asset_state(asset_index)?;
+        asset_risk_increase_gate(asset.lifecycle, asset.mode_long, asset.mode_short)
     }
 
     fn validate_configured_asset_index(&self, asset_index: usize) -> V16Result<()> {
@@ -12686,7 +12690,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         validate_basis(basis_pos_q)?;
         let asset = self.asset_state(asset_index)?;
-        self.require_asset_active_for_risk_increase(asset_index)?;
+        self.require_asset_risk_change_allowed(asset_index, true)?;
         let a_basis = match side {
             SideV16::Long => asset.a_long,
             SideV16::Short => asset.a_short,
@@ -12918,7 +12922,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return self.clear_leg(account, asset_index);
         }
         if route == PositionRouteV16::Flip {
-            self.require_asset_active_for_risk_increase(asset_index)?;
+            self.require_asset_risk_change_allowed(asset_index, true)?;
             self.clear_leg(account, asset_index)?;
             let side = if new > 0 {
                 SideV16::Long
@@ -12928,7 +12932,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return self.attach_leg(account, asset_index, side, new);
         }
         if new.unsigned_abs() > current.unsigned_abs() {
-            self.require_asset_active_for_risk_increase(asset_index)?;
+            self.require_asset_risk_change_allowed(asset_index, true)?;
         }
         let old_leg = account.header.legs[leg_slot].try_to_runtime()?;
         let new_weight = loss_weight_for_basis(new.unsigned_abs(), old_leg.a_basis)?;
@@ -13847,9 +13851,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             request,
         )?;
         let risk_increasing = trade_preflight.risk_increasing;
-        if risk_increasing {
-            self.require_asset_active_for_risk_increase(request.asset_index)?;
-        }
+        self.require_asset_risk_change_allowed(request.asset_index, risk_increasing)?;
         let notional = trade_notional_floor(abs_size_q, request.exec_price)?;
         let fee_notional = trade_fee_notional_ceil(abs_size_q, request.exec_price)?;
         let fee = checked_fee_bps(fee_notional, request.fee_bps)?;
@@ -16276,6 +16278,20 @@ fn trade_preflight_risk_gate(
 ) -> V16Result<()> {
     if touches_pending_domain_barrier
         || (risk_increasing && (asset_loss_stale || target_effective_lag))
+    {
+        return Err(V16Error::LockActive);
+    }
+    Ok(())
+}
+
+fn asset_risk_increase_gate(
+    lifecycle: AssetLifecycleV16,
+    mode_long: SideModeV16,
+    mode_short: SideModeV16,
+) -> V16Result<()> {
+    if lifecycle != AssetLifecycleV16::Active
+        || mode_long != SideModeV16::Normal
+        || mode_short != SideModeV16::Normal
     {
         return Err(V16Error::LockActive);
     }

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -859,6 +859,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Self::trade_signed_size_deltas(size_q)
     }
 
+    pub fn kani_require_asset_risk_change_allowed(
+        &self,
+        asset_index: usize,
+        risk_increasing: bool,
+    ) -> V16Result<()> {
+        self.require_asset_risk_change_allowed(asset_index, risk_increasing)
+    }
+
     pub fn kani_ensure_close_progress_not_expired(
         &mut self,
         ledger: CloseProgressLedgerV16,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -22,15 +22,15 @@ use percolator::v16::{
     BatchTradeOutcomeV16, CloseProgressLedgerV16, CloseProgressLedgerV16Account,
     EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16, HealthCertV16Account,
     InsuranceCreditReservationV16, InsuranceCreditReservationV16Account, Market,
-    MarketGroupV16HeaderAccount, MarketGroupV16View, MarketGroupV16ViewMut,
-    PermissionlessCrankActionV16, PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
+    MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
+    PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
     ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedCloseOutcomeV16,
     ResolvedPayoutLedgerV16, ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16,
     ResolvedPayoutReceiptV16Account, SideModeV16, SideV16, SourceCreditStateV16,
     SourceCreditStateV16Account, StockReconciliationProofV16, TokenValueClassV16,
-    TokenValueFlowProofV16, TradeRequestV16, V16Config, V16ConfigAccount, V16Error,
+    TokenValueFlowProofV16, V16Config, V16ConfigAccount, V16Error,
     V16OptionalRecoveryReasonAccount, V16PodI128, V16PodU128, V16PodU32, V16PodU64,
     BACKING_FEE_RATE_DEN_E9, MAX_BACKING_FEE_RATE_E9_PER_SLOT, MAX_BACKING_FEE_UTIL_BPS,
     PORTFOLIO_SOURCE_DOMAIN_CAP, V16_EMPTY_ACTIVE_BITMAP, V16_MAX_PORTFOLIO_ASSETS_N,
@@ -872,6 +872,88 @@ fn proof_v16_raw_oracle_target_change_invalidates_all_prior_certificates() {
         &expected_slot,
         &market.markets[0].engine
     ));
+}
+
+#[kani::proof]
+#[kani::solver(cadical)]
+fn proof_v16_persisted_risk_gate_is_complete_for_all_lifecycles_and_side_modes() {
+    let lifecycle_raw: u8 = kani::any();
+    let long_mode_raw: u8 = kani::any();
+    let short_mode_raw: u8 = kani::any();
+    let risk_increasing: bool = kani::any();
+    kani::assume(lifecycle_raw <= 5 && long_mode_raw <= 2 && short_mode_raw <= 2);
+
+    let decode_mode = |raw| match raw {
+        0 => SideModeV16::Normal,
+        1 => SideModeV16::DrainOnly,
+        _ => SideModeV16::ResetPending,
+    };
+    let lifecycle = match lifecycle_raw {
+        0 => AssetLifecycleV16::Disabled,
+        1 => AssetLifecycleV16::PendingActivation,
+        2 => AssetLifecycleV16::Active,
+        3 => AssetLifecycleV16::DrainOnly,
+        4 => AssetLifecycleV16::Retired,
+        _ => AssetLifecycleV16::Recovery,
+    };
+    let long_mode = decode_mode(long_mode_raw);
+    let short_mode = decode_mode(short_mode_raw);
+    let expected_ok = !risk_increasing
+        || (lifecycle == AssetLifecycleV16::Active
+            && long_mode == SideModeV16::Normal
+            && short_mode == SideModeV16::Normal);
+    let (mut header, mut markets, _) = one_market_view_fixture();
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.lifecycle = lifecycle;
+    asset.mode_long = long_mode;
+    asset.mode_short = short_mode;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let result = market.kani_require_asset_risk_change_allowed(0, risk_increasing);
+
+    kani::cover!(
+        risk_increasing
+            && lifecycle == AssetLifecycleV16::Active
+            && long_mode == SideModeV16::Normal
+            && short_mode == SideModeV16::Normal,
+        "active Normal/Normal admits risk increase"
+    );
+    kani::cover!(
+        risk_increasing
+            && lifecycle == AssetLifecycleV16::Active
+            && long_mode == SideModeV16::ResetPending,
+        "long ResetPending blocks fresh matched risk"
+    );
+    kani::cover!(
+        risk_increasing
+            && lifecycle == AssetLifecycleV16::Active
+            && short_mode == SideModeV16::ResetPending,
+        "short ResetPending blocks fresh matched risk"
+    );
+    kani::cover!(
+        risk_increasing
+            && lifecycle == AssetLifecycleV16::Active
+            && (long_mode == SideModeV16::DrainOnly || short_mode == SideModeV16::DrainOnly),
+        "either DrainOnly side blocks fresh matched risk"
+    );
+    kani::cover!(
+        risk_increasing && lifecycle != AssetLifecycleV16::Active,
+        "non-active lifecycle blocks fresh matched risk"
+    );
+    kani::cover!(
+        !risk_increasing
+            && lifecycle == AssetLifecycleV16::Recovery
+            && long_mode == SideModeV16::ResetPending
+            && short_mode == SideModeV16::DrainOnly,
+        "risk reduction remains admitted during recovery"
+    );
+
+    assert_eq!(result.is_ok(), expected_ok);
+    if expected_ok {
+        assert_eq!(result, Ok(()));
+    } else {
+        assert_eq!(result, Err(V16Error::LockActive));
+    }
 }
 
 #[kani::proof]

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -570,6 +570,136 @@ fn v16_finalize_side_reset_rejects_blocked_pending_side() {
 }
 
 #[test]
+fn v16_trade_rejects_fresh_risk_when_either_side_is_recovering() {
+    let cases = [
+        (SideModeV16::ResetPending, SideModeV16::Normal),
+        (SideModeV16::Normal, SideModeV16::ResetPending),
+        (SideModeV16::DrainOnly, SideModeV16::Normal),
+        (SideModeV16::Normal, SideModeV16::DrainOnly),
+    ];
+    for (mode_long, mode_short) in cases {
+        let (mut header, mut markets) = market_fixture(1, 100);
+        let mut long_header = account_fixture(1, 16);
+        let mut short_header = account_fixture(1, 17);
+        {
+            let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+            let mut long = PortfolioV16ViewMut::new(&mut long_header);
+            let mut short = PortfolioV16ViewMut::new(&mut short_header);
+            market.deposit_not_atomic(&mut long, 1_000).unwrap();
+            market.deposit_not_atomic(&mut short, 1_000).unwrap();
+        }
+        let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+        asset.mode_long = mode_long;
+        asset.mode_short = mode_short;
+        markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+        let value_before = (header.vault, header.c_tot, header.insurance);
+
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        assert_eq!(
+            market.execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: signed_q(POS_SCALE),
+                    exec_price: 100,
+                    fee_bps: 0,
+                },
+            ),
+            Err(V16Error::LockActive),
+            "fresh risk admitted with {mode_long:?}/{mode_short:?}"
+        );
+
+        let asset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+        assert_eq!(asset.oi_eff_long_q, 0);
+        assert_eq!(asset.oi_eff_short_q, 0);
+        assert_eq!(asset.stored_pos_count_long, 0);
+        assert_eq!(asset.stored_pos_count_short, 0);
+        assert_eq!(
+            long.header.active_bitmap,
+            V16_EMPTY_ACTIVE_BITMAP.map(V16PodU64::new)
+        );
+        assert_eq!(
+            short.header.active_bitmap,
+            V16_EMPTY_ACTIVE_BITMAP.map(V16PodU64::new)
+        );
+        assert_eq!(
+            (
+                market.header.vault,
+                market.header.c_tot,
+                market.header.insurance
+            ),
+            value_before
+        );
+    }
+}
+
+#[test]
+fn v16_trade_keeps_two_sided_risk_reduction_open_during_side_recovery() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut long_header = account_fixture(1, 18);
+    let mut short_header = account_fixture(1, 19);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market.deposit_not_atomic(&mut long, 1_000).unwrap();
+        market.deposit_not_atomic(&mut short, 1_000).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: signed_q(2 * POS_SCALE),
+                    exec_price: 100,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+    }
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.mode_long = SideModeV16::ResetPending;
+    asset.mode_short = SideModeV16::DrainOnly;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: -signed_q(POS_SCALE),
+                exec_price: 100,
+                fee_bps: 0,
+            },
+        )
+        .expect("recovery must not block a matched reduction of both open sides");
+
+    let asset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(asset.oi_eff_long_q, POS_SCALE);
+    assert_eq!(asset.oi_eff_short_q, POS_SCALE);
+    assert_eq!(asset.stored_pos_count_long, 1);
+    assert_eq!(asset.stored_pos_count_short, 1);
+    assert_eq!(
+        long.header.legs[0].try_to_runtime().unwrap().basis_pos_q,
+        signed_q(POS_SCALE)
+    );
+    assert_eq!(
+        short.header.legs[0].try_to_runtime().unwrap().basis_pos_q,
+        -signed_q(POS_SCALE)
+    );
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+    short.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_batch_trade_applies_multiple_fills_after_inline_refresh() {
     let (mut header, mut markets) = market_fixture(2, 100);
     let mut long_header = account_fixture(2, 201);


### PR DESCRIPTION
Fixes #97.

## Root cause
Risk-increase admission checked only the asset lifecycle. An Active asset could therefore admit fresh matched exposure while either side was `DrainOnly` or `ResetPending`, allowing later reset finalization to strand the new counterparty leg and open interest.

## Fix
- Require `Active` plus `Normal/Normal` for every risk-increasing attach, resize, flip, single trade, and batch fill.
- Preserve risk-reducing trades in all lifecycle/side modes so recovery exits remain available.
- Keep the gate O(1); risk reductions return before decoding asset state.

## Proof-driven validation
- The exhaustive theorem failed before the mode checks with all six covers reachable.
- `proof_v16_persisted_risk_gate_is_complete_for_all_lifecycles_and_side_modes` proves the persisted zero-copy gate over all 6 lifecycle states, all 9 side-mode pairs, and both risk directions in 29.2s, with 6/6 covers.
- Existing position-risk, trade-preflight, and OI-symmetry proofs pass.
- Runtime regressions prove fresh counterparties are blocked for either recovering side and matched reductions remain executable.
- `cargo test --tests --features fuzz`: 157 passed.