### PR TITLE
Prevent same-trade OI masking

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 243 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 244 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1397,6 +1397,45 @@ impl V16Core {
         }
     }
 
+    /// A trade may reduce only OI that existed before that trade. This makes
+    /// aggregate accounting independent of which counterparty mutates first.
+    pub(crate) fn kernel_trade_preexisting_oi_reduction_gate(
+        oi_long_q: u128,
+        oi_short_q: u128,
+        account_a_current_q: i128,
+        account_a_next_q: i128,
+        account_b_current_q: i128,
+        account_b_next_q: i128,
+    ) -> V16Result<(u128, u128)> {
+        let side_reduction = |current_q: i128, next_q: i128, side: SideV16| {
+            let on_side = |position_q: i128| match side {
+                SideV16::Long if position_q > 0 => position_q as u128,
+                SideV16::Short if position_q < 0 => position_q.unsigned_abs(),
+                _ => 0,
+            };
+            on_side(current_q).saturating_sub(on_side(next_q))
+        };
+        let long_reduction_q = side_reduction(account_a_current_q, account_a_next_q, SideV16::Long)
+            .checked_add(side_reduction(
+                account_b_current_q,
+                account_b_next_q,
+                SideV16::Long,
+            ))
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        let short_reduction_q =
+            side_reduction(account_a_current_q, account_a_next_q, SideV16::Short)
+                .checked_add(side_reduction(
+                    account_b_current_q,
+                    account_b_next_q,
+                    SideV16::Short,
+                ))
+                .ok_or(V16Error::ArithmeticOverflow)?;
+        if long_reduction_q > oi_long_q || short_reduction_q > oi_short_q {
+            return Err(V16Error::LockActive);
+        }
+        Ok((long_reduction_q, short_reduction_q))
+    }
+
     /// PRODUCTION KERNEL (roadmap 3A.2 risk-reduction / S-L3, A5.dec rank): the
     /// position-reduction core of liquidation/rebalance. Clamps the requested
     /// close to the leg and produces the toward-zero signed delta:
@@ -12574,6 +12613,20 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             Self::position_delta_lookup_for_asset(short_account, request.asset_index, short_delta)?;
         let risk_increasing = position_delta_increases_risk(long_lookup.current_q, long_delta)?
             || position_delta_increases_risk(short_lookup.current_q, short_delta)?;
