### PR TITLE
[REAL DoS] Reconcile expired source liens during live refresh

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -716,6 +716,65 @@ impl V16Core {
         Ok((required_face_num, required_backing_num))
     }
 
+    fn prepare_account_counterparty_lien_impairment(
+        mut source: PortfolioSourceDomainV16Account,
+    ) -> V16Result<(PortfolioSourceDomainV16Account, u128)> {
+        let face = source.source_claim_counterparty_liened_num.get();
+        let backing_num = source.source_lien_counterparty_backing_num.get();
+        if face == 0 && backing_num == 0 {
+            return Ok((source, 0));
+        }
+        if face == 0 || backing_num == 0 || backing_num % BOUND_SCALE != 0 {
+            return Err(V16Error::InvalidLeg);
+        }
+        let effective = backing_num / BOUND_SCALE;
+        if effective == 0 {
+            return Err(V16Error::InvalidLeg);
+        }
+
+        source.source_claim_counterparty_liened_num = V16PodU128::new(0);
+        source.source_claim_liened_num = V16PodU128::new(
+            source
+                .source_claim_liened_num
+                .get()
+                .checked_sub(face)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        source.source_claim_impaired_num = V16PodU128::new(
+            source
+                .source_claim_impaired_num
+                .get()
+                .checked_add(face)
+                .ok_or(V16Error::CounterOverflow)?,
+        );
+        source.source_lien_counterparty_backing_num = V16PodU128::new(0);
+        source.source_lien_effective_reserved = V16PodU128::new(
+            source
+                .source_lien_effective_reserved
+                .get()
+                .checked_sub(effective)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        source.source_lien_impaired_effective_reserved = V16PodU128::new(
+            source
+                .source_lien_impaired_effective_reserved
+                .get()
+                .checked_add(effective)
+                .ok_or(V16Error::CounterOverflow)?,
+        );
+        let live_fee = source.source_lien_capital_at_risk_fee_revenue.get();
+        source.source_lien_capital_at_risk_fee_revenue = V16PodU128::new(0);
+        source.source_lien_impaired_capital_at_risk_fee_revenue = V16PodU128::new(
+            source
+                .source_lien_impaired_capital_at_risk_fee_revenue
+                .get()
+                .checked_add(live_fee)
+                .ok_or(V16Error::CounterOverflow)?,
+        );
+        source.source_lien_fee_last_slot = V16PodU64::new(0);
+        Ok((source, effective))
+    }
+
     #[inline]
     fn validate_bound_num_atom_aligned(bound_num: u128) -> V16Result<()> {
         if bound_num == 0 {
@@ -7664,6 +7723,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
+    #[cfg(any(kani, feature = "fuzz"))]
     fn refresh_source_credit_domain_after_mutation(&mut self, domain: usize) -> V16Result<()> {
         self.recompute_source_credit_domain_after_mutation(domain)?;
         self.reservation_encumbrance_proof_for_domain(domain)?
@@ -7883,7 +7943,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.validate_shape()
     }
 
-    pub fn expire_source_backing_bucket_not_atomic(
+    fn expire_source_backing_bucket_core_not_atomic(
         &mut self,
         domain: usize,
         now_slot: u64,
@@ -7895,7 +7955,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         )?;
         self.set_backing_bucket_for_domain(domain, bucket)?;
         self.set_source_credit_for_domain(domain, source)?;
-        self.refresh_source_credit_domain_after_mutation(domain)
+        self.recompute_source_credit_domain_after_mutation(domain)?;
+        self.reservation_encumbrance_proof_for_domain(domain)?
+            .validate()
+    }
+
+    pub fn expire_source_backing_bucket_not_atomic(
+        &mut self,
+        domain: usize,
+        now_slot: u64,
+    ) -> V16Result<()> {
+        self.expire_source_backing_bucket_core_not_atomic(domain, now_slot)?;
+        self.validate_shape()
     }
 
     fn expire_first_lapsed_source_backing_for_account_not_atomic(
@@ -8611,6 +8682,30 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(Self::account_source_claim_bound_sum_num(account)? != 0)
     }
 
+    fn account_has_lapsed_source_backing(&self, account: &PortfolioV16View<'_>) -> V16Result<bool> {
+        let current_slot = self.header.current_slot.get();
+        let mut slot = 0usize;
+        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let source = account.source_domains()[slot];
+            if source.has_default_sparse_tag() && !source.is_occupied() {
+                break;
+            }
+            if source.is_occupied() {
+                let domain = source.domain.get() as usize;
+                let bucket = self.backing_bucket_for_domain(domain)?;
+                let newly_lapsed = bucket.status == BackingBucketStatusV16::Fresh
+                    && bucket.expiry_slot <= current_slot;
+                let pending_account_impairment = bucket.status == BackingBucketStatusV16::Impaired
+                    && source.source_lien_counterparty_backing_num.get() != 0;
+                if newly_lapsed || pending_account_impairment {
+                    return Ok(true);
+                }
+            }
+            slot += 1;
+        }
+        Ok(false)
+    }
+
     fn source_claim_unliened_num(account: &PortfolioV16View<'_>, domain: usize) -> V16Result<u128> {
         let source = account.source_domain(domain)?;
         let locked = source
@@ -8743,6 +8838,74 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         );
         account.header.health_cert.valid = 0;
         Ok(effective)
+    }
+
+    fn impair_account_source_credit_counterparty_lien_fields(
+        account: &mut PortfolioV16ViewMut<'_>,
+        domain: usize,
+    ) -> V16Result<u128> {
+        let slot = account
+            .source_domain_slot(domain)?
+            .ok_or(V16Error::InvalidLeg)?;
+        let (source, effective) = V16Core::prepare_account_counterparty_lien_impairment(
+            account.header.source_domains[slot],
+        )?;
+        account.header.source_domains[slot] = source;
+        account.header.health_cert.valid = 0;
+        Ok(effective)
+    }
+
+    fn reconcile_live_account_source_backing_expiry_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+    ) -> V16Result<()> {
+        if decode_market_mode(self.header.mode)? != MarketModeV16::Live {
+            return Ok(());
+        }
+        let current_slot = self.header.current_slot.get();
+        let mut changed = false;
+        let mut slot = 0usize;
+        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let source = account.header.source_domains[slot];
+            if source.has_default_sparse_tag() && !source.is_occupied() {
+                break;
+            }
+            if !source.is_occupied() {
+                slot += 1;
+                continue;
+            }
+            let domain = source.domain.get() as usize;
+            let bucket_before = self.backing_bucket_for_domain(domain)?;
+            let newly_lapsed = bucket_before.status == BackingBucketStatusV16::Fresh
+                && bucket_before.expiry_slot <= current_slot;
+            let pending_account_impairment = source.source_lien_counterparty_backing_num.get() != 0
+                && (newly_lapsed || bucket_before.status == BackingBucketStatusV16::Impaired);
+            if pending_account_impairment {
+                self.collect_account_backing_utilization_fee_for_domain_not_atomic(
+                    account, domain,
+                )?;
+            }
+            if newly_lapsed {
+                self.expire_source_backing_bucket_core_not_atomic(domain, current_slot)?;
+                changed = true;
+            }
+            if pending_account_impairment {
+                let impaired_backing = self
+                    .backing_bucket_for_domain(domain)?
+                    .impaired_liened_backing_num;
+                if impaired_backing < source.source_lien_counterparty_backing_num.get() {
+                    return Err(V16Error::CounterUnderflow);
+                }
+                Self::impair_account_source_credit_counterparty_lien_fields(account, domain)?;
+                changed = true;
+            }
+            slot += 1;
+        }
+        if !changed {
+            return Ok(());
+        }
+        account.validate_with_market(&self.as_view())?;
+        self.validate_shape()
     }
 
     // Release one domain's counterparty/insurance source-credit lien (returning the
