### PR TITLE
[BLOCKER DoS] Bound max-source account progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 248 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 249 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 244 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 246 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 246 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 248 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1542,6 +1542,34 @@ impl V16Core {
         allow_b_chunk && source_domain_count != 0 && has_pending_kf && leg_kf_pending
     }
 
+    #[inline]
+    fn kernel_source_credit_take(
+        remaining_effective: u128,
+        effective_by_claim: u128,
+        effective_by_backing: u128,
+    ) -> u128 {
+        remaining_effective
+            .min(effective_by_claim)
+            .min(effective_by_backing)
+    }
+
+    #[inline]
+    fn kernel_source_credit_rank_after_take(
+        remaining_effective: u128,
+        remaining_face_num: u128,
+        effective_taken: u128,
+        face_num_taken: u128,
+    ) -> V16Result<(u128, u128)> {
+        Ok((
+            remaining_effective
+                .checked_sub(effective_taken)
+                .ok_or(V16Error::CounterUnderflow)?,
+            remaining_face_num
+                .checked_sub(face_num_taken)
+                .ok_or(V16Error::CounterUnderflow)?,
+        ))
+    }
+
     /// PRODUCTION KERNEL (engine.md selection semantics): from the actionable
     /// summary and the ENGINE-selected assets, choose the single highest-priority
     /// bounded plan, carrying the engine-chosen asset (the caller chooses neither
@@ -8797,6 +8825,50 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             .ok_or(V16Error::ArithmeticOverflow)
     }
 
+    #[cfg(kani)]
+    fn account_unliened_source_realizable_support(
+        &self,
+        account: &PortfolioV16View<'_>,
+        face_claim: u128,
+    ) -> V16Result<u128> {
+        if face_claim == 0 {
+            return Ok(0);
+        }
+        let mut remaining_num = V16Core::bound_num_from_amount(face_claim)?;
+        let mut support_num = U256::ZERO;
+        let mut slot = 0usize;
+        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP && remaining_num != 0 {
+            let source = account.source_domains()[slot];
+            if source.has_default_sparse_tag() && !source.is_occupied() {
+                break;
+            }
+            if !source.is_occupied() {
+                slot += 1;
+                continue;
+            }
+            let d = source.domain.get() as usize;
+            let claim_num = Self::source_claim_unliened_num_from_source(source)?.min(remaining_num);
+            if claim_num != 0 {
+                self.validate_source_domain_ledger_current(d)?;
+                let credited_num = U256::from_u128(claim_num)
+                    .checked_mul(U256::from_u128(
+                        self.source_credit_for_domain(d)?.credit_rate_num,
+                    ))
+                    .and_then(|v| v.checked_div(U256::from_u128(CREDIT_RATE_SCALE)))
+                    .ok_or(V16Error::ArithmeticOverflow)?;
+                support_num = support_num
+                    .checked_add(credited_num)
+                    .ok_or(V16Error::ArithmeticOverflow)?;
+                remaining_num -= claim_num;
+            }
+            slot += 1;
+        }
+        support_num
+            .checked_div(U256::from_u128(BOUND_SCALE))
+            .and_then(|v| v.try_into_u128())
+            .ok_or(V16Error::ArithmeticOverflow)
+    }
+
     fn source_credit_available_backing_num(&self, domain: usize) -> V16Result<u128> {
         V16Core::available_backing_num_for_source_credit_state(
             self.source_credit_for_domain(domain)?,
@@ -9446,6 +9518,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let consumed = self.create_and_consume_account_source_credit_up_to_effective_not_atomic(
             account,
             effective_credit,
+            u128::MAX,
         )?;
         let total_consumed = consumed
             .counterparty_credit_consumed
@@ -9461,6 +9534,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
         effective_credit: u128,
+        mut remaining_face_num: u128,
     ) -> V16Result<SourceCreditConsumptionV16> {
         if effective_credit == 0 {
             return Ok(SourceCreditConsumptionV16 {
@@ -9485,17 +9559,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
             let d = source.domain.get() as usize;
             let rate = self.source_credit_for_domain(d)?.credit_rate_num;
-            let unliened = Self::source_claim_unliened_num_from_source(source)?;
-            if rate != 0 && unliened != 0 {
+            let claim_num =
+                Self::source_claim_unliened_num_from_source(source)?.min(remaining_face_num);
+            if rate != 0 && claim_num != 0 {
                 self.validate_source_domain_ledger_current(d)?;
-                let soft_num = U256::from_u128(unliened)
+                let soft_num = U256::from_u128(claim_num)
                     .checked_mul(U256::from_u128(rate))
                     .and_then(|v| v.checked_div(U256::from_u128(CREDIT_RATE_SCALE)))
                     .and_then(|v| v.try_into_u128())
                     .ok_or(V16Error::ArithmeticOverflow)?;
                 let by_claim = soft_num / BOUND_SCALE;
                 let by_backing = self.source_credit_available_backing_num(d)? / BOUND_SCALE;
-                let take = remaining.min(by_claim).min(by_backing);
+                let take = V16Core::kernel_source_credit_take(remaining, by_claim, by_backing);
                 if take != 0 {
                     let (face_num, backing_num) =
                         V16Core::source_credit_lien_amounts_for_effective(take, rate)?;
@@ -9523,7 +9598,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     face_burn_num = face_burn_num
                         .checked_add(face_num)
                         .ok_or(V16Error::ArithmeticOverflow)?;
-                    remaining -= take;
+                    (remaining, remaining_face_num) =
+                        V16Core::kernel_source_credit_rank_after_take(
+                            remaining,
+                            remaining_face_num,
+                            take,
+                            face_num,
+                        )?;
                 }
             }
             slot += 1;
@@ -10193,7 +10274,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let source_consumption = if has_source_claims {
             Some(
                 self.create_and_consume_account_source_credit_up_to_effective_not_atomic(
-                    account, loss_abs,
+                    account,
+                    loss_abs,
+                    V16Core::bound_num_from_amount(old_positive_face)?,
                 )?,
             )
         } else {

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -11317,13 +11317,53 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
         b_delta_budget: u128,
     ) -> V16Result<PermissionlessProgressOutcomeV16> {
+        self.settle_account_side_effects_inner_not_atomic(account, b_delta_budget, false)
+    }
+
+    fn settle_account_side_effects_bounded_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        b_delta_budget: u128,
+    ) -> V16Result<PermissionlessProgressOutcomeV16> {
+        self.settle_account_side_effects_inner_not_atomic(account, b_delta_budget, true)
+    }
+
+    fn settle_account_side_effects_inner_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        b_delta_budget: u128,
+        commit_one_source_kf_leg: bool,
+    ) -> V16Result<PermissionlessProgressOutcomeV16> {
         account.validate_with_market(&self.as_view())?;
+        let source_domain_count = if commit_one_source_kf_leg {
+            Self::account_source_domain_count(&account.as_view())
+        } else {
+            0
+        };
+        let has_pending_kf = if commit_one_source_kf_leg {
+            self.account_has_pending_kf_settlement(&account.as_view())?
+        } else {
+            false
+        };
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
             if leg.active {
                 let asset_index = leg.asset_index as usize;
+                let asset = self.asset_state(asset_index)?;
+                let (target_k, target_f) = Self::kf_target_for_leg_from_asset(asset, leg)?;
+                let kf_settlement_pending = leg.k_snap != target_k || leg.f_snap != target_f;
                 self.settle_leg_kf_effects_at_slot(account, slot)?;
+                if V16Core::kernel_permissionless_kf_settlement_commits_step(
+                    commit_one_source_kf_leg,
+                    source_domain_count,
+                    has_pending_kf,
+                    kf_settlement_pending,
+                ) {
+                    self.validate_account_audit_scan(&account.as_view())?;
+                    self.validate_shape_audit_scan()?;
+                    return Ok(PermissionlessProgressOutcomeV16::AccountLegSettled { asset_index });
+                }
                 let refreshed = account.header.legs[slot].try_to_runtime()?;
                 let target = self.b_target_for_leg(asset_index, refreshed)?;
                 if target > refreshed.b_snap {
@@ -15368,12 +15408,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if decode_market_mode(self.header.mode)? != MarketModeV16::Resolved {
             return Err(V16Error::LockActive);
         }
-        if let PermissionlessProgressOutcomeV16::AccountBChunk(_) = self
-            .settle_account_side_effects_not_atomic(
+        if matches!(
+            self.settle_account_side_effects_bounded_not_atomic(
                 account,
                 self.header.config.public_b_chunk_atoms.get(),
-            )?
-        {
+            )?,
+            PermissionlessProgressOutcomeV16::AccountLegSettled { .. }
+                | PermissionlessProgressOutcomeV16::AccountBChunk(_)
+        ) {
             self.validate_shape()?;
             return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
         }

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1571,6 +1571,23 @@ impl V16Core {
         ))
     }
 
+    #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &V16Result<u32>| match result {
+        Ok(next) => {
+            let bit = 1u32 << domain;
+            *next == processed | bit
+                && next.count_ones() == processed.count_ones() + 1
+                && *next & processed == processed
+        }
+        Err(_) => true,
+    }))]
+    fn kernel_mark_source_domain_processed(processed: u32, domain: u32) -> V16Result<u32> {
+        let bit = 1u32.checked_shl(domain).ok_or(V16Error::InvalidConfig)?;
+        if processed & bit != 0 {
+            return Err(V16Error::LockActive);
+        }
+        Ok(processed | bit)
+    }
+
     /// PRODUCTION KERNEL (engine.md selection semantics): from the actionable
     /// summary and the ENGINE-selected assets, choose the single highest-priority
     /// bounded plan, carrying the engine-chosen asset (the caller chooses neither
@@ -15293,13 +15310,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 let shift = u32::try_from(d).map_err(|_| V16Error::InvalidConfig)?;
                 let domain_bit = 1u32.checked_shl(shift).ok_or(V16Error::InvalidConfig)?;
                 if processed & domain_bit == 0 {
-                    selected = Some((slot, d, domain_bit, source));
+                    selected = Some((slot, d, source));
                     break;
                 }
             }
             slot += 1;
         }
-        let Some((selected_slot, d, domain_bit, source)) = selected else {
+        let Some((selected_slot, d, source)) = selected else {
             account.header.resolved_source_realization_bitmap = V16PodU32::new(0);
             return Ok((false, 0));
         };
@@ -15333,7 +15350,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             account.header.reserved_pnl = V16PodU128::new(0);
             self.apply_released_pnl_conversion_not_atomic(account, support)?
         };
-        account.header.resolved_source_realization_bitmap = V16PodU32::new(processed | domain_bit);
+        account.header.resolved_source_realization_bitmap = V16PodU32::new(
+            V16Core::kernel_mark_source_domain_processed(processed, d as u32)?,
+        );
 
         // If the payout snapshot was captured before this account realized (another
         // winner closed first), the realized face is still counted in the ledger's

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -8421,32 +8421,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(sum)
     }
 