+        let asset = self
+            .markets
+            .get(request.asset_index)
+            .ok_or(V16Error::InvalidLeg)?
+            .engine_slot()
+            .asset;
+        V16Core::kernel_trade_preexisting_oi_reduction_gate(
+            asset.oi_eff_long_q.get(),
+            asset.oi_eff_short_q.get(),
+            long_lookup.current_q,
+            long_lookup.next_q,
+            short_lookup.current_q,
+            short_lookup.next_q,
+        )?;
         let target_effective_lag = self.asset_has_target_effective_lag(request.asset_index)?;
         let blocked_by_pending_domain_barrier = pending_domain_loss_barrier_blocks_position_change(
             self.position_change_touches_pending_domain_loss_barrier(

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -281,6 +281,24 @@ pub fn kani_position_delta_increases_risk(current: i128, delta_q: i128) -> V16Re
     position_delta_increases_risk(current, delta_q)
 }
 
+pub fn kani_trade_preexisting_oi_reduction_gate(
+    oi_long_q: u128,
+    oi_short_q: u128,
+    account_a_current_q: i128,
+    account_a_next_q: i128,
+    account_b_current_q: i128,
+    account_b_next_q: i128,
+) -> V16Result<(u128, u128)> {
+    V16Core::kernel_trade_preexisting_oi_reduction_gate(
+        oi_long_q,
+        oi_short_q,
+        account_a_current_q,
+        account_a_next_q,
+        account_b_current_q,
+        account_b_next_q,
+    )
+}
+
 pub fn kani_trade_preflight_risk_gate(
     risk_increasing: bool,
     asset_loss_stale: bool,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -16,13 +16,13 @@ use percolator::v16::{
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
     kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
     kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
-    kani_target_effective_lag_adverse_delta, kani_trade_preflight_risk_gate,
-    kani_validate_positive_pnl_source_attribution, AssetLifecycleV16, AssetStateV16,
-    AssetStateV16Account, BackingBucketStatusV16, BackingBucketV16, BackingBucketV16Account,
-    BatchTradeOutcomeV16, CloseProgressLedgerV16, CloseProgressLedgerV16Account,
-    EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16, HealthCertV16Account,
-    InsuranceCreditReservationV16, InsuranceCreditReservationV16Account, Market,
-    MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
+    kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
+    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
+    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
+    BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
+    CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
+    HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
+    Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
     PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
@@ -3720,6 +3720,102 @@ fn proof_v16_position_delta_risk_classifier_matches_abs_exposure_change() {
         if increases {
             assert!(next != 0);
         }
+    }
+}
+
+#[kani::proof]
+#[kani::unwind(5)]
+#[kani::solver(cadical)]
+fn proof_v16_trade_reductions_are_funded_only_by_preexisting_side_oi() {
+    let account_a_current_q: i128 = kani::any();
+    let account_a_next_q: i128 = kani::any();
+    let account_b_current_q: i128 = kani::any();
+    let account_b_next_q: i128 = kani::any();
+    let oi_long_q: u128 = kani::any();
+    let oi_short_q: u128 = kani::any();
+    for position_q in [
+        account_a_current_q,
+        account_a_next_q,
+        account_b_current_q,
+        account_b_next_q,
+    ] {
+        kani::assume(position_q != i128::MIN);
+        kani::assume(position_q.unsigned_abs() <= MAX_POSITION_ABS_Q);
+    }
+    kani::assume(oi_long_q <= 2 * MAX_POSITION_ABS_Q);
+    kani::assume(oi_short_q <= 2 * MAX_POSITION_ABS_Q);
+
+    let side_reduction = |current_q: i128, next_q: i128, long_side: bool| {
+        let on_side = |position_q: i128| {
+            if (long_side && position_q > 0) || (!long_side && position_q < 0) {
+                position_q.unsigned_abs()
+            } else {
+                0
+            }
+        };
+        on_side(current_q).saturating_sub(on_side(next_q))
+    };
+    let required_long_q = side_reduction(account_a_current_q, account_a_next_q, true)
+        + side_reduction(account_b_current_q, account_b_next_q, true);
+    let required_short_q = side_reduction(account_a_current_q, account_a_next_q, false)
+        + side_reduction(account_b_current_q, account_b_next_q, false);
+    let expected_ok = required_long_q <= oi_long_q && required_short_q <= oi_short_q;
+    let result = kani_trade_preexisting_oi_reduction_gate(
+        oi_long_q,
+        oi_short_q,
+        account_a_current_q,
+        account_a_next_q,
+        account_b_current_q,
+        account_b_next_q,
+    );
+
+    let a_adds_long_q = if account_a_next_q > 0 {
+        (account_a_next_q as u128).saturating_sub(if account_a_current_q > 0 {
+            account_a_current_q as u128
+        } else {
+            0
+        })
+    } else {
+        0
+    };
+    kani::cover!(
+        !expected_ok
+            && account_a_current_q < 0
+            && account_a_next_q > 0
+            && account_b_current_q > account_b_next_q
+            && account_b_next_q > 0
+            && required_long_q > oi_long_q
+            && required_long_q <= oi_long_q.saturating_add(a_adds_long_q),
+        "same-call long addition cannot fund an oversized preexisting long reduction"
+    );
+    kani::cover!(
+        expected_ok
+            && account_a_current_q < 0
+            && account_a_next_q > 0
+            && account_b_current_q > 0
+            && account_b_next_q < 0,
+        "balanced two-sided flip remains admitted"
+    );
+    kani::cover!(
+        expected_ok
+            && account_a_current_q > account_a_next_q
+            && account_a_next_q > 0
+            && account_b_current_q < account_b_next_q
+            && account_b_next_q < 0,
+        "matched same-side reductions remain admitted"
+    );
+    kani::cover!(
+        !expected_ok && required_short_q > oi_short_q,
+        "preexisting short OI underfunding is rejected"
+    );
+
+    assert_eq!(result.is_ok(), expected_ok);
+    if expected_ok {
+        assert_eq!(result, Ok((required_long_q, required_short_q)));
+        assert!(required_long_q <= oi_long_q);
+        assert!(required_short_q <= oi_short_q);
+    } else {
+        assert_eq!(result, Err(V16Error::LockActive));
     }
 }
 

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -700,6 +700,109 @@ fn v16_trade_keeps_two_sided_risk_reduction_open_during_side_recovery() {
 }
 
 #[test]
+fn v16_crossed_trade_cannot_spend_same_call_addition_as_preexisting_oi() {
+    const SURVIVOR_Q: u128 = 13 * POS_SCALE;
+    const MATCHED_Q: u128 = 10 * POS_SCALE;
+    const CROSS_Q: u128 = 11 * POS_SCALE;
+
+    let (mut header, mut markets) = market_fixture(1, 1);
+    let mut survivor_header = account_fixture(1, 20);
+    let mut liquidated_header = account_fixture(1, 21);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut survivor = PortfolioV16ViewMut::new(&mut survivor_header);
+        let mut liquidated = PortfolioV16ViewMut::new(&mut liquidated_header);
+        market.deposit_not_atomic(&mut survivor, 100).unwrap();
+        market.deposit_not_atomic(&mut liquidated, 100).unwrap();
+    }
+
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.a_long = ADL_ONE * MATCHED_Q / SURVIVOR_Q;
+    asset.oi_eff_long_q = MATCHED_Q;
+    asset.oi_eff_short_q = MATCHED_Q;
+    asset.stored_pos_count_long = 1;
+    asset.stored_pos_count_short = 1;
+    asset.loss_weight_sum_long = SURVIVOR_Q;
+    asset.loss_weight_sum_short = MATCHED_Q;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(2);
+
+    survivor_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Long,
+        basis_pos_q: signed_q(SURVIVOR_Q),
+        a_basis: ADL_ONE,
+        k_snap: asset.k_long,
+        f_snap: asset.f_long_num,
+        epoch_snap: asset.epoch_long,
+        loss_weight: SURVIVOR_Q,
+        b_snap: asset.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    survivor_header.active_bitmap[0] = V16PodU64::new(1);
+    survivor_header.health_cert.valid = 0;
+    liquidated_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Short,
+        basis_pos_q: -signed_q(MATCHED_Q),
+        a_basis: ADL_ONE,
+        k_snap: asset.k_short,
+        f_snap: asset.f_short_num,
+        epoch_snap: asset.epoch_short,
+        loss_weight: MATCHED_Q,
+        b_snap: asset.b_short_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_short,
+        b_stale: false,
+        stale: false,
+    });
+    liquidated_header.active_bitmap[0] = V16PodU64::new(1);
+    liquidated_header.health_cert.valid = 0;
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut survivor = PortfolioV16ViewMut::new(&mut survivor_header);
+    let mut liquidated = PortfolioV16ViewMut::new(&mut liquidated_header);
+    market.validate_shape().unwrap();
+    survivor.validate_with_market(&market.as_view()).unwrap();
+    liquidated.validate_with_market(&market.as_view()).unwrap();
+    let value_before = (
+        market.header.vault,
+        market.header.c_tot,
+        market.header.insurance,
+    );
+    let asset_before = market.markets[0].engine.asset;
+
+    let result = market.execute_trade_with_fee_loss_stale_scoped_not_atomic(
+        &mut liquidated,
+        &mut survivor,
+        TradeRequestV16 {
+            asset_index: 0,
+            size_q: signed_q(CROSS_Q),
+            exec_price: 1,
+            fee_bps: 0,
+        },
+    );
+
+    assert_eq!(result, Err(V16Error::LockActive));
+    assert_eq!(market.markets[0].engine.asset, asset_before);
+    assert_eq!(
+        (
+            market.header.vault,
+            market.header.c_tot,
+            market.header.insurance
+        ),
+        value_before
+    );
+}
+
+#[test]
 fn v16_batch_trade_applies_multiple_fills_after_inline_refresh() {
     let (mut header, mut markets) = market_fixture(2, 100);
     let mut long_header = account_fixture(2, 201);


### PR DESCRIPTION
Fixes #103.

## Root cause
After unilateral partial liquidation, stored survivor basis can exceed effective matched OI while the side remains Normal. Position updates were applied sequentially, so a counterparty that flipped onto a side could add OI first; the second update could then remove more than the OI that existed before the instruction. This left same-side live legs with zero effective OI and no zero-sum trade path to clear them.

## Fix
Before fees or position mutation, sum each side's reductions across both counterparties and require pre-instruction OI to cover that sum. Same-call additions never fund reductions. The check is O(1), order-independent, and still permits balanced flips, transfers, and matched reductions.

## PDD
- The representable post-liquidation production-trade regression failed on master because the malformed crossed trade returned `Ok`.
- The same regression now rejects `LockActive` before asset/value mutation.
- `proof_v16_trade_reductions_are_funded_only_by_preexisting_side_oi` proves the general gate over full-width bounded positions/OI in 4.28s with 4/4 covers: masking attack, balanced two-sided flip, matched reductions, and short-side symmetry.
- Four adjacent signed-position/preflight/OI proofs pass.
- `cargo test --tests --features fuzz`: 158 passed.