@@ -10980,17 +11143,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 source_claim_sum_num,
             )?;
         }
-        // A source-backed winner can remain Live past the backing bucket's expiry.
-        // The permissionless path commits exactly one canonical expiry transition
-        // per call, then returns before valuation. Repeated auto-cranks drain the
-        // bounded domain set without an O(source-domains) CU cliff.
-        if allow_b_chunk {
-            if let Some(domain) =
-                self.expire_first_lapsed_source_backing_for_account_not_atomic(&account.as_view())?
-            {
-                return Ok(AccountRefreshCertOutcomeV16::SourceBackingExpired(domain));
-            }
-        }
+        self.reconcile_live_account_source_backing_expiry_not_atomic(account)?;
         if decode_bool(account.header.b_stale_state)? && !allow_b_chunk {
             return Err(V16Error::BStale);
         }
@@ -11292,12 +11445,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 V16PodU64::new(self.header.current_slot.get());
             return Ok(0);
         }
+        let mut bucket = self.backing_bucket_for_domain(domain)?;
+        let fee_through_slot = if bucket.expiry_slot == 0 {
+            self.header.current_slot.get()
+        } else {
+            self.header.current_slot.get().min(bucket.expiry_slot)
+        };
         let fee = V16Core::backing_utilization_fee_quote_atoms_for_lien(
             self.header.config.try_to_runtime_shape()?,
             self.source_credit_for_domain(domain)?,
             lien_backing_num,
             last_slot,
-            self.header.current_slot.get(),
+            fee_through_slot,
         )?;
         // Carry the floored-away fractional accrual forward: when the rent quote
         // floors to zero this interval, do NOT advance the fee cursor, so a later
@@ -11308,8 +11467,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Ok(0);
         }
         account.header.source_domains[slot].source_lien_fee_last_slot =