-    fn account_source_domain_count(account: &PortfolioV16View<'_>) -> usize {
-        let mut count = 0usize;
-        while count < PORTFOLIO_SOURCE_DOMAIN_CAP {
-            let source = account.source_domains()[count];
-            if source.has_default_sparse_tag() && !source.is_occupied() {
-                break;
-            }
-            count += 1;
-        }
-        count
-    }
-
-    fn account_has_pending_kf_settlement(&self, account: &PortfolioV16View<'_>) -> V16Result<bool> {
-        let mut slot = 0usize;
-        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
-            let leg = account.header.legs[slot].try_to_runtime()?;
-            if leg.active {
-                let asset = self.asset_state(leg.asset_index as usize)?;
-                let (target_k, target_f) = Self::kf_target_for_leg_from_asset(asset, leg)?;
-                if leg.k_snap != target_k || leg.f_snap != target_f {
-                    return Ok(true);
-                }
-            }
-            slot += 1;
-        }
-        Ok(false)
+    fn account_has_source_domains(account: &PortfolioV16View<'_>) -> bool {
+        account.source_domains()[0].is_occupied()
     }
 
     fn account_has_source_claims(account: &PortfolioV16View<'_>) -> V16Result<bool> {
@@ -10841,16 +10817,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .validate_source_credit_shape_with_market(&self.as_view())?;
             Self::account_source_claim_bound_sum_num(&account.as_view())?
         };
-        let source_domain_count = if allow_b_chunk {
-            Self::account_source_domain_count(&account.as_view())
-        } else {
-            0
-        };
-        let has_pending_kf = if allow_b_chunk {
-            self.account_has_pending_kf_settlement(&account.as_view())?
-        } else {
-            false
-        };
+        let source_domain_count =
+            if allow_b_chunk && Self::account_has_source_domains(&account.as_view()) {
+                1
+            } else {
+                0
+            };
         if source_claim_sum_num != 0 {
             V16Core::validate_positive_pnl_source_attribution(
                 account.header.pnl.get(),
@@ -10922,7 +10894,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             if V16Core::kernel_permissionless_kf_settlement_commits_step(
                 allow_b_chunk,
                 source_domain_count,
-                has_pending_kf,
+                kf_settlement_pending,
                 kf_settlement_pending,
             ) {
                 self.validate_account_audit_scan(&account.as_view())?;
@@ -11335,16 +11307,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         commit_one_source_kf_leg: bool,
     ) -> V16Result<PermissionlessProgressOutcomeV16> {
         account.validate_with_market(&self.as_view())?;
-        let source_domain_count = if commit_one_source_kf_leg {
-            Self::account_source_domain_count(&account.as_view())
-        } else {
-            0
-        };
-        let has_pending_kf = if commit_one_source_kf_leg {
-            self.account_has_pending_kf_settlement(&account.as_view())?
-        } else {
-            false
-        };
+        let source_domain_count =
+            if commit_one_source_kf_leg && Self::account_has_source_domains(&account.as_view()) {
+                1
+            } else {
+                0
+            };
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
@@ -11357,7 +11325,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 if V16Core::kernel_permissionless_kf_settlement_commits_step(
                     commit_one_source_kf_leg,
                     source_domain_count,
-                    has_pending_kf,
+                    kf_settlement_pending,
                     kf_settlement_pending,
                 ) {
                     self.validate_account_audit_scan(&account.as_view())?;

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1571,21 +1571,15 @@ impl V16Core {
         ))
     }
 
-    #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &V16Result<u32>| match result {
-        Ok(next) => {
-            let bit = 1u32 << domain;
-            *next == processed | bit
-                && next.count_ones() == processed.count_ones() + 1
-                && *next & processed == processed
-        }
+    #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &V16Result<u8>| match result {
+        Ok(next) => *next == encode_bool(true) && processed == encode_bool(false),
         Err(_) => true,
     }))]