-            V16PodU64::new(self.header.current_slot.get());
-        let mut bucket = self.backing_bucket_for_domain(domain)?;
+            V16PodU64::new(fee_through_slot);
         let (charged, next_capital, next_c_tot, next_earnings) =
             apply_backing_utilization_fee_charge(
                 account.header.capital.get(),
@@ -11469,6 +11627,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         b_delta_budget: u128,
     ) -> V16Result<PermissionlessProgressOutcomeV16> {
         account.validate_with_market(&self.as_view())?;
+        self.reconcile_live_account_source_backing_expiry_not_atomic(account)?;
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
@@ -11899,8 +12058,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     /// state to the ActionableState summary the self-classifying crank dispatches
     /// from. Each flag is exactly its production eligibility predicate, MODE-
     /// GATED so every flag that can be set has a currently-valid dispatch target:
-    ///   stale            — Live, health cert not current or a settled prior-reset
-    ///                      obligation still needs permissionless detachment
+    ///   stale            — Live, health cert not current, source backing needs expiry
+    ///                      reconciliation, or a settled prior-reset obligation remains
     ///   b_stale          — Live, some active leg flagged b-stale (has_b_stale_leg)
     ///   pending_close    — Live, a close-progress ledger is active
     ///   expired_close    — Live, that ledger is past its max-close slot
@@ -11937,7 +12096,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // (e.g. insurance absorbed the loss); only OUTSTANDING residual is real,
         // actionable close work. The `active` flag can linger past that.
         let close_outstanding = ledger.active && ledger.residual_remaining > 0;
-        let stale = live && (!cert_current || reset_obligation_asset.is_some());
+        // Expiry is itself actionable even when price/funding epochs did not move:
+        // refresh atomically expires the aggregate bucket and relabels this
+        // account's counterparty lien as impaired before reading source credit.
+        let stale = live
+            && (!cert_current
+                || reset_obligation_asset.is_some()
+                || self.account_has_lapsed_source_backing(account)?);
         let b_stale = live && Self::has_b_stale_leg(account)?;
         // pending_close is NOT proactively classified: the close-ledger residual is
         // booked ONLY inside the liquidation/resolved path that owns it

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -732,6 +732,8 @@ impl V16Core {
             return Err(V16Error::InvalidLeg);
         }
 
+        Self::crystallize_source_lien_fee_for_effective(&mut source, effective)?;
+
         source.source_claim_counterparty_liened_num = V16PodU128::new(0);
         source.source_claim_liened_num = V16PodU128::new(
             source
@@ -762,17 +764,45 @@ impl V16Core {
                 .checked_add(effective)
                 .ok_or(V16Error::CounterOverflow)?,
         );
+        source.source_lien_fee_last_slot = V16PodU64::new(0);
+        Ok((source, effective))
+    }
+
+    fn crystallize_source_lien_fee_for_effective(
+        source: &mut PortfolioSourceDomainV16Account,
+        impaired_effective: u128,
+    ) -> V16Result<u128> {
+        let live_effective = source.source_lien_effective_reserved.get();
+        if impaired_effective > live_effective {
+            return Err(V16Error::CounterUnderflow);
+        }
         let live_fee = source.source_lien_capital_at_risk_fee_revenue.get();
-        source.source_lien_capital_at_risk_fee_revenue = V16PodU128::new(0);
+        let impaired_fee = if impaired_effective == live_effective {
+            live_fee
+        } else if impaired_effective == 0 || live_fee == 0 {
+            0
+        } else {
+            U256::from_u128(live_fee)
+                .checked_mul(U256::from_u128(impaired_effective))
+                .ok_or(V16Error::ArithmeticOverflow)?
+                .checked_div(U256::from_u128(live_effective))
+                .ok_or(V16Error::ArithmeticOverflow)?
+                .try_into_u128()
+                .ok_or(V16Error::ArithmeticOverflow)?
+        };
+        source.source_lien_capital_at_risk_fee_revenue = V16PodU128::new(
+            live_fee
+                .checked_sub(impaired_fee)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
         source.source_lien_impaired_capital_at_risk_fee_revenue = V16PodU128::new(
             source
                 .source_lien_impaired_capital_at_risk_fee_revenue
                 .get()
-                .checked_add(live_fee)
+                .checked_add(impaired_fee)
                 .ok_or(V16Error::CounterOverflow)?,
         );
-        source.source_lien_fee_last_slot = V16PodU64::new(0);
-        Ok((source, effective))
+        Ok(impaired_fee)
     }
 
     #[inline]
@@ -8793,35 +8823,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .ok_or(V16Error::CounterOverflow)?,
         );
         source.source_lien_insurance_backing_num = V16PodU128::new(0);
-        // Genesis counter: move the pro-rata live capital-at-risk fee revenue to the impaired counter,
-        // matched to the backing capital that actually crystallized. Compute BEFORE shrinking the live
-        // effective reserve (the denominator). Floor rounding keeps dust with the still-live counter
-        // (conservative for residual farming; never over-credits).
-        let live_effective_before = source.source_lien_effective_reserved.get();
-        let live_fee = source.source_lien_capital_at_risk_fee_revenue.get();
-        let fee_to_crystallize = if live_effective_before == 0 || live_fee == 0 {
-            0
-        } else {
-            U256::from_u128(live_fee)
-                .checked_mul(U256::from_u128(effective))
-                .ok_or(V16Error::ArithmeticOverflow)?
-                .checked_div(U256::from_u128(live_effective_before))
-                .ok_or(V16Error::ArithmeticOverflow)?
-                .try_into_u128()
-                .ok_or(V16Error::ArithmeticOverflow)?
-        };
-        source.source_lien_capital_at_risk_fee_revenue = V16PodU128::new(
-            live_fee
-                .checked_sub(fee_to_crystallize)
-                .ok_or(V16Error::CounterUnderflow)?,
-        );
-        source.source_lien_impaired_capital_at_risk_fee_revenue = V16PodU128::new(
-            source
-                .source_lien_impaired_capital_at_risk_fee_revenue
-                .get()
-                .checked_add(fee_to_crystallize)
-                .ok_or(V16Error::CounterOverflow)?,
-        );
+        V16Core::crystallize_source_lien_fee_for_effective(source, effective)?;
         source.source_lien_effective_reserved = V16PodU128::new(
             source
                 .source_lien_effective_reserved

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -768,6 +768,34 @@ impl V16Core {
         Ok((source, effective))
     }
 
+    /// PRODUCTION KERNEL: one step of the compact source-domain scan. The
+    /// first sparse-tail entry or actionable domain terminates the scan.
+    fn kernel_live_source_backing_reconcile_scan_step(
+        selected: Option<(usize, bool, bool)>,
+        sparse_tail: bool,
+        occupied: bool,
+        domain: usize,
+        counterparty_backing_num: u128,
+        bucket_status: BackingBucketStatusV16,
+        expiry_slot: u64,
+        current_slot: u64,
+    ) -> (Option<(usize, bool, bool)>, bool) {
+        if selected.is_some() || sparse_tail {
+            return (selected, true);
+        }
+        if !occupied {
+            return (None, false);
+        }
+        let newly_lapsed =
+            bucket_status == BackingBucketStatusV16::Fresh && expiry_slot <= current_slot;
+        let impair_account = counterparty_backing_num != 0
+            && (newly_lapsed || bucket_status == BackingBucketStatusV16::Impaired);
+        if newly_lapsed || impair_account {
+            return (Some((domain, newly_lapsed, impair_account)), true);
+        }
+        (None, false)
+    }
+
     fn crystallize_source_lien_fee_for_effective(
         source: &mut PortfolioSourceDomainV16Account,
         impaired_effective: u128,
@@ -8686,28 +8714,52 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(Self::account_source_claim_bound_sum_num(account)? != 0)
     }
 
-    fn account_has_lapsed_source_backing(&self, account: &PortfolioV16View<'_>) -> V16Result<bool> {
+    fn first_live_account_source_backing_reconcile_action(
+        &self,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<Option<(usize, bool, bool)>> {
         let current_slot = self.header.current_slot.get();
+        let mut selected = None;
         let mut slot = 0usize;
         while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
             let source = account.source_domains()[slot];
-            if source.has_default_sparse_tag() && !source.is_occupied() {
-                break;
-            }
-            if source.is_occupied() {
+            let occupied = source.is_occupied();
+            let sparse_tail = source.has_default_sparse_tag() && !occupied;
+            let (domain, counterparty_backing_num, bucket_status, expiry_slot) = if occupied {
                 let domain = source.domain.get() as usize;
                 let bucket = self.backing_bucket_for_domain(domain)?;
-                let newly_lapsed = bucket.status == BackingBucketStatusV16::Fresh
-                    && bucket.expiry_slot <= current_slot;
-                let pending_account_impairment = bucket.status == BackingBucketStatusV16::Impaired
-                    && source.source_lien_counterparty_backing_num.get() != 0;
-                if newly_lapsed || pending_account_impairment {
-                    return Ok(true);
-                }
+                (
+                    domain,
+                    source.source_lien_counterparty_backing_num.get(),
+                    bucket.status,
+                    bucket.expiry_slot,
+                )
+            } else {
+                (0, 0, BackingBucketStatusV16::Empty, 0)
+            };
+            let (next_selected, stop) = V16Core::kernel_live_source_backing_reconcile_scan_step(
+                selected,
+                sparse_tail,
+                occupied,
+                domain,
+                counterparty_backing_num,
+                bucket_status,
+                expiry_slot,
+                current_slot,
+            );
+            selected = next_selected;
+            if stop {
+                break;
             }
             slot += 1;
         }
-        Ok(false)
+        Ok(selected)
+    }
+
+    fn account_has_lapsed_source_backing(&self, account: &PortfolioV16View<'_>) -> V16Result<bool> {
+        Ok(self
+            .first_live_account_source_backing_reconcile_action(account)?
+            .is_some())
     }
 
     fn source_claim_unliened_num(account: &PortfolioV16View<'_>, domain: usize) -> V16Result<u128> {
@@ -8839,47 +8891,30 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Ok(None);
         }
         let current_slot = self.header.current_slot.get();
-        let mut slot = 0usize;
-        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
-            let source = account.header.source_domains[slot];
-            if source.has_default_sparse_tag() && !source.is_occupied() {
-                break;
-            }
-            if !source.is_occupied() {
-                slot += 1;
-                continue;
-            }
-            let domain = source.domain.get() as usize;
-            let bucket_before = self.backing_bucket_for_domain(domain)?;
-            let newly_lapsed = bucket_before.status == BackingBucketStatusV16::Fresh
-                && bucket_before.expiry_slot <= current_slot;
-            let pending_account_impairment = source.source_lien_counterparty_backing_num.get() != 0
-                && (newly_lapsed || bucket_before.status == BackingBucketStatusV16::Impaired);
-            if pending_account_impairment {
-                self.collect_account_backing_utilization_fee_for_domain_not_atomic(
-                    account, domain,
-                )?;
-            }
-            if newly_lapsed {
-                self.expire_source_backing_bucket_core_not_atomic(domain, current_slot)?;
-            }
-            if pending_account_impairment {
-                let impaired_backing = self
-                    .backing_bucket_for_domain(domain)?
-                    .impaired_liened_backing_num;
-                if impaired_backing < source.source_lien_counterparty_backing_num.get() {
-                    return Err(V16Error::CounterUnderflow);
-                }
-                Self::impair_account_source_credit_counterparty_lien_fields(account, domain)?;
-            }
-            if newly_lapsed || pending_account_impairment {
-                account.validate_with_market(&self.as_view())?;
-                self.validate_shape()?;
-                return Ok(Some(domain));
-            }
-            slot += 1;
+        let Some((domain, newly_lapsed, impair_account)) =
+            self.first_live_account_source_backing_reconcile_action(&account.as_view())?
+        else {
+            return Ok(None);
+        };
+        let source = account.as_view().source_domain(domain)?;
+        if impair_account {
+            self.collect_account_backing_utilization_fee_for_domain_not_atomic(account, domain)?;
         }
-        Ok(None)
+        if newly_lapsed {
+            self.expire_source_backing_bucket_core_not_atomic(domain, current_slot)?;
+        }
+        if impair_account {
+            let impaired_backing = self
+                .backing_bucket_for_domain(domain)?
+                .impaired_liened_backing_num;
+            if impaired_backing < source.source_lien_counterparty_backing_num.get() {
+                return Err(V16Error::CounterUnderflow);
+            }
+            Self::impair_account_source_credit_counterparty_lien_fields(account, domain)?;
+        }
+        account.validate_with_market(&self.as_view())?;
+        self.validate_shape()?;
+        Ok(Some(domain))
     }
 
     // Release one domain's counterparty/insurance source-credit lien (returning the

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -7999,32 +7999,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.validate_shape()
     }
 
-    fn expire_first_lapsed_source_backing_for_account_not_atomic(
-        &mut self,
-        account: &PortfolioV16View<'_>,
-    ) -> V16Result<Option<usize>> {
-        let current_slot = self.header.current_slot.get();
-        let mut slot = 0usize;
-        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
-            let source = account.header.source_domains[slot];
-            if source.has_default_sparse_tag() && !source.is_occupied() {
-                break;
-            }
-            if source.is_occupied() {
-                let domain = source.domain.get() as usize;
-                let bucket = self.backing_bucket_for_domain(domain)?;
-                if bucket.status == BackingBucketStatusV16::Fresh
-                    && bucket.expiry_slot <= current_slot
-                {
-                    self.expire_source_backing_bucket_not_atomic(domain, current_slot)?;
-                    return Ok(Some(domain));
-                }
-            }
-            slot += 1;
-        }
-        Ok(None)
-    }
-
     #[cfg(any(kani, feature = "fuzz"))]
     pub fn create_source_credit_lien_from_counterparty_not_atomic(
         &mut self,
@@ -8857,15 +8831,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(effective)
     }
 
-    fn reconcile_live_account_source_backing_expiry_not_atomic(
+    fn reconcile_first_live_account_source_backing_expiry_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
-    ) -> V16Result<()> {
+    ) -> V16Result<Option<usize>> {
         if decode_market_mode(self.header.mode)? != MarketModeV16::Live {
-            return Ok(());
+            return Ok(None);
         }
         let current_slot = self.header.current_slot.get();
-        let mut changed = false;
         let mut slot = 0usize;
         while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
             let source = account.header.source_domains[slot];
@@ -8889,7 +8862,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
             if newly_lapsed {
                 self.expire_source_backing_bucket_core_not_atomic(domain, current_slot)?;
-                changed = true;
             }
             if pending_account_impairment {
                 let impaired_backing = self
@@ -8899,15 +8871,15 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     return Err(V16Error::CounterUnderflow);
                 }
                 Self::impair_account_source_credit_counterparty_lien_fields(account, domain)?;
-                changed = true;
+            }
+            if newly_lapsed || pending_account_impairment {
+                account.validate_with_market(&self.as_view())?;
+                self.validate_shape()?;
+                return Ok(Some(domain));
             }
             slot += 1;
         }
-        if !changed {
-            return Ok(());
-        }
-        account.validate_with_market(&self.as_view())?;
-        self.validate_shape()
+        Ok(None)
     }
 
     // Release one domain's counterparty/insurance source-credit lien (returning the
@@ -11145,7 +11117,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 source_claim_sum_num,
             )?;
         }
-        self.reconcile_live_account_source_backing_expiry_not_atomic(account)?;
+        if allow_b_chunk {
+            if let Some(domain) =
+                self.reconcile_first_live_account_source_backing_expiry_not_atomic(account)?
+            {
+                return Ok(AccountRefreshCertOutcomeV16::SourceBackingExpired(domain));
+            }
+        } else if decode_market_mode(self.header.mode)? == MarketModeV16::Live
+            && self.account_has_lapsed_source_backing(&account.as_view())?
+        {
+            return Err(V16Error::Stale);
+        }
         if decode_bool(account.header.b_stale_state)? && !allow_b_chunk {
             return Err(V16Error::BStale);
         }
@@ -11629,7 +11611,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         b_delta_budget: u128,
     ) -> V16Result<PermissionlessProgressOutcomeV16> {
         account.validate_with_market(&self.as_view())?;
-        self.reconcile_live_account_source_backing_expiry_not_atomic(account)?;
+        if decode_market_mode(self.header.mode)? == MarketModeV16::Live
+            && self.account_has_lapsed_source_backing(&account.as_view())?
+        {
+            return Err(V16Error::Stale);
+        }
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -792,6 +792,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         V16Core::source_credit_lien_amounts_for_effective(effective_credit, credit_rate_num)
     }
 