-    fn kernel_mark_source_domain_processed(processed: u32, domain: u32) -> V16Result<u32> {
-        let bit = 1u32.checked_shl(domain).ok_or(V16Error::InvalidConfig)?;
-        if processed & bit != 0 {
+    fn kernel_mark_source_domain_processed(processed: u8) -> V16Result<u8> {
+        if decode_bool(processed)? {
             return Err(V16Error::LockActive);
         }
-        Ok(processed | bit)
+        Ok(encode_bool(true))
     }
 
     /// PRODUCTION KERNEL (engine.md selection semantics): from the actionable
@@ -4113,6 +4107,14 @@ impl<'a> PortfolioV16ViewMut<'a> {
             write += 1;
         }
     }
+
+    fn clear_resolved_source_realization_progress(&mut self) {
+        let mut slot = 0usize;
+        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            self.header.source_domains[slot].resolved_realization_processed = encode_bool(false);
+            slot += 1;
+        }
+    }
 }
 
 impl<'a> PortfolioV16View<'a> {
@@ -4140,19 +4142,6 @@ impl<'a> PortfolioV16View<'a> {
         let source_claim_sum_num = self.source_claim_bound_sum_num()?;
         if source_claim_sum_num != 0 {
             V16Core::validate_positive_pnl_source_attribution(pnl, source_claim_sum_num)?;
-        }
-        let configured_domains = v16_domain_count_for_market_slots(config.max_market_slots as u32)?;
-        let terminal_bitmap = self.header.resolved_source_realization_bitmap.get();
-        let valid_domain_mask = if configured_domains == u32::BITS as usize {
-            u32::MAX
-        } else {
-            (1u32 << configured_domains) - 1
-        };
-        if terminal_bitmap & !valid_domain_mask != 0
-            || (terminal_bitmap != 0
-                && decode_market_mode(market.header.mode)? != MarketModeV16::Resolved)
-        {
-            return Err(V16Error::InvalidLeg);
         }
         Self::validate_resolved_payout_receipt_static(
             self.header.resolved_payout_receipt.try_to_runtime()?,
@@ -4229,27 +4218,40 @@ impl<'a> PortfolioV16View<'a> {
     ) -> V16Result<()> {
         let configured_domains =
             v16_domain_count_for_market_slots(market.header.config.max_market_slots.get())?;
-        let mut seen_domains = 0u32;
+        let market_mode = decode_market_mode(market.header.mode)?;
+        let mut seen = [u32::MAX; PORTFOLIO_SOURCE_DOMAIN_CAP];
+        let mut seen_count = 0usize;
         let mut slot_index = 0usize;
         while slot_index < PORTFOLIO_SOURCE_DOMAIN_CAP {
             let source = self.source_domains()[slot_index];
+            let realization_processed = decode_bool(source.resolved_realization_processed)?;
             if source.has_default_sparse_tag() && !source.is_occupied() {
+                if realization_processed {
+                    return Err(V16Error::InvalidLeg);
+                }
                 slot_index += 1;
                 continue;
             }
             if !source.is_occupied() {
                 return Err(V16Error::HiddenLeg);
             }
+            if realization_processed && market_mode != MarketModeV16::Resolved {
+                return Err(V16Error::InvalidLeg);
+            }
             let d_u32 = source.domain.get();
             let d = d_u32 as usize;
             if d >= configured_domains {
                 return Err(V16Error::HiddenLeg);
             }
-            let domain_bit = 1u32.checked_shl(d_u32).ok_or(V16Error::InvalidConfig)?;
-            if seen_domains & domain_bit != 0 {
-                return Err(V16Error::HiddenLeg);
+            let mut seen_i = 0usize;
+            while seen_i < seen_count {
+                if seen[seen_i] == d_u32 {
+                    return Err(V16Error::HiddenLeg);
+                }
+                seen_i += 1;
             }
-            seen_domains |= domain_bit;
+            seen[seen_count] = d_u32;
+            seen_count += 1;
             let asset_index = d / 2;
             let asset = market.markets[asset_index].engine.asset.try_to_runtime()?;
             if source.source_claim_market_id.get() != asset.market_id {
@@ -4438,7 +4440,6 @@ impl<'a> PortfolioV16View<'a> {
             || self.header.reserved_pnl.get() != 0
             || self.header.fee_credits.get() != 0
             || self.header.cancel_deposit_escrow.get() != 0
-            || self.header.resolved_source_realization_bitmap.get() != 0
             || decode_bool(self.header.stale_state)?
             || decode_bool(self.header.b_stale_state)?
             || decode_bool(self.header.rebalance_lock)?
@@ -15279,16 +15280,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     ) -> V16Result<(bool, u128)> {
         if decode_bool(account.header.resolved_payout_receipt.present)? {
             // The face is already frozen into the receipt pool.
-            account.header.resolved_source_realization_bitmap = V16PodU32::new(0);
+            account.clear_resolved_source_realization_progress();
             return Ok((false, 0));
         }
         if !Self::account_has_source_claims(&account.as_view())? {
-            account.header.resolved_source_realization_bitmap = V16PodU32::new(0);
+            account.clear_resolved_source_realization_progress();
             return Ok((false, 0));
         }
         let pos = account.header.pnl.get().max(0) as u128;
         if pos == 0 {
-            account.header.resolved_source_realization_bitmap = V16PodU32::new(0);
+            account.clear_resolved_source_realization_progress();
             return Ok((false, 0));
         }
 
@@ -15297,7 +15298,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // portfolio from combining 28 lien releases, expiries, and backing
         // consumptions in one transaction.
         let current_slot = self.header.current_slot.get();
-        let processed = account.header.resolved_source_realization_bitmap.get();
         let mut slot = 0usize;
         let mut selected = None;
         while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
@@ -15305,19 +15305,15 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             if source.has_default_sparse_tag() && !source.is_occupied() {
                 break;
             }
-            if source.is_occupied() {
+            if source.is_occupied() && !decode_bool(source.resolved_realization_processed)? {
                 let d = source.domain.get() as usize;
-                let shift = u32::try_from(d).map_err(|_| V16Error::InvalidConfig)?;
-                let domain_bit = 1u32.checked_shl(shift).ok_or(V16Error::InvalidConfig)?;
-                if processed & domain_bit == 0 {
-                    selected = Some((slot, d, source));
-                    break;
-                }
+                selected = Some((slot, d, source));
+                break;
             }
             slot += 1;
         }
         let Some((selected_slot, d, source)) = selected else {
-            account.header.resolved_source_realization_bitmap = V16PodU32::new(0);
+            account.clear_resolved_source_realization_progress();
             return Ok((false, 0));
         };
         if source.source_claim_liened_num.get() != 0 {
@@ -15350,9 +15346,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             account.header.reserved_pnl = V16PodU128::new(0);
             self.apply_released_pnl_conversion_not_atomic(account, support)?
         };
-        account.header.resolved_source_realization_bitmap = V16PodU32::new(
-            V16Core::kernel_mark_source_domain_processed(processed, d as u32)?,
-        );
+        if let Some(processed_slot) = account.source_domain_slot(d)? {
+            let processed =
+                account.header.source_domains[processed_slot].resolved_realization_processed;
+            account.header.source_domains[processed_slot].resolved_realization_processed =
+                V16Core::kernel_mark_source_domain_processed(processed)?;
+        }
 
         // If the payout snapshot was captured before this account realized (another
         // winner closed first), the realized face is still counted in the ledger's
@@ -16346,6 +16345,7 @@ impl ResolvedPayoutReceiptV16Account {
 pub struct PortfolioSourceDomainV16Account {
     pub domain: V16PodU32,
     pub source_claim_market_id: V16PodU64,
+    pub resolved_realization_processed: u8,
     pub source_claim_bound_num: V16PodU128,
     pub source_claim_liened_num: V16PodU128,
     pub source_claim_counterparty_liened_num: V16PodU128,
@@ -16414,7 +16414,6 @@ pub struct PortfolioAccountV16Account {
     pub fee_credits: V16PodI128,
     pub cancel_deposit_escrow: V16PodU128,
     pub last_fee_slot: V16PodU64,
-    pub resolved_source_realization_bitmap: V16PodU32,
     pub active_bitmap: [V16PodU64; V16_ACTIVE_BITMAP_WORDS],
     pub legs: [PortfolioLegV16Account; V16_MAX_PORTFOLIO_ASSETS_N],
     pub source_domains: [PortfolioSourceDomainV16Account; PORTFOLIO_SOURCE_DOMAIN_CAP],
@@ -16433,7 +16432,7 @@ pub struct PortfolioAccountV16Account {
 // Gated to non-kani: under `cfg(kani)` PORTFOLIO_SOURCE_DOMAIN_CAP is reduced for
 // proof tractability, so the production on-chain layout is the non-kani one.
 #[cfg(not(kani))]
-const _: () = assert!(core::mem::size_of::<PortfolioAccountV16Account>() == 9295);
+const _: () = assert!(core::mem::size_of::<PortfolioAccountV16Account>() == 9323);
 
 impl Default for PortfolioAccountV16Account {
     fn default() -> Self {
@@ -16459,7 +16458,6 @@ impl PortfolioAccountV16Account {
         self.fee_credits = V16PodI128::new(0);
         self.cancel_deposit_escrow = V16PodU128::new(0);
         self.last_fee_slot = V16PodU64::new(0);
-        self.resolved_source_realization_bitmap = V16PodU32::new(0);
         self.active_bitmap = [V16PodU64::new(0); V16_ACTIVE_BITMAP_WORDS];
 
         let empty_leg = PortfolioLegV16Account::from_runtime(&PortfolioLegV16::EMPTY);

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -8797,49 +8797,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             .ok_or(V16Error::ArithmeticOverflow)
     }
 
-    fn account_unliened_source_realizable_support(
-        &self,
-        account: &PortfolioV16View<'_>,
-        face_claim: u128,
-    ) -> V16Result<u128> {
-        if face_claim == 0 {
-            return Ok(0);
-        }
-        let mut remaining_num = V16Core::bound_num_from_amount(face_claim)?;
-        let mut support_num = U256::ZERO;
-        let mut slot = 0usize;
-        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP && remaining_num != 0 {
-            let source = account.source_domains()[slot];
-            if source.has_default_sparse_tag() && !source.is_occupied() {
-                break;
-            }
-            if !source.is_occupied() {
-                slot += 1;
-                continue;
-            }
-            let d = source.domain.get() as usize;
-            let claim_num = Self::source_claim_unliened_num_from_source(source)?.min(remaining_num);
-            if claim_num != 0 {
-                self.validate_source_domain_ledger_current(d)?;
-                let credited_num = U256::from_u128(claim_num)
-                    .checked_mul(U256::from_u128(
-                        self.source_credit_for_domain(d)?.credit_rate_num,
-                    ))
-                    .and_then(|v| v.checked_div(U256::from_u128(CREDIT_RATE_SCALE)))
-                    .ok_or(V16Error::ArithmeticOverflow)?;
-                support_num = support_num
-                    .checked_add(credited_num)
-                    .ok_or(V16Error::ArithmeticOverflow)?;
-                remaining_num -= claim_num;
-            }
-            slot += 1;
-        }
-        support_num
-            .checked_div(U256::from_u128(BOUND_SCALE))
-            .and_then(|v| v.try_into_u128())
-            .ok_or(V16Error::ArithmeticOverflow)
-    }
-
     fn source_credit_available_backing_num(&self, domain: usize) -> V16Result<u128> {
         V16Core::available_backing_num_for_source_credit_state(
             self.source_credit_for_domain(domain)?,
@@ -9486,6 +9443,25 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         effective_credit: u128,
     ) -> V16Result<SourceCreditConsumptionV16> {
         account.validate_with_market(&self.as_view())?;
+        let consumed = self.create_and_consume_account_source_credit_up_to_effective_not_atomic(
+            account,
+            effective_credit,
+        )?;
+        let total_consumed = consumed
+            .counterparty_credit_consumed
+            .checked_add(consumed.insurance_credit_consumed)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        if total_consumed != effective_credit {
+            return Err(V16Error::LockActive);
+        }
+        Ok(consumed)
+    }
+
+    fn create_and_consume_account_source_credit_up_to_effective_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        effective_credit: u128,
+    ) -> V16Result<SourceCreditConsumptionV16> {
         if effective_credit == 0 {
             return Ok(SourceCreditConsumptionV16 {
                 face_burn: 0,
@@ -9551,9 +9527,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 }
             }
             slot += 1;
-        }
-        if remaining != 0 {
-            return Err(V16Error::LockActive);
         }
         Ok(SourceCreditConsumptionV16 {
             face_burn: V16Core::amount_from_bound_num(face_burn_num)?,
@@ -10217,28 +10190,37 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             });
         }
         let has_source_claims = Self::account_has_source_claims(&account.as_view())?;
-        let effective_available = if has_source_claims {
-            self.account_unliened_source_realizable_support(&account.as_view(), old_positive_face)?
-        } else if decode_market_mode(self.header.mode)? == MarketModeV16::Live {
-            0
+        let source_consumption = if has_source_claims {
+            Some(
+                self.create_and_consume_account_source_credit_up_to_effective_not_atomic(
+                    account, loss_abs,
+                )?,
+            )
         } else {
-            self.haircut_effective_support(
-                old_positive_face,
-                self.residual(),
-                self.junior_claim_bound(),
-            )?
+            None
         };
-        let support_consumed = effective_available.min(loss_abs);
+        let support_consumed = match source_consumption {
+            Some(consumption) => consumption
+                .counterparty_credit_consumed
+                .checked_add(consumption.insurance_credit_consumed)
+                .ok_or(V16Error::ArithmeticOverflow)?,
+            None if decode_market_mode(self.header.mode)? == MarketModeV16::Live => 0,
+            None => self
+                .haircut_effective_support(
+                    old_positive_face,
+                    self.residual(),
+                    self.junior_claim_bound(),
+                )?
+                .min(loss_abs),
+        };
         let remaining_loss = loss_abs
             .checked_sub(support_consumed)
             .ok_or(V16Error::ArithmeticOverflow)?;
         let mut junior_face_burned = if has_source_claims {
-            self.create_and_consume_account_source_credit_for_effective_not_atomic(
-                account,
-                support_consumed,
-            )?
-            .face_burn
-            .min(old_positive_face)
+            source_consumption
+                .ok_or(V16Error::InvalidLeg)?
+                .face_burn
+                .min(old_positive_face)
         } else if support_consumed == 0 {
             0
         } else {

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -15396,7 +15396,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if account.header.pnl.get() < 0 {
             self.settle_resolved_bankruptcy_negative_pnl(account)?;
         }
-        self.detach_solvent_active_legs_for_resolved_close(account)?;
+        if self.detach_solvent_active_legs_for_resolved_close(account)? {
+            self.validate_shape()?;
+            return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
+        }
         if !active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get))
             || account.header.pnl.get() < 0
             || decode_bool(account.header.b_stale_state)?
@@ -15473,7 +15476,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     fn detach_solvent_active_legs_for_resolved_close(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
-    ) -> V16Result<()> {
+    ) -> V16Result<bool> {
         if account.header.pnl.get() < 0
             || decode_bool(account.header.b_stale_state)?
             || decode_bool(account.header.stale_state)?
@@ -15483,44 +15486,44 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .try_to_runtime()?
                 .has_pending_residual()
         {
-            return Ok(());
+            return Ok(false);
         }
 
         let configured_max = self.header.config.max_market_slots.get() as usize;
+        let mut first_active_asset = None;
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
             if leg.active {
                 if leg.b_stale || leg.stale {
-                    return Ok(());
+                    return Ok(false);
                 }
                 let asset_index = leg.asset_index as usize;
                 if asset_index >= configured_max {
                     return Err(V16Error::InvalidLeg);
                 }
                 if self.has_pending_domain_loss_barrier(asset_index, leg.side)? {
-                    return Ok(());
+                    return Ok(false);
                 }
                 let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;
                 if k_target != leg.k_snap || f_target != leg.f_snap {
-                    return Ok(());
+                    return Ok(false);
                 }
                 if self.b_target_for_leg(asset_index, leg)? != leg.b_snap {
-                    return Ok(());
+                    return Ok(false);
+                }
+                if first_active_asset.is_none() {
+                    first_active_asset = Some(asset_index);
                 }
             }
             slot += 1;
         }
 
-        let mut slot = 0usize;
-        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
-            let leg = account.header.legs[slot].try_to_runtime()?;
-            if leg.active {
-                self.clear_resolved_close_leg(account, leg.asset_index as usize)?;
-            }
-            slot += 1;
+        if let Some(asset_index) = first_active_asset {
+            self.clear_resolved_close_leg(account, asset_index)?;
+            return Ok(true);
         }
-        Ok(())
+        Ok(false)
     }
 
     pub fn deposit_not_atomic(

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -27,8 +27,9 @@ pub type V16ActiveBitmap = [u64; V16_ACTIVE_BITMAP_WORDS];
 pub const V16_EMPTY_ACTIVE_BITMAP: V16ActiveBitmap = [0; V16_ACTIVE_BITMAP_WORDS];
 pub const V16_BACKING_BUCKETS_PER_DOMAIN: usize = 1;
 // Bump whenever the on-chain account/header Pod layout changes (see the
-// PortfolioAccountV16Account size assertion). 17: added funding flow counters.
-pub const V16_LAYOUT_DISCRIMINATOR: u16 = 17;
+// PortfolioAccountV16Account size assertion). 18: added resolved source-domain
+// realization progress.
+pub const V16_LAYOUT_DISCRIMINATOR: u16 = 18;
 pub const V16_ACCOUNT_VERSION: u16 = 1;
 pub const BACKING_FEE_RATE_DEN_E9: u128 = 1_000_000_000;
 pub const MAX_BACKING_FEE_RATE_E9_PER_SLOT: u64 = 1_000_000_000;
@@ -4123,6 +4124,19 @@ impl<'a> PortfolioV16View<'a> {
         if source_claim_sum_num != 0 {
             V16Core::validate_positive_pnl_source_attribution(pnl, source_claim_sum_num)?;
         }
+        let configured_domains = v16_domain_count_for_market_slots(config.max_market_slots as u32)?;
+        let terminal_bitmap = self.header.resolved_source_realization_bitmap.get();
+        let valid_domain_mask = if configured_domains == u32::BITS as usize {
+            u32::MAX
+        } else {
+            (1u32 << configured_domains) - 1
+        };
+        if terminal_bitmap & !valid_domain_mask != 0
+            || (terminal_bitmap != 0
+                && decode_market_mode(market.header.mode)? != MarketModeV16::Resolved)
+        {
+            return Err(V16Error::InvalidLeg);
+        }
         Self::validate_resolved_payout_receipt_static(
             self.header.resolved_payout_receipt.try_to_runtime()?,
         )?;
@@ -4407,6 +4421,7 @@ impl<'a> PortfolioV16View<'a> {
             || self.header.reserved_pnl.get() != 0
             || self.header.fee_credits.get() != 0
             || self.header.cancel_deposit_escrow.get() != 0
+            || self.header.resolved_source_realization_bitmap.get() != 0
             || decode_bool(self.header.stale_state)?
             || decode_bool(self.header.b_stale_state)?
             || decode_bool(self.header.rebalance_lock)?
@@ -14733,6 +14748,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if converted == 0 {
             return Err(V16Error::LockActive);
         }
+        self.apply_released_pnl_conversion_not_atomic(account, converted)
+    }
+
+    fn apply_released_pnl_conversion_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        converted: u128,
+    ) -> V16Result<u128> {
+        if converted == 0 || converted > account.header.pnl.get().max(0) as u128 {
+            return Err(V16Error::InvalidConfig);
+        }
         let vault_before = self.header.vault.get();
         let consumption = if Self::account_has_source_claims(&account.as_view())? {
             self.create_and_consume_account_source_credit_for_effective_not_atomic(
@@ -15233,31 +15259,30 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     fn realize_source_backed_claims_for_resolved_close_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
-    ) -> V16Result<u128> {
+    ) -> V16Result<(bool, u128)> {
         if decode_bool(account.header.resolved_payout_receipt.present)? {
             // The face is already frozen into the receipt pool.
-            return Ok(0);
+            account.header.resolved_source_realization_bitmap = V16PodU32::new(0);
+            return Ok((false, 0));
         }
         if !Self::account_has_source_claims(&account.as_view())? {
-            return Ok(0);
+            account.header.resolved_source_realization_bitmap = V16PodU32::new(0);
+            return Ok((false, 0));
         }
         let pos = account.header.pnl.get().max(0) as u128;
         if pos == 0 {
-            return Ok(0);
+            account.header.resolved_source_realization_bitmap = V16PodU32::new(0);
+            return Ok((false, 0));
         }
-        // Release the account's persisted liens first (the terminal burn would do
-        // this anyway): the conversion consumes only UNLIENED claims, so a still-
-        // liened claim would make the realizable estimate exceed what consumption
-        // can deliver and dead-lock the close with LockActive. In the same sweep,
-        // expire any domain whose backing bucket has lapsed (status Fresh but
-        // expiry_slot <= current_slot): realization is best-effort, and querying
-        // realizable support against a past-expiry bucket would otherwise return
-        // Stale and strand the winner's close. Expiry forfeits the lapsed
-        // principal to the junior pool (the documented expiry semantics), drops
-        // the domain's credit rate to zero, and lets this step fall through to
-        // the junior receipt path instead of reverting.
+
+        // Terminal source realization is permissionless, so each successful call
+        // commits at most one bounded domain step. This prevents a max-shape
+        // portfolio from combining 28 lien releases, expiries, and backing
+        // consumptions in one transaction.
         let current_slot = self.header.current_slot.get();
+        let processed = account.header.resolved_source_realization_bitmap.get();
         let mut slot = 0usize;
+        let mut selected = None;
         while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
             let source = account.header.source_domains[slot];
             if source.has_default_sparse_tag() && !source.is_occupied() {
@@ -15265,30 +15290,57 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
             if source.is_occupied() {
                 let d = source.domain.get() as usize;
-                if source.source_claim_liened_num.get() != 0 {
-                    self.release_account_source_credit_lien_for_domain_not_atomic(account, d)?;
-                }
-                let bucket = self.backing_bucket_for_domain(d)?;
-                if bucket.status == BackingBucketStatusV16::Fresh
-                    && bucket.expiry_slot <= current_slot
-                {
-                    self.expire_source_backing_bucket_not_atomic(d, current_slot)?;
+                let shift = u32::try_from(d).map_err(|_| V16Error::InvalidConfig)?;
+                let domain_bit = 1u32.checked_shl(shift).ok_or(V16Error::InvalidConfig)?;
+                if processed & domain_bit == 0 {
+                    selected = Some((slot, d, domain_bit, source));
+                    break;
                 }
             }
             slot += 1;
         }
-        if self.account_source_realizable_support(&account.as_view(), pos)? == 0 {
-            return Ok(0);
+        let Some((selected_slot, d, domain_bit, source)) = selected else {
+            account.header.resolved_source_realization_bitmap = V16PodU32::new(0);
+            return Ok((false, 0));
+        };
+        if source.source_claim_liened_num.get() != 0 {
+            self.release_account_source_credit_lien_for_domain_not_atomic(account, d)?;
+            return Ok((true, 0));
         }
-        // Terminal: PnL reservations no longer gate realization.
-        account.header.reserved_pnl = V16PodU128::new(0);
-        let converted = self.convert_released_pnl_to_capital_core_not_atomic(account)?;
+        let bucket = self.backing_bucket_for_domain(d)?;
+        if bucket.status == BackingBucketStatusV16::Fresh && bucket.expiry_slot <= current_slot {
+            self.expire_source_backing_bucket_not_atomic(d, current_slot)?;
+            return Ok((true, 0));
+        }
+
+        let face_atoms =
+            (Self::source_claim_unliened_num_from_source(source)? / BOUND_SCALE).min(pos);
+        let support = if face_atoms == 0 {
+            0
+        } else {
+            self.source_domain_realizable_support_for_face(d, face_atoms)?
+                .min(pos)
+        };
+        let converted = if support == 0 {
+            0
+        } else {
+            // Move the selected domain to the front of the compact source table
+            // so the existing consumption and claim-burn traversals consume the
+            // same domain.
+            if selected_slot != 0 {
+                account.header.source_domains.swap(0, selected_slot);
+            }
+            account.header.reserved_pnl = V16PodU128::new(0);
+            self.apply_released_pnl_conversion_not_atomic(account, support)?
+        };
+        account.header.resolved_source_realization_bitmap = V16PodU32::new(processed | domain_bit);
+
         // If the payout snapshot was captured before this account realized (another
         // winner closed first), the realized face is still counted in the ledger's
         // unreceipted bound. Refine it out, or the stale bound dilutes the payout
         // rate forever and blocks every remaining receipt from reaching the
         // terminal rate (never finalized, never clearable).
-        if decode_bool(self.header.payout_snapshot_captured)? {
+        if converted != 0 && decode_bool(self.header.payout_snapshot_captured)? {
             let pos_after = account.header.pnl.get().max(0) as u128;
             let face_burned = pos
                 .checked_sub(pos_after)
@@ -15300,7 +15352,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 self.refine_resolved_unreceipted_bound_not_atomic(decrease_num)?;
             }
         }
-        Ok(converted)
+        Ok((true, converted))
     }
 
     fn claim_resolved_payout_topup_core_not_atomic(
@@ -15418,7 +15470,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if account.header.pnl.get() > 0 && !self.resolved_positive_payout_ready()? {
             return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
         }
-        self.realize_source_backed_claims_for_resolved_close_not_atomic(account)?;
+        if self
+            .realize_source_backed_claims_for_resolved_close_not_atomic(account)?
+            .0
+        {
+            self.validate_shape()?;
+            return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
+        }
         let mut payout_receipt = None;
         let pnl_payout = if account.header.pnl.get() > 0
             || decode_bool(account.header.resolved_payout_receipt.present)?
@@ -16337,6 +16395,7 @@ pub struct PortfolioAccountV16Account {
     pub fee_credits: V16PodI128,
     pub cancel_deposit_escrow: V16PodU128,
     pub last_fee_slot: V16PodU64,
+    pub resolved_source_realization_bitmap: V16PodU32,
     pub active_bitmap: [V16PodU64; V16_ACTIVE_BITMAP_WORDS],
     pub legs: [PortfolioLegV16Account; V16_MAX_PORTFOLIO_ASSETS_N],
     pub source_domains: [PortfolioSourceDomainV16Account; PORTFOLIO_SOURCE_DOMAIN_CAP],
@@ -16355,7 +16414,7 @@ pub struct PortfolioAccountV16Account {
 // Gated to non-kani: under `cfg(kani)` PORTFOLIO_SOURCE_DOMAIN_CAP is reduced for
 // proof tractability, so the production on-chain layout is the non-kani one.
 #[cfg(not(kani))]
-const _: () = assert!(core::mem::size_of::<PortfolioAccountV16Account>() == 9291);
+const _: () = assert!(core::mem::size_of::<PortfolioAccountV16Account>() == 9295);
 
 impl Default for PortfolioAccountV16Account {
     fn default() -> Self {
@@ -16381,6 +16440,7 @@ impl PortfolioAccountV16Account {
         self.fee_credits = V16PodI128::new(0);
         self.cancel_deposit_escrow = V16PodU128::new(0);
         self.last_fee_slot = V16PodU64::new(0);
+        self.resolved_source_realization_bitmap = V16PodU32::new(0);
         self.active_bitmap = [V16PodU64::new(0); V16_ACTIVE_BITMAP_WORDS];
 
         let empty_leg = PortfolioLegV16Account::from_runtime(&PortfolioLegV16::EMPTY);

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -4170,8 +4170,7 @@ impl<'a> PortfolioV16View<'a> {
     ) -> V16Result<()> {
         let configured_domains =
             v16_domain_count_for_market_slots(market.header.config.max_market_slots.get())?;
-        let mut seen = [u32::MAX; PORTFOLIO_SOURCE_DOMAIN_CAP];
-        let mut seen_count = 0usize;
+        let mut seen_domains = 0u32;
         let mut slot_index = 0usize;
         while slot_index < PORTFOLIO_SOURCE_DOMAIN_CAP {
             let source = self.source_domains()[slot_index];
@@ -4187,15 +4186,11 @@ impl<'a> PortfolioV16View<'a> {
             if d >= configured_domains {
                 return Err(V16Error::HiddenLeg);
             }
-            let mut seen_i = 0usize;
-            while seen_i < seen_count {
-                if seen[seen_i] == d_u32 {
-                    return Err(V16Error::HiddenLeg);
-                }
-                seen_i += 1;
+            let domain_bit = 1u32.checked_shl(d_u32).ok_or(V16Error::InvalidConfig)?;
+            if seen_domains & domain_bit != 0 {
+                return Err(V16Error::HiddenLeg);
             }
-            seen[seen_count] = d_u32;
-            seen_count += 1;
+            seen_domains |= domain_bit;
             let asset_index = d / 2;
             let asset = market.markets[asset_index].engine.asset.try_to_runtime()?;
             if source.source_claim_market_id.get() != asset.market_id {
@@ -8432,6 +8427,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
 
     fn source_claim_unliened_num(account: &PortfolioV16View<'_>, domain: usize) -> V16Result<u128> {
         let source = account.source_domain(domain)?;
+        Self::source_claim_unliened_num_from_source(source)
+    }
+
+    fn source_claim_unliened_num_from_source(
+        source: PortfolioSourceDomainV16Account,
+    ) -> V16Result<u128> {
         let locked = source
             .source_claim_liened_num
             .get()
@@ -8649,7 +8650,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             {
                 self.release_account_source_credit_lien_for_domain_not_atomic(account, d)?;
             }
-            let burnable = Self::source_claim_unliened_num(&account.as_view(), d)?;
+            let burnable =
+                Self::source_claim_unliened_num_from_source(account.header.source_domains[slot])?;
             let burn = burnable.min(burn_num);
             if burn != 0 {
                 let source = &mut account.header.source_domains[slot];
@@ -8816,7 +8818,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 continue;
             }
             let d = source.domain.get() as usize;
-            let claim_num = Self::source_claim_unliened_num(account, d)?.min(remaining_num);
+            let claim_num = Self::source_claim_unliened_num_from_source(source)?.min(remaining_num);
             if claim_num != 0 {
                 self.validate_source_domain_ledger_current(d)?;
                 let credited_num = U256::from_u128(claim_num)
@@ -9507,7 +9509,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
             let d = source.domain.get() as usize;
             let rate = self.source_credit_for_domain(d)?.credit_rate_num;
-            let unliened = Self::source_claim_unliened_num(&account.as_view(), d)?;
+            let unliened = Self::source_claim_unliened_num_from_source(source)?;
             if rate != 0 && unliened != 0 {
                 self.validate_source_domain_ledger_current(d)?;
                 let soft_num = U256::from_u128(unliened)
@@ -9710,7 +9712,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
             let d = source.domain.get() as usize;
             let rate = self.source_credit_for_domain(d)?.credit_rate_num;
-            let unliened = Self::source_claim_unliened_num(&account.as_view(), d)?;
+            let unliened = Self::source_claim_unliened_num_from_source(source)?;
             if rate != 0 && unliened != 0 {
                 self.validate_source_domain_ledger_current(d)?;
                 let soft_num = U256::from_u128(unliened)

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -11014,10 +11014,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 slot += 1;
                 continue;
             }
-            let d = source.domain.get() as usize;
             total_charged = total_charged
                 .checked_add(
-                    self.collect_account_backing_utilization_fee_for_domain_not_atomic(account, d)?,
+                    self.collect_account_backing_utilization_fee_for_slot_not_atomic(
+                        account, slot,
+                    )?,
                 )
                 .ok_or(V16Error::ArithmeticOverflow)?;
             slot += 1;
@@ -11038,6 +11039,25 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             Some(slot) => slot,
             None => return Ok(0),
         };
+        self.collect_account_backing_utilization_fee_for_slot_not_atomic(account, slot)
+    }
+
+    fn collect_account_backing_utilization_fee_for_slot_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        slot: usize,
+    ) -> V16Result<u128> {
+        let source = account
+            .header
+            .source_domains
+            .get(slot)
+            .copied()
+            .ok_or(V16Error::InvalidConfig)?;
+        if !source.is_occupied() {
+            return Err(V16Error::InvalidLeg);
+        }
+        let domain = source.domain.get() as usize;
+        self.domain_asset_side(domain)?;
         let lien_backing_num = account.header.source_domains[slot]
             .source_lien_counterparty_backing_num
             .get();

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -12973,17 +12973,25 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
-    fn clear_resolved_close_leg(
+    fn clear_resolved_close_leg_at_slot(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
-        asset_index: usize,
+        leg_slot: usize,
     ) -> V16Result<()> {
         if decode_market_mode(self.header.mode)? != MarketModeV16::Resolved {
             return Err(V16Error::LockActive);
         }
-        let leg_slot = Self::require_active_leg_slot_for_asset(&account.as_view(), asset_index)?;
+        if leg_slot >= V16_MAX_PORTFOLIO_ASSETS_N {
+            return Err(V16Error::InvalidLeg);
+        }
         let mut leg = account.header.legs[leg_slot].try_to_runtime()?;
         if !leg.active || leg.b_stale || leg.stale {
+            return Err(V16Error::InvalidLeg);
+        }
+        let asset_index = leg.asset_index as usize;
+        if asset_index >= self.header.config.max_market_slots.get() as usize
+            || asset_index >= self.markets.len()
+        {
             return Err(V16Error::InvalidLeg);
         }
         if account
@@ -15489,39 +15497,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Ok(false);
         }
 
-        let configured_max = self.header.config.max_market_slots.get() as usize;
-        let mut first_active_asset = None;
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
             if leg.active {
-                if leg.b_stale || leg.stale {
-                    return Ok(false);
-                }
-                let asset_index = leg.asset_index as usize;
-                if asset_index >= configured_max {
-                    return Err(V16Error::InvalidLeg);
-                }
-                if self.has_pending_domain_loss_barrier(asset_index, leg.side)? {
-                    return Ok(false);
-                }
-                let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;
-                if k_target != leg.k_snap || f_target != leg.f_snap {
-                    return Ok(false);
-                }
-                if self.b_target_for_leg(asset_index, leg)? != leg.b_snap {
-                    return Ok(false);
-                }
-                if first_active_asset.is_none() {
-                    first_active_asset = Some(asset_index);
-                }
+                self.clear_resolved_close_leg_at_slot(account, slot)?;
+                return Ok(true);
             }
             slot += 1;
-        }
-
-        if let Some(asset_index) = first_active_asset {
-            self.clear_resolved_close_leg(account, asset_index)?;
-            return Ok(true);
         }
         Ok(false)
     }

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1532,6 +1532,16 @@ impl V16Core {
         None
     }
 
+    #[inline]
+    fn kernel_permissionless_kf_settlement_commits_step(
+        allow_b_chunk: bool,
+        source_domain_count: usize,
+        has_pending_kf: bool,
+        leg_kf_pending: bool,
+    ) -> bool {
+        allow_b_chunk && source_domain_count != 0 && has_pending_kf && leg_kf_pending
+    }
+
     /// PRODUCTION KERNEL (engine.md selection semantics): from the actionable
     /// summary and the ENGINE-selected assets, choose the single highest-priority
     /// bounded plan, carrying the engine-chosen asset (the caller chooses neither
@@ -1648,6 +1658,16 @@ impl V16Core {
             && cert.cert_risk_epoch == risk_epoch
             && cert.cert_asset_set_epoch == asset_set_epoch
             && cert.active_bitmap_at_cert == account_bitmap
+    }
+
+    #[inline]
+    fn kernel_position_action_reuses_current_certificate(
+        account_stale: bool,
+        account_b_stale: bool,
+        cert_current: bool,
+        has_b_stale_leg: bool,
+    ) -> bool {
+        !account_stale && !account_b_stale && cert_current && !has_b_stale_leg
     }
 
     /// PRODUCTION FIDELITY BUILDER (roadmap 3C step 4, actionable-state
@@ -4906,6 +4926,7 @@ struct PositionDeltaLookupV16 {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum AccountRefreshCertOutcomeV16 {
     Certified(HealthCertV16),
+    LegSettled { asset_index: usize },
     BChunk(AccountBSettlementChunkV16),
 }
 
@@ -8377,6 +8398,34 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(sum)
     }
 
+    fn account_source_domain_count(account: &PortfolioV16View<'_>) -> usize {
+        let mut count = 0usize;
+        while count < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let source = account.source_domains()[count];
+            if source.has_default_sparse_tag() && !source.is_occupied() {
+                break;
+            }
+            count += 1;
+        }
+        count
+    }
+
+    fn account_has_pending_kf_settlement(&self, account: &PortfolioV16View<'_>) -> V16Result<bool> {
+        let mut slot = 0usize;
+        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg = account.header.legs[slot].try_to_runtime()?;
+            if leg.active {
+                let asset = self.asset_state(leg.asset_index as usize)?;
+                let (target_k, target_f) = Self::kf_target_for_leg_from_asset(asset, leg)?;
+                if leg.k_snap != target_k || leg.f_snap != target_f {
+                    return Ok(true);
+                }
+            }
+            slot += 1;
+        }
+        Ok(false)
+    }
+
     fn account_has_source_claims(account: &PortfolioV16View<'_>) -> V16Result<bool> {
         Ok(Self::account_source_claim_bound_sum_num(account)? != 0)
     }
@@ -10704,6 +10753,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     ) -> V16Result<HealthCertV16> {
         match self.refresh_account_and_certify_not_atomic(account, None, 0, false)? {
             AccountRefreshCertOutcomeV16::Certified(cert) => Ok(cert),
+            AccountRefreshCertOutcomeV16::LegSettled { .. } => Err(V16Error::Stale),
             AccountRefreshCertOutcomeV16::BChunk(_) => Err(V16Error::BStale),
         }
     }
@@ -10723,6 +10773,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .as_view()
                 .validate_source_credit_shape_with_market(&self.as_view())?;
             Self::account_source_claim_bound_sum_num(&account.as_view())?
+        };
+        let source_domain_count = if allow_b_chunk {
+            Self::account_source_domain_count(&account.as_view())
+        } else {
+            0
+        };
+        let has_pending_kf = if allow_b_chunk {
+            self.account_has_pending_kf_settlement(&account.as_view())?
+        } else {
+            false
         };
         if source_claim_sum_num != 0 {
             V16Core::validate_positive_pnl_source_attribution(
@@ -10789,7 +10849,19 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
             seen_assets[seen_asset_count] = leg.asset_index;
             seen_asset_count += 1;
+            let (target_k, target_f) = Self::kf_target_for_leg_from_asset(asset, leg)?;
+            let kf_settlement_pending = leg.k_snap != target_k || leg.f_snap != target_f;
             self.settle_leg_kf_effects_at_slot_with_asset(account, slot, asset)?;
+            if V16Core::kernel_permissionless_kf_settlement_commits_step(
+                allow_b_chunk,
+                source_domain_count,
+                has_pending_kf,
+                kf_settlement_pending,
+            ) {
+                self.validate_account_audit_scan(&account.as_view())?;
+                self.validate_shape_audit_scan()?;
+                return Ok(AccountRefreshCertOutcomeV16::LegSettled { asset_index });
+            }
             let mut refreshed = account.header.legs[slot].try_to_runtime()?;
             let target = Self::b_target_for_leg_from_asset(asset, refreshed)?;
             if target > refreshed.b_snap {
@@ -11535,6 +11607,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     true,
                 )? {
                     AccountRefreshCertOutcomeV16::Certified(_) => {}
+                    AccountRefreshCertOutcomeV16::LegSettled { asset_index } => {
+                        self.validate_shape_audit_scan()?;
+                        return Ok(PermissionlessProgressOutcomeV16::AccountLegSettled {
+                            asset_index,
+                        });
+                    }
                     AccountRefreshCertOutcomeV16::BChunk(out) => {
                         self.validate_shape_audit_scan()?;
                         return Ok(PermissionlessProgressOutcomeV16::AccountBChunk(out));
@@ -13535,18 +13613,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         let fee_bps = config.liquidation_fee_bps;
         self.require_asset_live_reducible(request.asset_index)?;
-        self.validate_account_scalar_preflight(&account.as_view())?;
+        let cert = self.settle_account_for_position_action_and_refresh_not_atomic(account)?;
         Self::require_active_leg_slot_for_asset(&account.as_view(), request.asset_index)?;
-        match self.refresh_account_and_certify_not_atomic(
-            account,
-            None,
-            self.header.config.public_b_chunk_atoms.get(),
-            false,
-        )? {
-            AccountRefreshCertOutcomeV16::Certified(_) => {}
-            AccountRefreshCertOutcomeV16::BChunk(_) => return Err(V16Error::BStale),
-        }
-        let cert = account.header.health_cert.try_to_runtime()?;
         if cert.certified_liq_deficit == 0 {
             return Err(V16Error::NonProgress);
         }
@@ -13726,17 +13794,29 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
     ) -> V16Result<HealthCertV16> {
         self.validate_account_scalar_preflight(&account.as_view())?;
-        if !decode_bool(account.header.stale_state)?
-            && !decode_bool(account.header.b_stale_state)?
+        let account_stale = decode_bool(account.header.stale_state)?;
+        let account_b_stale = decode_bool(account.header.b_stale_state)?;
+        let cert_current = !account_stale
+            && !account_b_stale
             && self
                 .ensure_favorable_action_current_certificate(&account.as_view())
-                .is_ok()
-            && !Self::has_b_stale_leg(&account.as_view())?
-        {
+                .is_ok();
+        let has_b_stale_leg = if cert_current {
+            Self::has_b_stale_leg(&account.as_view())?
+        } else {
+            true
+        };
+        if V16Core::kernel_position_action_reuses_current_certificate(
+            account_stale,
+            account_b_stale,
+            cert_current,
+            has_b_stale_leg,
+        ) {
             return account.header.health_cert.try_to_runtime();
         }
         match self.refresh_account_and_certify_not_atomic(account, None, 0, false)? {
             AccountRefreshCertOutcomeV16::Certified(cert) => Ok(cert),
+            AccountRefreshCertOutcomeV16::LegSettled { .. } => Err(V16Error::Stale),
             AccountRefreshCertOutcomeV16::BChunk(_) => Err(V16Error::BStale),
         }
     }
@@ -16278,6 +16358,7 @@ impl RiskScoreV16 {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PermissionlessProgressOutcomeV16 {
     AccountCurrent,
+    AccountLegSettled { asset_index: usize },
     AccountBChunk(AccountBSettlementChunkV16),
     ResidualBooked(BResidualBookingOutcomeV16),
     RecoveryDeclared(PermissionlessRecoveryReasonV16),

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -112,6 +112,10 @@ pub fn kani_source_credit_rank_after_take(
     )
 }
 
+pub fn kani_mark_source_domain_processed(processed: u32, domain: u32) -> V16Result<u32> {
+    V16Core::kernel_mark_source_domain_processed(processed, domain)
+}
+
 pub fn kani_active_bitmap_set(
     bitmap: &mut V16ActiveBitmap,
     leg_slot_index: usize,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -112,8 +112,8 @@ pub fn kani_source_credit_rank_after_take(
     )
 }
 
-pub fn kani_mark_source_domain_processed(processed: u32, domain: u32) -> V16Result<u32> {
-    V16Core::kernel_mark_source_domain_processed(processed, domain)
+pub fn kani_mark_source_domain_processed(processed: u8) -> V16Result<u8> {
+    V16Core::kernel_mark_source_domain_processed(processed)
 }
 
 pub fn kani_active_bitmap_set(
@@ -1424,6 +1424,7 @@ pub fn kani_eq_portfolio_source_domain_v16_account(
 ) -> bool {
     a.domain.get() == b.domain.get()
         && a.source_claim_market_id.get() == b.source_claim_market_id.get()
+        && a.resolved_realization_processed == b.resolved_realization_processed
         && a.source_claim_bound_num.get() == b.source_claim_bound_num.get()
         && a.source_claim_liened_num.get() == b.source_claim_liened_num.get()
         && a.source_claim_counterparty_liened_num.get()

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -86,6 +86,32 @@ pub fn kani_position_action_reuses_current_certificate(
     )
 }
 
+pub fn kani_source_credit_take(
+    remaining_effective: u128,
+    effective_by_claim: u128,
+    effective_by_backing: u128,
+) -> u128 {
+    V16Core::kernel_source_credit_take(
+        remaining_effective,
+        effective_by_claim,
+        effective_by_backing,
+    )
+}
+
+pub fn kani_source_credit_rank_after_take(
+    remaining_effective: u128,
+    remaining_face_num: u128,
+    effective_taken: u128,
+    face_num_taken: u128,
+) -> V16Result<(u128, u128)> {
+    V16Core::kernel_source_credit_rank_after_take(
+        remaining_effective,
+        remaining_face_num,
+        effective_taken,
+        face_num_taken,
+    )
+}
+
 pub fn kani_active_bitmap_set(
     bitmap: &mut V16ActiveBitmap,
     leg_slot_index: usize,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -58,6 +58,34 @@ pub fn kani_cert_is_current(
     )
 }
 
+pub fn kani_permissionless_kf_settlement_commits_step(
+    allow_b_chunk: bool,
+    source_domain_count: usize,
+    has_pending_kf: bool,
+    leg_kf_pending: bool,
+) -> bool {
+    V16Core::kernel_permissionless_kf_settlement_commits_step(
+        allow_b_chunk,
+        source_domain_count,
+        has_pending_kf,
+        leg_kf_pending,
+    )
+}
+
+pub fn kani_position_action_reuses_current_certificate(
+    account_stale: bool,
+    account_b_stale: bool,
+    cert_current: bool,
+    has_b_stale_leg: bool,
+) -> bool {
+    V16Core::kernel_position_action_reuses_current_certificate(
+        account_stale,
+        account_b_stale,
+        cert_current,
+        has_b_stale_leg,
+    )
+}
+
 pub fn kani_active_bitmap_set(
     bitmap: &mut V16ActiveBitmap,
     leg_slot_index: usize,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -1077,6 +1077,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
     ) -> V16Result<u128> {
         self.realize_source_backed_claims_for_resolved_close_not_atomic(account)
+            .map(|(_, converted)| converted)
     }
 
     pub fn kani_create_resolved_payout_receipt_if_needed(

--- a/tests/backing_double_claim_fuzz.rs
+++ b/tests/backing_double_claim_fuzz.rs
@@ -215,6 +215,37 @@ fn resolved_market_with_backed_winner(
     (header, markets, account_header)
 }
 
+#[test]
+fn terminal_source_chunk_does_not_revisit_a_recomputed_domain_rate() {
+    // floor(81 * floor(8 / 81)) realizes seven atoms. Revisiting the same
+    // domain after burning that face would raise its rate and incorrectly
+    // consume the eighth provider atom.
+    let pnl = 81u128;
+    let backing = 8u128;
+    let (mut header, mut markets, mut account_header) =
+        resolved_market_with_backed_winner(pnl, backing, 0);
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+
+    let first = market
+        .close_resolved_account_not_atomic(&mut account, 0)
+        .unwrap();
+    assert_eq!(first, ResolvedCloseOutcomeV16::ProgressOnly);
+    assert_eq!(account.header.resolved_source_realization_bitmap.get(), 1);
+    assert_eq!(account.header.capital.get(), 7);
+
+    let final_outcome = close_resolved_to_completion(&mut market, &mut account);
+    assert!(matches!(
+        final_outcome,
+        ResolvedCloseOutcomeV16::Closed { payout: 7 }
+    ));
+    assert_eq!(market.header.vault.get(), 1);
+    market
+        .withdraw_fresh_counterparty_backing_not_atomic(0, 1)
+        .unwrap();
+    assert_eq!(market.header.vault.get(), 0);
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(300))]
 

--- a/tests/backing_double_claim_fuzz.rs
+++ b/tests/backing_double_claim_fuzz.rs
@@ -16,7 +16,8 @@ use percolator::{
     Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PortfolioAccountV16Account,
     PortfolioV16ViewMut, ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedCloseOutcomeV16,
     SourceCreditStateV16, SourceCreditStateV16Account, V16Config, V16PodI128, V16PodU128,
-    V16PodU32, V16PodU64, CREDIT_RATE_SCALE,
+    V16PodU32, V16PodU64, CREDIT_RATE_SCALE, PORTFOLIO_SOURCE_DOMAIN_CAP,
+    V16_MAX_PORTFOLIO_ASSETS_N,
 };
 use proptest::prelude::*;
 
@@ -88,6 +89,24 @@ fn winner_account(capital: u128, pnl: u128) -> PortfolioAccountV16Account {
     account_header
 }
 
+fn close_resolved_to_completion(
+    market: &mut MarketGroupV16ViewMut<'_, u64>,
+    account: &mut PortfolioV16ViewMut<'_>,
+) -> ResolvedCloseOutcomeV16 {
+    // One call can settle one leg, release/expire/realize one source domain,
+    // or finalize the payout.
+    let max_steps = V16_MAX_PORTFOLIO_ASSETS_N + 3 * PORTFOLIO_SOURCE_DOMAIN_CAP + 4;
+    for _ in 0..max_steps {
+        let outcome = market
+            .close_resolved_account_not_atomic(account, 0)
+            .expect("resolved continuation must not revert");
+        if matches!(outcome, ResolvedCloseOutcomeV16::Closed { .. }) {
+            return outcome;
+        }
+    }
+    panic!("resolved close exceeded its finite leg/source-domain rank");
+}
+
 /// Close the winner, then (optionally first) withdraw the provider principal.
 /// Returns (winner_payout, vault_after_everything).
 fn run_order(
@@ -110,9 +129,7 @@ fn run_order(
             .withdraw_fresh_counterparty_backing_not_atomic(0, backing)
             .expect("provider principal must be withdrawable before the winner closes");
     }
-    let outcome = market
-        .close_resolved_account_not_atomic(&mut account, 0)
-        .expect("winner close must not revert");
+    let outcome = close_resolved_to_completion(&mut market, &mut account);
     let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { .. });
     assert!(closed, "winner did not fully close");
     if !provider_first {
@@ -230,9 +247,7 @@ proptest! {
         prop_assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
 
         let vault_before = market.header.vault.get();
-        let outcome = market
-            .close_resolved_account_not_atomic(&mut account, 0)
-            .expect("backed winner close must not revert");
+        let outcome = close_resolved_to_completion(&mut market, &mut account);
         let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { payout: _ });
         prop_assert!(closed, "backed winner did not fully close");
         let paid = vault_before - market.header.vault.get();
@@ -325,9 +340,7 @@ proptest! {
         prop_assume!(account.validate_with_market(&market.as_view()) == Ok(()));
 
         let vault_before = market.header.vault.get();
-        let outcome = market
-            .close_resolved_account_not_atomic(&mut account, 0)
-            .expect("liened backed winner close must not revert");
+        let outcome = close_resolved_to_completion(&mut market, &mut account);
         let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { payout: _ });
         prop_assert!(closed, "liened backed winner did not fully close");
         let paid = vault_before - market.header.vault.get();
@@ -400,13 +413,13 @@ fn realization_after_snapshot_refines_unreceipted_bound() {
     assert_eq!(b.validate_with_market(&market.as_view()), Ok(()));
 
     // A closes first: captures the snapshot while B's face is unreceipted.
-    market.close_resolved_account_not_atomic(&mut a, 0).unwrap();
+    close_resolved_to_completion(&mut market, &mut a);
     let a_receipt = a.header.resolved_payout_receipt.try_to_runtime().unwrap();
     assert!(a_receipt.present && !a_receipt.finalized); // diluted by B's face
 
     // B realizes against its backing at terminal close.
     let vault_before_b = market.header.vault.get();
-    market.close_resolved_account_not_atomic(&mut b, 0).unwrap();
+    close_resolved_to_completion(&mut market, &mut b);
     assert_eq!(vault_before_b - market.header.vault.get(), pnl_b);
     assert_eq!(b.header.pnl.get(), 0);
     assert_eq!(b.header.capital.get(), 0);
@@ -457,9 +470,7 @@ fn terminal_close_with_expired_backing_does_not_strand() {
     assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
 
     let vault_before = market.header.vault.get();
-    let outcome = market
-        .close_resolved_account_not_atomic(&mut account, 0)
-        .expect("expired-backing winner close must not revert (liveness)");
+    let outcome = close_resolved_to_completion(&mut market, &mut account);
     let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { payout: _ });
     assert!(closed, "expired-backing winner did not fully close");
     let paid = vault_before - market.header.vault.get();
@@ -511,9 +522,7 @@ proptest! {
         prop_assume!(account.validate_with_market(&market.as_view()) == Ok(()));
 
         let vault_before = market.header.vault.get();
-        let outcome = market
-            .close_resolved_account_not_atomic(&mut account, 0)
-            .expect("backed winner close must not revert at any backing level (no DoS)");
+        let outcome = close_resolved_to_completion(&mut market, &mut account);
         // No DoS: the close fully settles rather than stalling.
         let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { payout: _ });
         prop_assert!(closed, "close did not finalize at backing={}", backing);

--- a/tests/backing_double_claim_fuzz.rs
+++ b/tests/backing_double_claim_fuzz.rs
@@ -231,7 +231,10 @@ fn terminal_source_chunk_does_not_revisit_a_recomputed_domain_rate() {
         .close_resolved_account_not_atomic(&mut account, 0)
         .unwrap();
     assert_eq!(first, ResolvedCloseOutcomeV16::ProgressOnly);
-    assert_eq!(account.header.resolved_source_realization_bitmap.get(), 1);
+    assert_eq!(
+        account.header.source_domains[0].resolved_realization_processed,
+        1
+    );
     assert_eq!(account.header.capital.get(), 7);
 
     let final_outcome = close_resolved_to_completion(&mut market, &mut account);

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -14,7 +14,9 @@ use percolator::v16::{
     kani_liquidation_engine_close_request_q, kani_liquidation_fee_from_raw_fee,
     kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
-    kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
+    kani_pending_domain_loss_barrier_blocks_position_change,
+    kani_permissionless_kf_settlement_commits_step,
+    kani_position_action_reuses_current_certificate, kani_position_delta_increases_risk,
     kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
     kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
     kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
@@ -235,6 +237,173 @@ fn proof_v16_active_bitmap_set_get_count_is_exact_and_bounds_checked() {
         assert!(!active_bitmap_get(bitmap, slot));
         assert_eq!(after_count, before_count);
     }
+}
+
+#[kani::proof]
+#[kani::unwind(17)]
+#[kani::solver(cadical)]
+fn proof_v16_permissionless_source_kf_refresh_exhausts_exact_pending_rank() {
+    assert!(V16_MAX_PORTFOLIO_ASSETS_N < 64);
+    let raw_pending: u64 = kani::any();
+    let valid_mask = (1u64 << V16_MAX_PORTFOLIO_ASSETS_N) - 1;
+    let mut pending = raw_pending & valid_mask;
+    let initial_count = pending.count_ones();
+    let source_domain_count = (kani::any::<u8>() as usize) % (PORTFOLIO_SOURCE_DOMAIN_CAP + 1);
+    let allow_b_chunk: bool = kani::any();
+    let chunked = allow_b_chunk && source_domain_count != 0;
+    let mut steps = 0u32;
+
+    kani::cover!(
+        chunked && initial_count == V16_MAX_PORTFOLIO_ASSETS_N as u32,
+        "permissionless source refresh covers the maximum stale-leg shape"
+    );
+    kani::cover!(
+        chunked && initial_count >= 2 && pending & 1 == 0,
+        "permissionless source refresh covers sparse stale-leg sets"
+    );
+    kani::cover!(
+        allow_b_chunk && source_domain_count == PORTFOLIO_SOURCE_DOMAIN_CAP,
+        "permissionless refresh covers the maximum source-domain shape"
+    );
+    kani::cover!(
+        !allow_b_chunk && source_domain_count != 0 && initial_count != 0,
+        "direct refresh remains unchunked despite source attribution"
+    );
+    kani::cover!(
+        allow_b_chunk && source_domain_count == 0 && initial_count != 0,
+        "source-free permissionless refresh remains unchunked"
+    );
+
+    loop {
+        let has_pending = pending != 0;
+        let mut selected = None;
+        let mut slot = 0usize;
+        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg_pending = pending & (1u64 << slot) != 0;
+            if kani_permissionless_kf_settlement_commits_step(
+                allow_b_chunk,
+                source_domain_count,
+                has_pending,
+                leg_pending,
+            ) {
+                selected = Some(slot);
+                break;
+            }
+            slot += 1;
+        }
+
+        if !chunked || pending == 0 {
+            assert!(selected.is_none());
+            break;
+        }
+
+        let selected = selected.unwrap();
+        assert_eq!(selected, pending.trailing_zeros() as usize);
+        let after = pending & !(1u64 << selected);
+        assert_eq!(after.count_ones() + 1, pending.count_ones());
+        assert_eq!(after.count_ones() + steps + 1, initial_count);
+        pending = after;
+        steps += 1;
+    }
+
+    if chunked {
+        assert_eq!(pending, 0);
+        assert_eq!(steps, initial_count);
+        assert!(steps <= V16_MAX_PORTFOLIO_ASSETS_N as u32);
+    } else {
+        assert_eq!(pending.count_ones(), initial_count);
+        assert_eq!(steps, 0);
+    }
+}
+
+#[kani::proof]
+#[kani::unwind(16)]
+#[kani::solver(cadical)]
+fn proof_v16_current_liquidatable_account_reuses_certificate_without_refresh() {
+    let cert = HealthCertV16 {
+        certified_equity: kani::any(),
+        certified_initial_req: kani::any(),
+        certified_maintenance_req: kani::any(),
+        certified_liq_deficit: kani::any(),
+        certified_worst_case_loss: kani::any(),
+        cert_oracle_epoch: kani::any(),
+        cert_funding_epoch: kani::any(),
+        cert_risk_epoch: kani::any(),
+        cert_asset_set_epoch: kani::any(),
+        active_bitmap_at_cert: kani::any(),
+        valid: kani::any(),
+    };
+    let oracle_epoch: u64 = kani::any();
+    let funding_epoch: u64 = kani::any();
+    let risk_epoch: u64 = kani::any();
+    let asset_set_epoch: u64 = kani::any();
+    let account_bitmap = kani::any();
+    let account_stale: bool = kani::any();
+    let account_b_stale: bool = kani::any();
+    let has_b_stale_leg: bool = kani::any();
+    let cert_current = kani_cert_is_current(
+        cert,
+        oracle_epoch,
+        funding_epoch,
+        risk_epoch,
+        asset_set_epoch,
+        account_bitmap,
+    );
+    let reuse = kani_position_action_reuses_current_certificate(
+        account_stale,
+        account_b_stale,
+        cert_current,
+        has_b_stale_leg,
+    );
+
+    kani::cover!(
+        reuse && cert.certified_liq_deficit > 0,
+        "a current liquidatable account takes the certificate fast path"
+    );
+    kani::cover!(
+        !reuse && cert_current,
+        "account or leg staleness blocks certificate reuse"
+    );
+    kani::cover!(
+        !reuse && !cert_current,
+        "an invalid or epoch-mismatched certificate forces refresh"
+    );
+
+    assert_eq!(
+        reuse,
+        !account_stale
+            && !account_b_stale
+            && cert.valid
+            && cert.cert_oracle_epoch == oracle_epoch
+            && cert.cert_funding_epoch == funding_epoch
+            && cert.cert_risk_epoch == risk_epoch
+            && cert.cert_asset_set_epoch == asset_set_epoch
+            && cert.active_bitmap_at_cert == account_bitmap
+            && !has_b_stale_leg
+    );
+
+    let mut alternate_liquidation_state = cert;
+    alternate_liquidation_state.certified_liq_deficit = if cert.certified_liq_deficit == 0 {
+        1
+    } else {
+        0
+    };
+    let alternate_current = kani_cert_is_current(
+        alternate_liquidation_state,
+        oracle_epoch,
+        funding_epoch,
+        risk_epoch,
+        asset_set_epoch,
+        account_bitmap,
+    );
+    let alternate_reuse = kani_position_action_reuses_current_certificate(
+        account_stale,
+        account_b_stale,
+        alternate_current,
+        has_b_stale_leg,
+    );
+    assert_eq!(alternate_current, cert_current);
+    assert_eq!(alternate_reuse, reuse);
 }
 
 #[kani::proof]

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -14,7 +14,7 @@ use percolator::v16::{
     kani_liquidation_engine_close_request_q, kani_liquidation_fee_from_raw_fee,
     kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
-    kani_pending_domain_loss_barrier_blocks_position_change,
+    kani_mark_source_domain_processed, kani_pending_domain_loss_barrier_blocks_position_change,
     kani_permissionless_kf_settlement_commits_step,
     kani_position_action_reuses_current_certificate, kani_position_delta_increases_risk,
     kani_prepare_asset_recovery_transition, kani_source_credit_rank_after_take,
@@ -47,6 +47,24 @@ use percolator::{
     MAX_ORACLE_PRICE, MAX_POSITION_ABS_Q, MAX_TRADE_SIZE_Q, MAX_VAULT_TVL, POS_SCALE,
     SOCIAL_LOSS_DEN, V16_ACTIVE_BITMAP_WORDS,
 };
+
+#[kani::proof]
+fn proof_v16_terminal_source_domain_step_strictly_decreases_remaining_rank() {
+    let processed: u32 = kani::any();
+    let domain_raw: u8 = kani::any();
+    kani::assume(domain_raw < u32::BITS as u8);
+    let domain = domain_raw as u32;
+    let bit = 1u32 << domain;
+    kani::assume(processed & bit == 0);
+
+    let next = kani_mark_source_domain_processed(processed, domain).unwrap();
+
+    assert_eq!(next, processed | bit);
+    assert_eq!(next.count_ones(), processed.count_ones() + 1);
+    assert_eq!(next & processed, processed);
+    kani::cover!(processed == 0, "terminal source rank covers first domain");
+    kani::cover!(processed != 0, "terminal source rank covers a later domain");
+}
 
 fn ids() -> ([u8; 32], [u8; 32], [u8; 32]) {
     ([1; 32], [2; 32], [3; 32])

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -17,7 +17,8 @@ use percolator::v16::{
     kani_pending_domain_loss_barrier_blocks_position_change,
     kani_permissionless_kf_settlement_commits_step,
     kani_position_action_reuses_current_certificate, kani_position_delta_increases_risk,
-    kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
+    kani_prepare_asset_recovery_transition, kani_source_credit_rank_after_take,
+    kani_source_credit_state_realizable_support_for_face, kani_source_credit_take,
     kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
     kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
     AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
@@ -404,6 +405,88 @@ fn proof_v16_current_liquidatable_account_reuses_certificate_without_refresh() {
     );
     assert_eq!(alternate_current, cert_current);
     assert_eq!(alternate_reuse, reuse);
+}
+
+#[kani::proof]
+#[kani::unwind(29)]
+#[kani::solver(cadical)]
+fn proof_v16_fused_source_credit_take_exhausts_exact_effective_rank() {
+    let requested = kani::any::<u16>() as u128;
+    let claim_capacity: [u8; PORTFOLIO_SOURCE_DOMAIN_CAP] = kani::any();
+    let backing_capacity: [u8; PORTFOLIO_SOURCE_DOMAIN_CAP] = kani::any();
+    let mut remaining = requested;
+    let mut total_capacity = 0u128;
+    let mut consumed = 0u128;
+    let mut slot = 0usize;
+
+    while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
+        let by_claim = claim_capacity[slot] as u128;
+        let by_backing = backing_capacity[slot] as u128;
+        let capacity = by_claim.min(by_backing);
+        total_capacity += capacity;
+        let take = kani_source_credit_take(remaining, by_claim, by_backing);
+
+        assert!(take <= remaining);
+        assert!(take <= by_claim);
+        assert!(take <= by_backing);
+        remaining -= take;
+        consumed += take;
+        assert_eq!(consumed + remaining, requested);
+        slot += 1;
+    }
+
+    kani::cover!(
+        requested != 0 && total_capacity < requested,
+        "fused source consumption covers backing-exhausted partial support"
+    );
+    kani::cover!(
+        requested != 0 && total_capacity >= requested,
+        "fused source consumption covers fully satisfied support"
+    );
+    kani::cover!(
+        claim_capacity[0] > backing_capacity[0],
+        "fused source consumption is capped by backing"
+    );
+    kani::cover!(
+        backing_capacity[0] > claim_capacity[0],
+        "fused source consumption is capped by claims"
+    );
+
+    assert_eq!(consumed, requested.min(total_capacity));
+    assert_eq!(remaining, requested.saturating_sub(total_capacity));
+}
+
+#[kani::proof]
+#[kani::unwind(4)]
+#[kani::solver(cadical)]
+fn proof_v16_fused_source_credit_take_preserves_face_cap() {
+    let remaining_effective: u128 = kani::any();
+    let remaining_face_num: u128 = kani::any();
+    let effective_taken: u128 = kani::any();
+    let face_num_taken: u128 = kani::any();
+    kani::assume(effective_taken <= remaining_effective);
+    kani::assume(face_num_taken <= remaining_face_num);
+
+    let (next_effective, next_face_num) = kani_source_credit_rank_after_take(
+        remaining_effective,
+        remaining_face_num,
+        effective_taken,
+        face_num_taken,
+    )
+    .unwrap();
+
+    kani::cover!(
+        effective_taken != 0 && face_num_taken != 0,
+        "fused source consumption advances both ranks"
+    );
+    kani::cover!(
+        effective_taken == remaining_effective && face_num_taken < remaining_face_num,
+        "effective demand can finish before the face cap is exhausted"
+    );
+    assert_eq!(next_effective + effective_taken, remaining_effective);
+    assert_eq!(next_face_num + face_num_taken, remaining_face_num);
+    assert!(next_effective <= remaining_effective);
+    assert!(next_face_num <= remaining_face_num);
 }
 
 #[kani::proof]

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -50,20 +50,16 @@ use percolator::{
 
 #[kani::proof]
 fn proof_v16_terminal_source_domain_step_strictly_decreases_remaining_rank() {
-    let processed: u32 = kani::any();
-    let domain_raw: u8 = kani::any();
-    kani::assume(domain_raw < u32::BITS as u8);
-    let domain = domain_raw as u32;
-    let bit = 1u32 << domain;
-    kani::assume(processed & bit == 0);
+    let processed: u8 = kani::any();
+    kani::assume(processed == 0);
 
-    let next = kani_mark_source_domain_processed(processed, domain).unwrap();
+    let next = kani_mark_source_domain_processed(processed).unwrap();
 
-    assert_eq!(next, processed | bit);
-    assert_eq!(next.count_ones(), processed.count_ones() + 1);
-    assert_eq!(next & processed, processed);
-    kani::cover!(processed == 0, "terminal source rank covers first domain");
-    kani::cover!(processed != 0, "terminal source rank covers a later domain");
+    assert_eq!(next, 1);
+    let remaining_before = if processed == 0 { 1u8 } else { 0 };
+    let remaining_after = if next == 0 { 1u8 } else { 0 };
+    assert_eq!(remaining_after, remaining_before - 1);
+    kani::cover!(next == 1, "terminal source entry rank reaches processed");
 }
 
 fn ids() -> ([u8; 32], [u8; 32], [u8; 32]) {

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -10,10 +10,11 @@ use percolator::{
     PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
-    ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedPayoutLedgerV16,
-    ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16, ResolvedPayoutReceiptV16Account,
-    SideModeV16, SideV16, SourceCreditStateV16, SourceCreditStateV16Account, TradeRequestV16,
-    V16Config, V16Error, V16PodI128, V16PodU128, V16PodU32, V16PodU64, V16_EMPTY_ACTIVE_BITMAP,
+    ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedCloseOutcomeV16,
+    ResolvedPayoutLedgerV16, ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16,
+    ResolvedPayoutReceiptV16Account, SideModeV16, SideV16, SourceCreditStateV16,
+    SourceCreditStateV16Account, TradeRequestV16, V16Config, V16Error, V16PodI128, V16PodU128,
+    V16PodU32, V16PodU64, V16_EMPTY_ACTIVE_BITMAP,
 };
 use percolator::{ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, POS_SCALE};
 
@@ -3088,6 +3089,80 @@ fn v16_auto_crank_chunks_source_bearing_kf_refresh() {
         AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent),
     );
     assert!(long.header.health_cert.try_to_runtime().unwrap().valid);
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_resolved_close_chunks_source_bearing_kf_settlement() {
+    const PRICE: u64 = 1_000_000;
+    let (mut header, mut markets) = market_fixture(14, PRICE);
+    let mut long_header = account_fixture(14, 213);
+    let mut short_header = account_fixture(14, 214);
+    let requests = [0usize, 1, 2].map(|asset_index| TradeRequestV16 {
+        asset_index,
+        size_q: signed_q(POS_SCALE),
+        exec_price: PRICE,
+        fee_bps: 0,
+    });
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market.deposit_not_atomic(&mut long, 10_000_000).unwrap();
+    market.deposit_not_atomic(&mut short, 10_000_000).unwrap();
+    market
+        .execute_batch_with_fee_loss_stale_scoped_not_atomic(&mut long, &mut short, &requests)
+        .unwrap();
+    for domain in 0..11 {
+        market
+            .add_account_source_positive_pnl_not_atomic(&mut long, domain, 1)
+            .unwrap();
+    }
+    for asset_index in 0..3 {
+        market
+            .accrue_asset_to_not_atomic(asset_index, 20, 1_001_000, 0, true)
+            .unwrap();
+    }
+    market.resolve_market_not_atomic(20).unwrap();
+
+    let pending_kf_count = |market: &MarketGroupV16ViewMut<'_, u64>,
+                            account: &PortfolioV16ViewMut<'_>| {
+        account
+            .header
+            .legs
+            .iter()
+            .map(|leg| leg.try_to_runtime().unwrap())
+            .filter(|leg| {
+                if !leg.active {
+                    return false;
+                }
+                let asset = market.markets[leg.asset_index as usize]
+                    .engine
+                    .asset
+                    .try_to_runtime()
+                    .unwrap();
+                let (k_target, f_target) = match leg.side {
+                    SideV16::Long => (asset.k_long, asset.f_long_num),
+                    SideV16::Short => (asset.k_short, asset.f_short_num),
+                };
+                leg.k_snap != k_target || leg.f_snap != f_target
+            })
+            .count()
+    };
+
+    assert_eq!(pending_kf_count(&market, &long), 3);
+    for expected_before in (1..=3).rev() {
+        let outcome = market
+            .close_resolved_account_not_atomic(&mut long, 0)
+            .unwrap();
+        assert_eq!(outcome, ResolvedCloseOutcomeV16::ProgressOnly);
+        assert_eq!(
+            pending_kf_count(&market, &long),
+            expected_before - 1,
+            "each resolved-close call must settle exactly one source-bearing K/F leg"
+        );
+    }
     market.validate_shape().unwrap();
     long.validate_with_market(&market.as_view()).unwrap();
 }

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3030,6 +3030,68 @@ fn v16_auto_crank_classifies_fresh_account_stale_then_refreshes_to_clean() {
     account.validate_with_market(&market.as_view()).unwrap();
 }
 
+#[test]
+fn v16_auto_crank_chunks_source_bearing_kf_refresh() {
+    const PRICE: u64 = 1_000_000;
+    let (mut header, mut markets) = market_fixture(14, PRICE);
+    let mut long_header = account_fixture(14, 211);
+    let mut short_header = account_fixture(14, 212);
+    let requests = [0usize, 1, 2].map(|asset_index| TradeRequestV16 {
+        asset_index,
+        size_q: signed_q(POS_SCALE),
+        exec_price: PRICE,
+        fee_bps: 0,
+    });
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market.deposit_not_atomic(&mut long, 10_000_000).unwrap();
+    market.deposit_not_atomic(&mut short, 10_000_000).unwrap();
+    market
+        .execute_batch_with_fee_loss_stale_scoped_not_atomic(&mut long, &mut short, &requests)
+        .unwrap();
+    for domain in 0..11 {
+        market
+            .add_account_source_positive_pnl_not_atomic(&mut long, domain, 1)
+            .unwrap();
+    }
+    for asset_index in 0..3 {
+        market
+            .accrue_asset_to_not_atomic(asset_index, 20, 1_001_000, 0, true)
+            .unwrap();
+    }
+
+    let work = AutoCrankWorkV16 {
+        now_slot: 20,
+        observations: &[],
+        resolved_close_fee_rate_per_slot: 0,
+    };
+    for expected_asset in 0..3 {
+        let result = market
+            .permissionless_auto_crank_not_atomic(&mut long, work)
+            .unwrap();
+        assert_eq!(
+            result.outcome,
+            AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountLegSettled {
+                asset_index: expected_asset,
+            }),
+        );
+        assert!(!long.header.health_cert.try_to_runtime().unwrap().valid);
+    }
+
+    let certified = market
+        .permissionless_auto_crank_not_atomic(&mut long, work)
+        .unwrap();
+    assert_eq!(
+        certified.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent),
+    );
+    assert!(long.header.health_cert.try_to_runtime().unwrap().valid);
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+}
+
 // ROADMAP 3C step 4 / NB2 finite-multi-step liveness via the self-classifying
 // crank: an uncertified, underwater account must be driven to a de-risked fixed
 // point by repeated auto-cranks — the classifier ESCALATES (stale -> refresh,

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3163,6 +3163,31 @@ fn v16_resolved_close_chunks_source_bearing_kf_settlement() {
             "each resolved-close call must settle exactly one source-bearing K/F leg"
         );
     }
+    assert_eq!(
+        long.header
+            .active_bitmap
+            .map(V16PodU64::get)
+            .iter()
+            .map(|word| word.count_ones())
+            .sum::<u32>(),
+        3
+    );
+    for expected_before in (1..=3).rev() {
+        let outcome = market
+            .close_resolved_account_not_atomic(&mut long, 0)
+            .unwrap();
+        assert_eq!(outcome, ResolvedCloseOutcomeV16::ProgressOnly);
+        assert_eq!(
+            long.header
+                .active_bitmap
+                .map(V16PodU64::get)
+                .iter()
+                .map(|word| word.count_ones())
+                .sum::<u32>(),
+            expected_before - 1,
+            "each resolved-close call must detach exactly one current active leg"
+        );
+    }
     market.validate_shape().unwrap();
     long.validate_with_market(&market.as_view()).unwrap();
 }


### PR DESCRIPTION
## Finding

A fully public 14-asset portfolio with 28 occupied source domains could put both live liquidation progress and resolved terminal close at the 1,400,000 CU transaction ceiling. SVM rollback left the victim unchanged, and every available owner/keeper continuation repeated the same oversized work, so this was a persistent funds-locking state rather than a single expensive call.

During RED-to-GREEN verification, the first progress encoding also exposed a release blocker: global source domain IDs are not bounded by the 28-entry portfolio table. A `u32` bitmap rejected legitimate source claims on asset 16 and above even though markets publicly support more than 64 assets.

## Fix

- settle at most one stale K/F leg per permissionless continuation and reuse its health certificate
- linearize and fuse source-domain support/consumption work
- detach one resolved leg per call without full active-leg prescans
- realize at most one resolved source entry per call
- persist completion on each sparse source entry, so progress supports every configured global domain ID and follows entries through compaction
- restore domain-agnostic duplicate validation and validate per-entry progress as a resolved-only boolean
- keep layout discriminator 18 and prove each selected source-entry step strictly decreases its remaining rank

## Public regression and measurements

The paired wrapper PR constructs both states through public SBF instructions only. It covers the 14-leg/28-source max shape and a real backed winner on asset 16 (global domain 32), then requires finite permissionless progress and exact custody conservation.

Post-fix max CU:

- stale-leg settlement / refresh: 1,324,675 CU
- liquidation: 939,113 CU
- resolved close step: 1,163,297 CU
- resolved terminal calls for both max-shape accounts: 58

## Verification

- engine runtime: 141/141 passed
- terminal source-entry rank Kani harness: 0/8 failed, cover reached
- wrapper runtime against the exact rebuilt SBF: 6/6 + 567/567 passed
- wrapper instruction decoder Kani harness: 0/864 failed, cover reached

Wrapper public repro: aeyakovenko/percolator-prog#212