+    pub fn kani_prepare_account_counterparty_lien_impairment(
+        source: PortfolioSourceDomainV16Account,
+    ) -> V16Result<(PortfolioSourceDomainV16Account, u128)> {
+        V16Core::prepare_account_counterparty_lien_impairment(source)
+    }
+
     pub fn kani_counterparty_cure_atoms_from_scaled_backing(amount: u128) -> V16Result<u128> {
         V16Core::validate_bound_num_atom_aligned(amount)?;
         Ok(amount / BOUND_SCALE)

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -798,6 +798,28 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         V16Core::prepare_account_counterparty_lien_impairment(source)
     }
 
+    pub fn kani_live_source_backing_reconcile_scan_step(
+        selected: Option<(usize, bool, bool)>,
+        sparse_tail: bool,
+        occupied: bool,
+        domain: usize,
+        counterparty_backing_num: u128,
+        bucket_status: BackingBucketStatusV16,
+        expiry_slot: u64,
+        current_slot: u64,
+    ) -> (Option<(usize, bool, bool)>, bool) {
+        V16Core::kernel_live_source_backing_reconcile_scan_step(
+            selected,
+            sparse_tail,
+            occupied,
+            domain,
+            counterparty_backing_num,
+            bucket_status,
+            expiry_slot,
+            current_slot,
+        )
+    }
+
     pub fn kani_counterparty_cure_atoms_from_scaled_backing(amount: u128) -> V16Result<u128> {
         V16Core::validate_bound_num_atom_aligned(amount)?;
         Ok(amount / BOUND_SCALE)

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -16024,8 +16024,8 @@ fn proof_v16_expired_counterparty_lien_impairment_is_exact_relabel() {
         "counterparty expiry composes with prior impaired face"
     );
     kani::cover!(
-        live_fee > 0,
-        "counterparty expiry preserves accrued fee revenue"
+        live_fee > 0 && insurance_effective > 0,
+        "counterparty expiry splits mixed-lien fee revenue"
     );
     assert_eq!(impaired_effective, counter_effective as u128);
     assert_eq!(after.domain.get(), source.domain.get());
@@ -16071,9 +16071,19 @@ fn proof_v16_expired_counterparty_lien_impairment_is_exact_relabel() {
             + source.source_lien_impaired_effective_reserved.get()
     );
     assert_eq!(after.source_lien_fee_last_slot.get(), 0);
-    assert_eq!(after.source_lien_capital_at_risk_fee_revenue.get(), 0);
+    let expected_impaired_fee =
+        (live_fee as u128) * (counter_effective as u128) / (live_effective as u128);
+    assert_eq!(
+        after.source_lien_capital_at_risk_fee_revenue.get(),
+        live_fee as u128 - expected_impaired_fee
+    );
     assert_eq!(
         after.source_lien_impaired_capital_at_risk_fee_revenue.get(),
+        impaired_fee as u128 + expected_impaired_fee
+    );
+    assert_eq!(
+        after.source_lien_capital_at_risk_fee_revenue.get()
+            + after.source_lien_impaired_capital_at_risk_fee_revenue.get(),
         live_fee as u128 + impaired_fee as u128
     );
 }

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -186,7 +186,7 @@ fn empty_recovery_slot_for_market(
 }
 
 #[kani::proof]
-#[kani::unwind(8)]
+#[kani::unwind(40)]
 #[kani::solver(cadical)]
 fn proof_v16_active_bitmap_set_get_count_is_exact_and_bounds_checked() {
     let slot_raw: u8 = kani::any();
@@ -15966,4 +15966,114 @@ fn proof_v16_full_drain_reset_then_prior_epoch_clear_is_total_and_exact() {
         "reset+clear preserves nonzero K/F/B targets"
     );
     assert_eq!(cleared, expected_clear);
+}
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_expired_counterparty_lien_impairment_is_exact_relabel() {
+    let counter_face_atoms: u8 = kani::any();
+    let counter_effective: u8 = kani::any();
+    let insurance_face_atoms: u8 = kani::any();
+    let insurance_effective: u8 = kani::any();
+    let prior_impaired_face_atoms: u8 = kani::any();
+    let prior_impaired_effective: u8 = kani::any();
+    let live_fee: u8 = kani::any();
+    let impaired_fee: u8 = kani::any();
+    kani::assume(counter_face_atoms > 0 && counter_face_atoms <= 8);
+    kani::assume(counter_effective > 0 && counter_effective <= counter_face_atoms);
+    kani::assume(insurance_face_atoms <= 8);
+    kani::assume(insurance_effective <= insurance_face_atoms);
+    kani::assume(prior_impaired_face_atoms <= 8);
+    kani::assume(prior_impaired_effective <= prior_impaired_face_atoms);
+
+    let counter_face = (counter_face_atoms as u128) * BOUND_SCALE;
+    let insurance_face = (insurance_face_atoms as u128) * BOUND_SCALE;
+    let prior_impaired_face = (prior_impaired_face_atoms as u128) * BOUND_SCALE;
+    let counter_backing = (counter_effective as u128) * BOUND_SCALE;
+    let insurance_backing = (insurance_effective as u128) * BOUND_SCALE;
+    let live_effective = counter_effective as u128 + insurance_effective as u128;
+    let source = PortfolioSourceDomainV16Account {
+        domain: V16PodU32::new(3),
+        source_claim_market_id: V16PodU64::new(9),
+        source_claim_bound_num: V16PodU128::new(
+            counter_face + insurance_face + prior_impaired_face + BOUND_SCALE,
+        ),
+        source_claim_liened_num: V16PodU128::new(counter_face + insurance_face),
+        source_claim_counterparty_liened_num: V16PodU128::new(counter_face),
+        source_claim_insurance_liened_num: V16PodU128::new(insurance_face),
+        source_lien_effective_reserved: V16PodU128::new(live_effective),
+        source_lien_counterparty_backing_num: V16PodU128::new(counter_backing),
+        source_lien_insurance_backing_num: V16PodU128::new(insurance_backing),
+        source_lien_fee_last_slot: V16PodU64::new(7),
+        source_claim_impaired_num: V16PodU128::new(prior_impaired_face),
+        source_lien_impaired_effective_reserved: V16PodU128::new(prior_impaired_effective as u128),
+        source_lien_capital_at_risk_fee_revenue: V16PodU128::new(live_fee as u128),
+        source_lien_impaired_capital_at_risk_fee_revenue: V16PodU128::new(impaired_fee as u128),
+    };
+
+    let (after, impaired_effective) =
+        MarketGroupV16ViewMut::<u64>::kani_prepare_account_counterparty_lien_impairment(source)
+            .unwrap();
+
+    kani::cover!(
+        insurance_face_atoms > 0,
+        "counterparty expiry preserves a mixed insurance-backed lien"
+    );
+    kani::cover!(
+        prior_impaired_face_atoms > 0,
+        "counterparty expiry composes with prior impaired face"
+    );
+    kani::cover!(
+        live_fee > 0,
+        "counterparty expiry preserves accrued fee revenue"
+    );
+    assert_eq!(impaired_effective, counter_effective as u128);
+    assert_eq!(after.domain.get(), source.domain.get());
+    assert_eq!(
+        after.source_claim_market_id.get(),
+        source.source_claim_market_id.get()
+    );
+    assert_eq!(
+        after.source_claim_bound_num.get(),
+        source.source_claim_bound_num.get()
+    );
+    assert_eq!(after.source_claim_liened_num.get(), insurance_face);
+    assert_eq!(after.source_claim_counterparty_liened_num.get(), 0);
+    assert_eq!(
+        after.source_claim_insurance_liened_num.get(),
+        source.source_claim_insurance_liened_num.get()
+    );
+    assert_eq!(
+        after.source_claim_impaired_num.get(),
+        prior_impaired_face + counter_face
+    );
+    assert_eq!(
+        after.source_claim_liened_num.get() + after.source_claim_impaired_num.get(),
+        source.source_claim_liened_num.get() + source.source_claim_impaired_num.get()
+    );
+    assert_eq!(
+        after.source_lien_effective_reserved.get(),
+        insurance_effective as u128
+    );
+    assert_eq!(after.source_lien_counterparty_backing_num.get(), 0);
+    assert_eq!(
+        after.source_lien_insurance_backing_num.get(),
+        source.source_lien_insurance_backing_num.get()
+    );
+    assert_eq!(
+        after.source_lien_impaired_effective_reserved.get(),
+        prior_impaired_effective as u128 + counter_effective as u128
+    );
+    assert_eq!(
+        after.source_lien_effective_reserved.get()
+            + after.source_lien_impaired_effective_reserved.get(),
+        source.source_lien_effective_reserved.get()
+            + source.source_lien_impaired_effective_reserved.get()
+    );
+    assert_eq!(after.source_lien_fee_last_slot.get(), 0);
+    assert_eq!(after.source_lien_capital_at_risk_fee_revenue.get(), 0);
+    assert_eq!(
+        after.source_lien_impaired_capital_at_risk_fee_revenue.get(),
+        live_fee as u128 + impaired_fee as u128
+    );
 }

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -16087,3 +16087,171 @@ fn proof_v16_expired_counterparty_lien_impairment_is_exact_relabel() {
         live_fee as u128 + impaired_fee as u128
     );
 }
+
+// Repeated production scan steps composed with the real expiry and account
+// impairment kernels form a finite rank-decreasing permissionless process.
+// This separates the amount-independent liveness theorem from the full-width
+// relabel theorem above, avoiding an artificial solver dependency on amounts.
+#[kani::proof]
+#[kani::unwind(12)]
+#[kani::solver(cadical)]
+fn proof_v16_live_source_backing_reconcile_is_bounded_progress() {
+    assert_eq!(PORTFOLIO_SOURCE_DOMAIN_CAP, 4);
+    let roster_len: u8 = kani::any();
+    let lapsed_mask: u8 = kani::any();
+    let lapsed_lien_mask: u8 = kani::any();
+    let impaired_lien_mask: u8 = kani::any();
+    let future_lien_mask: u8 = kani::any();
+    let foreign_impaired_mask: u8 = kani::any();
+    kani::assume(roster_len as usize <= PORTFOLIO_SOURCE_DOMAIN_CAP);
+    let roster_mask = (1u8 << roster_len) - 1;
+    kani::assume(lapsed_mask & !roster_mask == 0);
+    kani::assume(lapsed_lien_mask & !lapsed_mask == 0);
+    kani::assume(impaired_lien_mask & !roster_mask == 0);
+    kani::assume(future_lien_mask & !roster_mask == 0);
+    kani::assume(foreign_impaired_mask & !roster_mask == 0);
+    kani::assume(lapsed_mask & impaired_lien_mask == 0);
+    kani::assume(lapsed_mask & future_lien_mask == 0);
+    kani::assume(lapsed_mask & foreign_impaired_mask == 0);
+    kani::assume(impaired_lien_mask & future_lien_mask == 0);
+    kani::assume(impaired_lien_mask & foreign_impaired_mask == 0);
+    kani::assume(future_lien_mask & foreign_impaired_mask == 0);
+
+    let now_slot = 10u64;
+    let initial_actionable = lapsed_mask | impaired_lien_mask;
+    let mut remaining = initial_actionable;
+    let mut remaining_lapsed = lapsed_mask;
+    let mut account_lien_mask = lapsed_lien_mask | impaired_lien_mask | future_lien_mask;
+    let mut calls = 0usize;
+    while calls <= PORTFOLIO_SOURCE_DOMAIN_CAP {
+        let rank_before = remaining.count_ones();
+        let mut expected = None;
+        let mut selected = None;
+        let mut stopped = false;
+        let mut domain = 0usize;
+        while domain < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let bit = 1u8 << domain;
+            if expected.is_none() && remaining & bit != 0 {
+                expected = Some(domain);
+            }
+            if !stopped {
+                let occupied = domain < roster_len as usize;
+                let sparse_tail = domain == roster_len as usize;
+                let processed_lapsed_lien = lapsed_lien_mask & !remaining_lapsed & bit != 0;
+                let status = if remaining_lapsed & bit != 0 {
+                    BackingBucketStatusV16::Fresh
+                } else if (impaired_lien_mask | foreign_impaired_mask) & bit != 0
+                    || processed_lapsed_lien
+                {
+                    BackingBucketStatusV16::Impaired
+                } else if future_lien_mask & bit != 0 {
+                    BackingBucketStatusV16::Fresh
+                } else {
+                    BackingBucketStatusV16::Expired
+                };
+                let expiry_slot = if remaining_lapsed & bit != 0 {
+                    now_slot
+                } else {
+                    now_slot + 1
+                };
+                (selected, stopped) =
+                    MarketGroupV16ViewMut::<u64>::kani_live_source_backing_reconcile_scan_step(
+                        selected,
+                        sparse_tail,
+                        occupied,
+                        domain,
+                        if account_lien_mask & bit != 0 {
+                            BOUND_SCALE
+                        } else {
+                            0
+                        },
+                        status,
+                        expiry_slot,
+                        now_slot,
+                    );
+            }
+            domain += 1;
+        }
+        assert_eq!(selected.map(|action| action.0), expected);
+
+        if let Some((selected_domain, newly_lapsed, impair_account)) = selected {
+            let selected_bit = 1u8 << selected_domain;
+            assert!(remaining & selected_bit != 0);
+            assert_eq!(newly_lapsed, remaining_lapsed & selected_bit != 0);
+            assert_eq!(impair_account, account_lien_mask & selected_bit != 0);
+            if newly_lapsed {
+                let liened = lapsed_lien_mask & selected_bit != 0;
+                let bucket = BackingBucketV16 {
+                    market_id: 1,
+                    fresh_unliened_backing_num: if liened { 0 } else { BOUND_SCALE },
+                    valid_liened_backing_num: if liened { BOUND_SCALE } else { 0 },
+                    expiry_slot: now_slot,
+                    status: BackingBucketStatusV16::Fresh,
+                    ..BackingBucketV16::EMPTY
+                };
+                let source = SourceCreditStateV16 {
+                    fresh_reserved_backing_num: BOUND_SCALE,
+                    valid_liened_backing_num: bucket.valid_liened_backing_num,
+                    ..SourceCreditStateV16::EMPTY
+                };
+                let (bucket_after, source_after) =
+                    MarketGroupV16ViewMut::<u64>::kani_prepare_counterparty_backing_expiry_delta(
+                        bucket, source, now_slot,
+                    )
+                    .unwrap();
+                assert_eq!(source_after.fresh_reserved_backing_num, 0);
+                assert_ne!(bucket_after.status, BackingBucketStatusV16::Fresh);
+                remaining_lapsed &= !selected_bit;
+            }
+            if impair_account {
+                let source = PortfolioSourceDomainV16Account {
+                    domain: V16PodU32::new(selected_domain as u32),
+                    source_claim_bound_num: V16PodU128::new(2 * BOUND_SCALE),
+                    source_claim_liened_num: V16PodU128::new(BOUND_SCALE),
+                    source_claim_counterparty_liened_num: V16PodU128::new(BOUND_SCALE),
+                    source_lien_effective_reserved: V16PodU128::new(1),
+                    source_lien_counterparty_backing_num: V16PodU128::new(BOUND_SCALE),
+                    ..PortfolioSourceDomainV16Account::default()
+                };
+                let (source_after, impaired_effective) = MarketGroupV16ViewMut::<u64>::
+                    kani_prepare_account_counterparty_lien_impairment(source)
+                    .unwrap();
+                assert_eq!(impaired_effective, 1);
+                assert_eq!(source_after.source_lien_counterparty_backing_num.get(), 0);
+                account_lien_mask &= !selected_bit;
+            }
+            remaining &= !selected_bit;
+            assert_eq!(remaining.count_ones() + 1, rank_before);
+        } else {
+            assert_eq!(rank_before, 0);
+        }
+        assert_eq!(account_lien_mask & future_lien_mask, future_lien_mask);
+        assert_eq!(account_lien_mask & foreign_impaired_mask, 0);
+        calls += 1;
+    }
+
+    assert_eq!(remaining, 0);
+    kani::cover!(initial_actionable == 0, "clean roster is a fixed point");
+    kani::cover!(
+        initial_actionable.count_ones() > 1,
+        "multiple obligations drain in bounded calls"
+    );
+    kani::cover!(
+        lapsed_mask & !lapsed_lien_mask != 0,
+        "unliened lapsed backing progresses"
+    );
+    kani::cover!(lapsed_lien_mask != 0, "lapsed account liens progress");
+    kani::cover!(
+        impaired_lien_mask != 0,
+        "already-impaired account liens progress"
+    );
+    kani::cover!(future_lien_mask != 0, "future source liens stay live");
+    kani::cover!(
+        foreign_impaired_mask != 0,
+        "foreign impaired backing remains isolated"
+    );
+    kani::cover!(
+        initial_actionable & 1 == 0 && initial_actionable != 0,
+        "scan skips earlier non-actionable domains"
+    );
+}

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -2695,6 +2695,150 @@ fn v16_risk_increasing_trade_creates_source_credit_lien_for_im() {
 }
 
 #[test]
+fn v16_expired_counterparty_source_lien_is_impaired_before_health_read() {
+    const OPEN_Q: u128 = 1_000 * POS_SCALE;
+    const INCREASE_Q: u128 = 50 * POS_SCALE;
+    let (mut header, mut markets) = market_fixture(1, 100);
+    header.config.maintenance_margin_bps = V16PodU64::new(1_000);
+    header.config.initial_margin_bps = V16PodU64::new(5_000);
+    header.config.max_price_move_bps_per_slot = V16PodU64::new(500);
+    header.config.max_accrual_dt_slots = V16PodU64::new(1);
+    header.config.min_funding_lifetime_slots = V16PodU64::new(1);
+    header.config.backing_fee_base_rate_e9_per_slot = V16PodU64::new(1_000_000_000);
+    let mut long_header = account_fixture(1, 10);
+    let mut short_header = account_fixture(1, 11);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market
+        .deposit_fresh_counterparty_backing_not_atomic(1, 100_000, 3)
+        .unwrap();
+    market.deposit_not_atomic(&mut long, 52_501).unwrap();
+    market.deposit_not_atomic(&mut short, 1_000_000).unwrap();
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: signed_q(OPEN_Q),
+                exec_price: 100,
+                fee_bps: 0,
+            },
+        )
+        .unwrap();
+
+    market
+        .set_asset_raw_oracle_target_not_atomic(0, 105)
+        .unwrap();
+    market
+        .accrue_asset_to_not_atomic(0, 2, 105, 0, true)
+        .unwrap();
+    market.full_account_refresh_not_atomic(&mut short).unwrap();
+    market.full_account_refresh_not_atomic(&mut long).unwrap();
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: signed_q(INCREASE_Q),
+                exec_price: 105,
+                fee_bps: 0,
+            },
+        )
+        .unwrap();
+    let lien_before = long.header.source_domains[0];
+    assert!(lien_before.source_claim_counterparty_liened_num.get() > 0);
+    assert!(lien_before.source_lien_counterparty_backing_num.get() > 0);
+
+    market
+        .accrue_asset_to_not_atomic(0, 3, 105, 0, true)
+        .unwrap();
+    market
+        .accrue_asset_to_not_atomic(0, 4, 105, 0, true)
+        .unwrap();
+    market.full_account_refresh_not_atomic(&mut short).unwrap();
+    let summary = market.build_actionable_summary(&long.as_view()).unwrap();
+    assert!(
+        summary.stale,
+        "bucket expiry alone must make a current certificate actionable"
+    );
+    let observations = [AutoCrankObservationV16 {
+        asset_index: 0,
+        effective_price: 105,
+        funding_rate_e9: 0,
+    }];
+    let crank = market
+        .permissionless_auto_crank_not_atomic(
+            &mut long,
+            AutoCrankWorkV16 {
+                now_slot: 4,
+                observations: &observations,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("an expired source lien must impair and remain progressable");
+    assert_eq!(
+        crank.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    );
+    assert!(matches!(
+        crank.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+    ));
+    let cert = long.header.health_cert.try_to_runtime().unwrap();
+
+    let source = long.header.source_domains[0];
+    let bucket = market.markets[0]
+        .engine
+        .backing_short
+        .try_to_runtime()
+        .unwrap();
+    let domain = market.markets[0]
+        .engine
+        .source_credit_short
+        .try_to_runtime()
+        .unwrap();
+    assert_eq!(bucket.status, BackingBucketStatusV16::Impaired);
+    assert_eq!(
+        bucket.utilization_fee_earnings,
+        lien_before.source_lien_effective_reserved.get(),
+        "utilization rent must stop at expiry rather than charging through reconciliation"
+    );
+    assert_eq!(bucket.valid_liened_backing_num, 0);
+    assert_eq!(domain.valid_liened_backing_num, 0);
+    assert_eq!(domain.fresh_reserved_backing_num, 0);
+    assert_eq!(domain.credit_rate_num, 0);
+    assert_eq!(source.source_claim_liened_num.get(), 0);
+    assert_eq!(source.source_claim_counterparty_liened_num.get(), 0);
+    assert_eq!(source.source_lien_effective_reserved.get(), 0);
+    assert_eq!(source.source_lien_counterparty_backing_num.get(), 0);
+    assert_eq!(
+        source.source_claim_impaired_num.get(),
+        lien_before.source_claim_counterparty_liened_num.get()
+    );
+    assert_eq!(
+        source.source_lien_impaired_effective_reserved.get(),
+        lien_before.source_lien_effective_reserved.get()
+    );
+    assert_eq!(
+        source
+            .source_lien_impaired_capital_at_risk_fee_revenue
+            .get(),
+        lien_before.source_lien_effective_reserved.get()
+    );
+    assert!(cert.valid);
+    assert_eq!(cert.certified_equity, long.header.capital.get() as i128);
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+    short.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_residual_reward_credit_uses_real_principal_not_notional() {
     let (mut header, mut markets) = market_fixture(1, 1_000);
     header.config.initial_margin_bps = V16PodU64::new(500);

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -2788,9 +2788,14 @@ fn v16_expired_counterparty_source_lien_is_impaired_before_health_read() {
     );
     assert!(matches!(
         crank.outcome,
-        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::SourceBackingExpired {
+            domain: 1
+        })
     ));
-    let cert = long.header.health_cert.try_to_runtime().unwrap();
+    assert!(
+        !long.header.health_cert.try_to_runtime().unwrap().valid,
+        "the bounded expiry step must not certify before reading the impaired state"
+    );
 
     let source = long.header.source_domains[0];
     let bucket = market.markets[0]
@@ -2831,6 +2836,22 @@ fn v16_expired_counterparty_source_lien_is_impaired_before_health_read() {
             .get(),
         lien_before.source_lien_effective_reserved.get()
     );
+
+    let refresh = market
+        .permissionless_auto_crank_not_atomic(
+            &mut long,
+            AutoCrankWorkV16 {
+                now_slot: 4,
+                observations: &observations,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the next bounded crank must certify from the impaired state");
+    assert!(matches!(
+        refresh.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+    ));
+    let cert = long.header.health_cert.try_to_runtime().unwrap();
     assert!(cert.valid);
     assert_eq!(cert.certified_equity, long.header.capital.get() as i128);
     market.validate_shape().unwrap();


### PR DESCRIPTION
## What changed

- Treat a lapsed source-backing domain as actionable even when price and funding epochs are unchanged.
- Reconcile exactly one live account lien from an expired source domain per auto-crank, relabeling its claim as impaired before any source-credit health read.
- Route both stale classification and mutation through one production scan-step/selection kernel.
- Cap backing-utilization rent at the bucket expiry slot.
- Return bounded auto-crank work so a max-source account progresses through a finite, rank-decreasing sequence instead of an atomic full-domain mutation.
- Add production lifecycle, mixed-fee impairment, bounded-progress, and Kani regressions.

## Root cause

A portfolio could create a valid source-credit IM lien through ordinary trades while its backing bucket was fresh. Once the configured bucket expiry arrived, source-credit health reads returned `Stale`, but no public route reconciled the account lien. Crank, bilateral reduction, unilateral reduction, and PnL conversion could all fail, and depositing more capital did not repair the state.

This contradicted the expiry rule that aggregate backing expires before a credit-rate read and account liens become impaired through bounded permissionless progress.

## Impact

A backing authority could publish short-lived backing, allow users to create real liens, and then leave a live position unable to progress after expiry. The corrected route needs at most one successful crank per live source-domain obligation and does not require a max-domain atomic mutation.

## PDD validation

The proofs are symbolic invariants over production kernels, not fixed-case unit checks:

- `proof_v16_live_source_backing_reconcile_is_bounded_progress`: every ordering of lapsed backing, lapsed account liens, already-impaired account liens, future liens, and foreign-account impaired backing in the four-domain Kani roster. It proves first-action completeness, exactly one rank decrease per successful call, completion within the roster bound, future-lien isolation, and foreign-account isolation. 295 checks, 8/8 cover goals, 8.95s.
- `proof_v16_expired_counterparty_lien_impairment_is_exact_relabel`: symbolic face, effective backing, mixed insurance support, prior impairment, and fee history; exact relabel and conservation. 245 checks, 3/3 cover goals, 21.14s.
- Mutation check: removing already-impaired account-lien selection fails the bounded-progress theorem.
- Mutation check: classifying future Fresh buckets as expired fails the bounded-progress theorem.
- `cargo test --all-targets`: 140 passed.
- `spec.md` remains unchanged.
- Wrapper max-shape lifecycle coverage: https://github.com/aeyakovenko/percolator-prog/pull/214