### PR TITLE
Bound max-source lien allocation CU

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -11607,8 +11607,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         );
         let ledger = account.header.close_progress.try_to_runtime()?;
 
-        let has_open_risk =
-            !active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get));
+        let (_, dispatchable_active_asset) = self.auto_crank_selected_assets(account)?;
+        let has_open_risk = dispatchable_active_asset.is_some();
         // A close ledger with residual_remaining==0 is already fully booked/covered
         // (e.g. insurance absorbed the loss); only OUTSTANDING residual is real,
         // actionable close work. The `active` flag can linger past that.
@@ -11676,20 +11676,30 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     /// ENGINE asset self-selection (engine.md): scan the account's bounded legs and
     /// return, for each asset-scoped continuation, the engine-chosen asset_index —
     /// the FIRST active b-stale leg's asset (SettleBChunk), and the FIRST active
-    /// leg's asset (used for both Liquidate and the refresh accrual target). The
+    /// leg whose asset is currently accrual/reduction-dispatchable (Active or
+    /// DrainOnly, used for both Liquidate and the refresh accrual target). Recovery
+    /// legs remain refreshable as part of the account scan, but cannot be selected
+    /// as the action asset because both accrual and liquidation reject them. The
     /// selection is proven in-range / actionable / first-match / complete by the
-    /// first_actionable_slot contract; the slot->asset_index read is by inspection.
+    /// first_actionable_slot contract; the slot->asset_index and lifecycle filter
+    /// are bound to production state here.
     fn auto_crank_selected_assets(
+        &self,
         account: &PortfolioV16View<'_>,
     ) -> V16Result<(Option<usize>, Option<usize>)> {
         let bitmap = account.header.active_bitmap.map(V16PodU64::get);
-        let mut active_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+        let mut dispatchable_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut b_stale_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
             let active = active_bitmap_get(bitmap, slot) && leg.active;
-            active_flags[slot] = active;
+            if active {
+                dispatchable_flags[slot] = matches!(
+                    self.asset_state(leg.asset_index as usize)?.lifecycle,
+                    AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
+                );
+            }
             b_stale_flags[slot] = active && leg.b_stale;
             slot += 1;
         }
@@ -11702,7 +11712,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
         };
         let b_stale_asset = asset_of(V16Core::first_actionable_slot(b_stale_flags))?;
-        let active_asset = asset_of(V16Core::first_actionable_slot(active_flags))?;
+        let active_asset = asset_of(V16Core::first_actionable_slot(dispatchable_flags))?;
         Ok((b_stale_asset, active_asset))
     }
 
@@ -11737,7 +11747,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         work: AutoCrankWorkV16<'_>,
     ) -> V16Result<AutoCrankResultV16> {
         let summary = self.build_actionable_summary(&account.as_view())?;
-        let (b_stale_asset, active_asset) = Self::auto_crank_selected_assets(&account.as_view())?;
+        let (b_stale_asset, active_asset) = self.auto_crank_selected_assets(&account.as_view())?;
         let recovery_reason = if summary.expired_close {
             PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
         } else {

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -716,6 +716,29 @@ impl V16Core {
         Ok((required_face_num, required_backing_num))
     }
 
+    #[inline(always)]
+    fn source_credit_lien_allocation_take(
+        remaining: u128,
+        unliened_face_num: u128,
+        available_backing_num: u128,
+        credit_rate_num: u128,
+    ) -> V16Result<u128> {
+        if remaining == 0 || unliened_face_num == 0 || credit_rate_num == 0 {
+            return Ok(0);
+        }
+        if credit_rate_num > CREDIT_RATE_SCALE {
+            return Err(V16Error::InvalidConfig);
+        }
+        let realizable_num = U256::from_u128(unliened_face_num)
+            .checked_mul(U256::from_u128(credit_rate_num))
+            .and_then(|v| v.checked_div(U256::from_u128(CREDIT_RATE_SCALE)))
+            .and_then(|v| v.try_into_u128())
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        Ok(remaining
+            .min(realizable_num / BOUND_SCALE)
+            .min(available_backing_num / BOUND_SCALE))
+    }
+
     #[inline]
     fn validate_bound_num_atom_aligned(bound_num: u128) -> V16Result<()> {
         if bound_num == 0 {
@@ -4384,24 +4407,7 @@ impl<'a> PortfolioV16View<'a> {
             if source.source_claim_bound_num.get() > domain_credit.positive_claim_bound_num {
                 return Err(V16Error::InvalidLeg);
             }
-            let proof = SourceCreditLienAggregateProofV16 {
-                domain: u16::try_from(d).map_err(|_| V16Error::ArithmeticOverflow)?,
-                source_claim_bound_num: source.source_claim_bound_num.get(),
-                face_claim_locked_num: source.source_claim_liened_num.get(),
-                counterparty_face_claim_locked_num: source
-                    .source_claim_counterparty_liened_num
-                    .get(),
-                insurance_face_claim_locked_num: source.source_claim_insurance_liened_num.get(),
-                effective_credit_reserved: source.source_lien_effective_reserved.get(),
-                counterparty_backing_reserved_num: source
-                    .source_lien_counterparty_backing_num
-                    .get(),
-                insurance_backing_reserved_num: source.source_lien_insurance_backing_num.get(),
-                impaired_face_claim_num: source.source_claim_impaired_num.get(),
-                impaired_effective_credit_reserved: source
-                    .source_lien_impaired_effective_reserved
-                    .get(),
-            };
+            let proof = Self::source_credit_lien_aggregate_proof(source, d)?;
             proof.validate()?;
             let locked = proof
                 .face_claim_locked_num
@@ -4448,6 +4454,26 @@ impl<'a> PortfolioV16View<'a> {
             slot_index += 1;
         }
         Ok(())
+    }
+
+    fn source_credit_lien_aggregate_proof(
+        source: PortfolioSourceDomainV16Account,
+        domain: usize,
+    ) -> V16Result<SourceCreditLienAggregateProofV16> {
+        Ok(SourceCreditLienAggregateProofV16 {
+            domain: u16::try_from(domain).map_err(|_| V16Error::ArithmeticOverflow)?,
+            source_claim_bound_num: source.source_claim_bound_num.get(),
+            face_claim_locked_num: source.source_claim_liened_num.get(),
+            counterparty_face_claim_locked_num: source.source_claim_counterparty_liened_num.get(),
+            insurance_face_claim_locked_num: source.source_claim_insurance_liened_num.get(),
+            effective_credit_reserved: source.source_lien_effective_reserved.get(),
+            counterparty_backing_reserved_num: source.source_lien_counterparty_backing_num.get(),
+            insurance_backing_reserved_num: source.source_lien_insurance_backing_num.get(),
+            impaired_face_claim_num: source.source_claim_impaired_num.get(),
+            impaired_effective_credit_reserved: source
+                .source_lien_impaired_effective_reserved
+                .get(),
+        })
     }
 
     fn source_claim_bound_sum_num(&self) -> V16Result<u128> {
@@ -9691,14 +9717,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             let unliened = Self::source_claim_unliened_num(&account.as_view(), d)?;
             if rate != 0 && unliened != 0 {
                 self.validate_source_domain_ledger_current(d)?;
-                let soft_num = U256::from_u128(unliened)
-                    .checked_mul(U256::from_u128(rate))
-                    .and_then(|v| v.checked_div(U256::from_u128(CREDIT_RATE_SCALE)))
-                    .and_then(|v| v.try_into_u128())
-                    .ok_or(V16Error::ArithmeticOverflow)?;
-                let by_claim = soft_num / BOUND_SCALE;
-                let by_backing = self.source_credit_available_backing_num(d)? / BOUND_SCALE;
-                let take = remaining.min(by_claim).min(by_backing);
+                let take = V16Core::source_credit_lien_allocation_take(
+                    remaining,
+                    unliened,
+                    self.source_credit_available_backing_num(d)?,
+                    rate,
+                )?;
                 if take != 0 {
                     let (face_num, backing_num) =
                         V16Core::source_credit_lien_amounts_for_effective(take, rate)?;
@@ -9895,14 +9919,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             let unliened = Self::source_claim_unliened_num(&account.as_view(), d)?;
             if rate != 0 && unliened != 0 {
                 self.validate_source_domain_ledger_current(d)?;
-                let soft_num = U256::from_u128(unliened)
-                    .checked_mul(U256::from_u128(rate))
-                    .and_then(|v| v.checked_div(U256::from_u128(CREDIT_RATE_SCALE)))
-                    .and_then(|v| v.try_into_u128())
-                    .ok_or(V16Error::ArithmeticOverflow)?;
-                let by_claim = soft_num / BOUND_SCALE;
-                let by_backing = self.source_credit_available_backing_num(d)? / BOUND_SCALE;
-                let take = remaining.min(by_claim).min(by_backing);
+                let take = V16Core::source_credit_lien_allocation_take(
+                    remaining,
+                    unliened,
+                    self.source_credit_available_backing_num(d)?,
+                    rate,
+                )?;
                 if take != 0 {
                     self.create_account_source_credit_lien_for_effective_core_not_atomic(
                         account, d, take,

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1542,6 +1542,52 @@ impl V16Core {
         )
     }
 
+    fn kernel_is_prior_reset_obligation(
+        side_mode: SideModeV16,
+        asset_epoch: u64,
+        leg_epoch_snap: u64,
+    ) -> bool {
+        side_mode == SideModeV16::ResetPending && leg_epoch_snap.checked_add(1) == Some(asset_epoch)
+    }
+
+    /// PRODUCTION KERNEL: classify one account leg for the bounded auto-crank
+    /// scans. A prior-reset obligation remains refreshable but can never be
+    /// dispatched as liquidation work because its effective OI was removed by
+    /// the reset.
+    fn kernel_auto_crank_leg_flags(
+        active: bool,
+        lifecycle: AssetLifecycleV16,
+        basis_pos_q: i128,
+        side_oi_q: u128,
+        side_mode: SideModeV16,
+        asset_epoch: u64,
+        leg_epoch_snap: u64,
+        leg_b_stale: bool,
+    ) -> (bool, bool, bool, bool) {
+        let lifecycle_dispatchable = Self::kernel_auto_crank_lifecycle_dispatchable(lifecycle);
+        let prior_reset_obligation =
+            Self::kernel_is_prior_reset_obligation(side_mode, asset_epoch, leg_epoch_snap);
+        let refresh = active && lifecycle_dispatchable;
+        let liquidatable = refresh && basis_pos_q != 0 && side_oi_q != 0 && !prior_reset_obligation;
+        (
+            active && leg_b_stale,
+            refresh,
+            liquidatable,
+            active && prior_reset_obligation,
+        )
+    }
+
+    /// PRODUCTION KERNEL: a refresh detaches at most one settled prior-reset
+    /// obligation. A pending close residual owns the account and blocks this
+    /// cleanup until its own continuation advances.
+    fn kernel_should_clear_prior_reset_obligation(
+        already_cleared: bool,
+        prior_reset_obligation: bool,
+        pending_close_residual: bool,
+    ) -> bool {
+        !already_cleared && prior_reset_obligation && !pending_close_residual
+    }
+
     /// PRODUCTION KERNEL (engine.md selection semantics): from the actionable
     /// summary and the ENGINE-selected assets, choose the single highest-priority
     /// bounded plan, carrying the engine-chosen asset (the caller chooses neither
@@ -10833,14 +10879,22 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             // K/F/B claims are settled above, detaching it is bookkeeping, not
             // a position close. Clear at most one per call to keep max-shape CU
             // bounded; the classifier keeps another obligation actionable.
-            if !reset_obligation_cleared
-                && Self::leg_is_prior_reset_obligation(asset, refreshed)
-                && !account
-                    .header
-                    .close_progress
-                    .try_to_runtime()?
-                    .has_pending_residual()
+            let should_clear_reset = if reset_obligation_cleared
+                || !Self::leg_is_prior_reset_obligation(asset, refreshed)
             {
+                false
+            } else {
+                V16Core::kernel_should_clear_prior_reset_obligation(
+                    false,
+                    true,
+                    account
+                        .header
+                        .close_progress
+                        .try_to_runtime()?
+                        .has_pending_residual(),
+                )
+            };
+            if should_clear_reset {
                 self.clear_leg(account, asset_index)?;
                 reset_obligation_cleared = true;
                 slot += 1;
@@ -11722,16 +11776,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     /// first_actionable_slot contract; the slot->asset_index and lifecycle filter
     /// are bound to production state here.
     fn leg_is_prior_reset_obligation(asset: AssetStateV16, leg: PortfolioLegV16) -> bool {
-        match leg.side {
-            SideV16::Long => {
-                asset.mode_long == SideModeV16::ResetPending
-                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_long)
-            }
-            SideV16::Short => {
-                asset.mode_short == SideModeV16::ResetPending
-                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_short)
-            }
-        }
+        let (side_mode, asset_epoch) = match leg.side {
+            SideV16::Long => (asset.mode_long, asset.epoch_long),
+            SideV16::Short => (asset.mode_short, asset.epoch_short),
+        };
+        V16Core::kernel_is_prior_reset_obligation(side_mode, asset_epoch, leg.epoch_snap)
     }
 
     fn auto_crank_selected_assets(
@@ -11749,23 +11798,26 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             let active = active_bitmap_get(bitmap, slot) && leg.active;
             if active {
                 let asset = self.asset_state(leg.asset_index as usize)?;
-                let lifecycle_dispatchable = matches!(
-                    asset.lifecycle,
-                    AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
-                );
-                refresh_flags[slot] = lifecycle_dispatchable;
-                let side_oi = match leg.side {
-                    SideV16::Long => asset.oi_eff_long_q,
-                    SideV16::Short => asset.oi_eff_short_q,
+                let (side_oi, side_mode, asset_epoch) = match leg.side {
+                    SideV16::Long => (asset.oi_eff_long_q, asset.mode_long, asset.epoch_long),
+                    SideV16::Short => (asset.oi_eff_short_q, asset.mode_short, asset.epoch_short),
                 };
-                let prior_reset_obligation = Self::leg_is_prior_reset_obligation(asset, leg);
-                reset_obligation_flags[slot] = prior_reset_obligation;
-                liquidation_flags[slot] = lifecycle_dispatchable
-                    && leg.basis_pos_q != 0
-                    && side_oi != 0
-                    && !prior_reset_obligation;
+                let (b_stale, refresh, liquidatable, reset_obligation) =
+                    V16Core::kernel_auto_crank_leg_flags(
+                        true,
+                        asset.lifecycle,
+                        leg.basis_pos_q,
+                        side_oi,
+                        side_mode,
+                        asset_epoch,
+                        leg.epoch_snap,
+                        leg.b_stale,
+                    );
+                b_stale_flags[slot] = b_stale;
+                refresh_flags[slot] = refresh;
+                liquidation_flags[slot] = liquidatable;
+                reset_obligation_flags[slot] = reset_obligation;
             }
-            b_stale_flags[slot] = active && leg.b_stale;
             slot += 1;
         }
         let asset_of = |s: Option<usize>| -> V16Result<Option<usize>> {

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -15552,6 +15552,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 if self.has_pending_domain_loss_barrier(asset_index, leg.side)? {
                     return Ok(());
                 }
+                let asset = self.asset_state(asset_index)?;
+                if Self::leg_has_exhausted_effective_oi(asset, leg) {
+                    // A legacy Live state may resolve before its next auto-crank.
+                    // Establish the same terminal reset epoch here so resolved
+                    // teardown does not subtract stored basis from zero OI.
+                    self.begin_full_drain_reset_inner(asset_index, leg.side)?;
+                }
                 let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;
                 if k_target != leg.k_snap || f_target != leg.f_snap {
                     return Ok(());

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -5100,6 +5100,7 @@ struct PositionDeltaLookupV16 {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum AccountRefreshCertOutcomeV16 {
     Certified(HealthCertV16),
+    LegSettled { asset_index: usize },
     BChunk(AccountBSettlementChunkV16),
     SourceBackingExpired(usize),
 }
@@ -8571,6 +8572,41 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(sum)
     }
 
+    fn account_source_domain_count(account: &PortfolioV16View<'_>) -> usize {
+        let mut count = 0usize;
+        while count < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let source = account.source_domains()[count];
+            if source.has_default_sparse_tag() && !source.is_occupied() {
+                break;
+            }
+            count += 1;
+        }
+        count
+    }
+
+    fn account_pending_kf_settlement_count(
+        &self,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<usize> {
+        let mut count = 0usize;
+        let mut slot = 0usize;
+        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg = account.header.legs[slot].try_to_runtime()?;
+            if leg.active {
+                let asset = self.asset_state(leg.asset_index as usize)?;
+                let (target_k, target_f) = Self::kf_target_for_leg_from_asset(asset, leg)?;
+                if Self::leg_has_exhausted_effective_oi(asset, leg)
+                    || leg.k_snap != target_k
+                    || leg.f_snap != target_f
+                {
+                    count += 1;
+                }
+            }
+            slot += 1;
+        }
+        Ok(count)
+    }
+
     fn account_has_source_claims(account: &PortfolioV16View<'_>) -> V16Result<bool> {
         Ok(Self::account_source_claim_bound_sum_num(account)? != 0)
     }
@@ -10898,6 +10934,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     ) -> V16Result<HealthCertV16> {
         match self.refresh_account_and_certify_not_atomic(account, None, 0, false)? {
             AccountRefreshCertOutcomeV16::Certified(cert) => Ok(cert),
+            AccountRefreshCertOutcomeV16::LegSettled { .. } => Err(V16Error::Stale),
             AccountRefreshCertOutcomeV16::BChunk(_) => Err(V16Error::BStale),
             AccountRefreshCertOutcomeV16::SourceBackingExpired(_) => Err(V16Error::Stale),
         }
@@ -10919,6 +10956,23 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .validate_source_credit_shape_with_market(&self.as_view())?;
             Self::account_source_claim_bound_sum_num(&account.as_view())?
         };
+        let source_domain_count = if allow_b_chunk {
+            Self::account_source_domain_count(&account.as_view())
+        } else {
+            0
+        };
+        let pending_kf_count = if allow_b_chunk {
+            self.account_pending_kf_settlement_count(&account.as_view())?
+        } else {
+            0
+        };
+        // Existing source attribution adds another bounded scan to every K/F
+        // settlement. In that state permissionless refresh commits at most one
+        // stale leg, keeping the last few legs from being folded into an
+        // unbounded certification tail as earlier chunks remove domains. The
+        // source-free max-leg path remains monolithic and has its own SBF bound.
+        let chunk_kf_settlement =
+            allow_b_chunk && source_domain_count != 0 && pending_kf_count != 0;
         if source_claim_sum_num != 0 {
             V16Core::validate_positive_pnl_source_attribution(
                 account.header.pnl.get(),
@@ -11011,7 +11065,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 self.begin_full_drain_reset_inner(asset_index, leg.side)?;
                 asset = self.asset_state(asset_index)?;
             }
+            let (target_k, target_f) = Self::kf_target_for_leg_from_asset(asset, leg)?;
+            let kf_settlement_pending = leg.k_snap != target_k || leg.f_snap != target_f;
             self.settle_leg_kf_effects_at_slot_with_asset(account, slot, asset)?;
+            if chunk_kf_settlement && kf_settlement_pending {
+                self.validate_account_audit_scan(&account.as_view())?;
+                self.validate_shape_audit_scan()?;
+                return Ok(AccountRefreshCertOutcomeV16::LegSettled { asset_index });
+            }
             let mut refreshed = account.header.legs[slot].try_to_runtime()?;
             let target = Self::b_target_for_leg_from_asset(asset, refreshed)?;
             if target > refreshed.b_snap {
@@ -11783,6 +11844,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     true,
                 )? {
                     AccountRefreshCertOutcomeV16::Certified(_) => {}
+                    AccountRefreshCertOutcomeV16::LegSettled { asset_index } => {
+                        self.validate_shape_audit_scan()?;
+                        return Ok(PermissionlessProgressOutcomeV16::AccountLegSettled {
+                            asset_index,
+                        });
+                    }
                     AccountRefreshCertOutcomeV16::BChunk(out) => {
                         self.validate_shape_audit_scan()?;
                         return Ok(PermissionlessProgressOutcomeV16::AccountBChunk(out));
@@ -13858,19 +13925,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         let fee_bps = config.liquidation_fee_bps;
         self.require_asset_live_reducible(request.asset_index)?;
-        self.validate_account_scalar_preflight(&account.as_view())?;
+        let cert = self.settle_account_for_position_action_and_refresh_not_atomic(account)?;
         Self::require_active_leg_slot_for_asset(&account.as_view(), request.asset_index)?;
-        match self.refresh_account_and_certify_not_atomic(
-            account,
-            None,
-            self.header.config.public_b_chunk_atoms.get(),
-            false,
-        )? {
-            AccountRefreshCertOutcomeV16::Certified(_) => {}
-            AccountRefreshCertOutcomeV16::BChunk(_) => return Err(V16Error::BStale),
-            AccountRefreshCertOutcomeV16::SourceBackingExpired(_) => return Err(V16Error::Stale),
-        }
-        let cert = account.header.health_cert.try_to_runtime()?;
         if cert.certified_liq_deficit == 0 {
             return Err(V16Error::NonProgress);
         }
@@ -14072,6 +14128,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         match self.refresh_account_and_certify_not_atomic(account, None, 0, false)? {
             AccountRefreshCertOutcomeV16::Certified(cert) => Ok(cert),
+            AccountRefreshCertOutcomeV16::LegSettled { .. } => Err(V16Error::Stale),
             AccountRefreshCertOutcomeV16::BChunk(_) => Err(V16Error::BStale),
             AccountRefreshCertOutcomeV16::SourceBackingExpired(_) => Err(V16Error::Stale),
         }
@@ -16757,6 +16814,7 @@ impl RiskScoreV16 {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PermissionlessProgressOutcomeV16 {
     AccountCurrent,
+    AccountLegSettled { asset_index: usize },
     AccountBChunk(AccountBSettlementChunkV16),
     SourceBackingExpired { domain: usize },
     ResidualBooked(BResidualBookingOutcomeV16),

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1532,6 +1532,16 @@ impl V16Core {
         None
     }
 
+    /// PRODUCTION KERNEL: ordinary refresh accrual and liquidation can target
+    /// only a live or draining asset. Recovery legs remain account obligations,
+    /// but selecting one as the action asset would deterministically fail.
+    fn kernel_auto_crank_lifecycle_dispatchable(lifecycle: AssetLifecycleV16) -> bool {
+        matches!(
+            lifecycle,
+            AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
+        )
+    }
+
     /// PRODUCTION KERNEL (engine.md selection semantics): from the actionable
     /// summary and the ENGINE-selected assets, choose the single highest-priority
     /// bounded plan, carrying the engine-chosen asset (the caller chooses neither
@@ -11695,9 +11705,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             let leg = account.header.legs[slot].try_to_runtime()?;
             let active = active_bitmap_get(bitmap, slot) && leg.active;
             if active {
-                dispatchable_flags[slot] = matches!(
+                dispatchable_flags[slot] = V16Core::kernel_auto_crank_lifecycle_dispatchable(
                     self.asset_state(leg.asset_index as usize)?.lifecycle,
-                    AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
                 );
             }
             b_stale_flags[slot] = active && leg.b_stale;

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -10825,7 +10825,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             if asset_index >= configured_assets || asset_index >= self.markets.len() {
                 return Err(V16Error::HiddenLeg);
             }
-            let asset = self.markets[asset_index].engine.asset.try_to_runtime()?;
+            let mut asset = self.markets[asset_index].engine.asset.try_to_runtime()?;
             if leg.market_id != asset.market_id
                 || !matches!(
                     asset.lifecycle,
@@ -10846,6 +10846,21 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
             seen_assets[seen_asset_count] = leg.asset_index;
             seen_asset_count += 1;
+            // Older states can contain a nonzero stored basis after ADL has
+            // exhausted the side's effective OI. Move that terminal residue
+            // behind the normal reset epoch before settling it; otherwise a
+            // clear would subtract stored basis from zero effective OI forever.
+            if Self::leg_has_exhausted_effective_oi(asset, leg)
+                && !account
+                    .header
+                    .close_progress
+                    .try_to_runtime()?
+                    .has_pending_residual()
+                && !self.has_pending_domain_loss_barrier(asset_index, leg.side)?
+            {
+                self.begin_full_drain_reset_inner(asset_index, leg.side)?;
+                asset = self.asset_state(asset_index)?;
+            }
             self.settle_leg_kf_effects_at_slot_with_asset(account, slot, asset)?;
             let mut refreshed = account.header.legs[slot].try_to_runtime()?;
             let target = Self::b_target_for_leg_from_asset(asset, refreshed)?;
@@ -10875,10 +10890,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 }
                 return Err(V16Error::BStale);
             }
-            // A prior-reset leg no longer owns effective OI. Once its terminal
-            // K/F/B claims are settled above, detaching it is bookkeeping, not
-            // a position close. Clear at most one per call to keep max-shape CU
-            // bounded; the classifier keeps another obligation actionable.
+            // A prior-reset leg no longer owns effective OI. This includes a
+            // legacy Normal-mode residue migrated into a reset above. Once its
+            // terminal K/F/B claims are settled, detaching it is bookkeeping,
+            // not a position close. Clear at most one per call to keep max-shape
+            // CU bounded; the classifier keeps another obligation actionable.
             let should_clear_reset = if reset_obligation_cleared
                 || !Self::leg_is_prior_reset_obligation(asset, refreshed)
             {
@@ -11767,11 +11783,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     /// return, for each asset-scoped continuation, the engine-chosen asset_index —
     /// the FIRST active b-stale leg's asset (SettleBChunk), the FIRST active leg
     /// whose asset is accrual-dispatchable (refresh), and the FIRST live-reducible
-    /// leg (liquidation). A prior-epoch ResetPending leg is still refreshable, but
-    /// its effective OI was already removed by ADL; selecting it for liquidation
-    /// would fail before a later current-epoch leg could make progress. Recovery
-    /// legs cannot be selected for refresh or liquidation because both reject
-    /// their lifecycle. The
+    /// leg with matched effective OI (liquidation). A prior-epoch ResetPending leg,
+    /// or a legacy stored-basis residue whose effective OI was exhausted by ADL,
+    /// is refreshable bookkeeping but not a liquidation candidate. Selecting one
+    /// for liquidation would fail before a later current-epoch leg could make
+    /// progress. Recovery legs cannot be selected for refresh or liquidation
+    /// because both reject their lifecycle. The
     /// selection is proven in-range / actionable / first-match / complete by the
     /// first_actionable_slot contract; the slot->asset_index and lifecycle filter
     /// are bound to production state here.
@@ -11781,6 +11798,43 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             SideV16::Short => (asset.mode_short, asset.epoch_short),
         };
         V16Core::kernel_is_prior_reset_obligation(side_mode, asset_epoch, leg.epoch_snap)
+    }
+
+    fn side_effective_oi(asset: AssetStateV16, side: SideV16) -> u128 {
+        match side {
+            SideV16::Long => asset.oi_eff_long_q,
+            SideV16::Short => asset.oi_eff_short_q,
+        }
+    }
+
+    fn side_stored_position_count(asset: AssetStateV16, side: SideV16) -> u64 {
+        match side {
+            SideV16::Long => asset.stored_pos_count_long,
+            SideV16::Short => asset.stored_pos_count_short,
+        }
+    }
+
+    fn side_pending_obligation_count(asset: AssetStateV16, side: SideV16) -> u64 {
+        match side {
+            SideV16::Long => asset.pending_obligation_count_long,
+            SideV16::Short => asset.pending_obligation_count_short,
+        }
+    }
+
+    fn side_mode(asset: AssetStateV16, side: SideV16) -> SideModeV16 {
+        match side {
+            SideV16::Long => asset.mode_long,
+            SideV16::Short => asset.mode_short,
+        }
+    }
+
+    fn leg_has_exhausted_effective_oi(asset: AssetStateV16, leg: PortfolioLegV16) -> bool {
+        leg.active
+            && leg.basis_pos_q != 0
+            && Self::side_effective_oi(asset, leg.side) == 0
+            && Self::side_stored_position_count(asset, leg.side) != 0
+            && Self::side_pending_obligation_count(asset, leg.side) == 0
+            && Self::side_mode(asset, leg.side) != SideModeV16::ResetPending
     }
 
     fn auto_crank_selected_assets(
@@ -11798,16 +11852,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             let active = active_bitmap_get(bitmap, slot) && leg.active;
             if active {
                 let asset = self.asset_state(leg.asset_index as usize)?;
-                let (side_oi, side_mode, asset_epoch) = match leg.side {
-                    SideV16::Long => (asset.oi_eff_long_q, asset.mode_long, asset.epoch_long),
-                    SideV16::Short => (asset.oi_eff_short_q, asset.mode_short, asset.epoch_short),
+                let (side_mode, asset_epoch) = match leg.side {
+                    SideV16::Long => (asset.mode_long, asset.epoch_long),
+                    SideV16::Short => (asset.mode_short, asset.epoch_short),
                 };
+                let matched_oi = asset.oi_eff_long_q.min(asset.oi_eff_short_q);
                 let (b_stale, refresh, liquidatable, reset_obligation) =
                     V16Core::kernel_auto_crank_leg_flags(
                         true,
                         asset.lifecycle,
                         leg.basis_pos_q,
-                        side_oi,
+                        matched_oi,
                         side_mode,
                         asset_epoch,
                         leg.epoch_snap,
@@ -11816,7 +11871,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 b_stale_flags[slot] = b_stale;
                 refresh_flags[slot] = refresh;
                 liquidation_flags[slot] = liquidatable;
-                reset_obligation_flags[slot] = reset_obligation;
+                reset_obligation_flags[slot] =
+                    reset_obligation || Self::leg_has_exhausted_effective_oi(asset, leg);
             }
             slot += 1;
         }
@@ -13633,6 +13689,30 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
+    fn unilateral_close_capacity(&self, asset_index: usize, stored_abs: u128) -> V16Result<u128> {
+        let asset = self.asset_state(asset_index)?;
+        Ok(stored_abs
+            .min(asset.oi_eff_long_q)
+            .min(asset.oi_eff_short_q))
+    }
+
+    fn begin_side_reset_if_effective_oi_exhausted(
+        &mut self,
+        asset_index: usize,
+        side: SideV16,
+    ) -> V16Result<()> {
+        let asset = self.asset_state(asset_index)?;
+        if Self::side_effective_oi(asset, side) == 0
+            && Self::side_stored_position_count(asset, side) != 0
+            && Self::side_pending_obligation_count(asset, side) == 0
+            && Self::side_mode(asset, side) != SideModeV16::ResetPending
+            && !self.has_pending_domain_loss_barrier(asset_index, side)?
+        {
+            self.begin_full_drain_reset_inner(asset_index, side)?;
+        }
+        Ok(())
+    }
+
     fn reduce_position(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
@@ -13654,6 +13734,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             SideV16::Short => close_i128,
         };
         self.apply_position_delta(account, asset_index, delta)?;
+        self.begin_side_reset_if_effective_oi_exhausted(asset_index, leg.side)?;
         self.reduce_matching_open_interest_for_unilateral_close(asset_index, leg.side, close_q)
     }
 
@@ -13708,9 +13789,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // risk-reduction kernel rebalance uses, so A5.dec's strict-progress
         // contract now governs the real liquidation route (3C). Liquidation size
         // is engine-selected: close just enough to restore maintenance health
-        // when possible, otherwise close the selected leg fully.
+        // when possible, otherwise close the selected leg fully. The matched-OI
+        // capacity prevents a partially ADL-reduced stored basis from subtracting
+        // more effective OI than remains on the two-sided market.
+        let close_budget = close_request_q.min(
+            self.unilateral_close_capacity(request.asset_index, leg.basis_pos_q.unsigned_abs())?,
+        );
+        if close_budget == 0 {
+            return Err(V16Error::NonProgress);
+        }
         let (close_q, close_delta) =
-            V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, close_request_q)?;
+            V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, close_budget)?;
         if self.position_delta_touches_pending_domain_loss_barrier(
             &account.as_view(),
             request.asset_index,
@@ -13834,8 +13923,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         // PRODUCTION KERNEL: clamp + toward-zero reduction delta (rank decrease,
         // never over-closes, full close clears).
+        let reduce_budget = request.reduce_q.min(
+            self.unilateral_close_capacity(request.asset_index, leg.basis_pos_q.unsigned_abs())?,
+        );
         let (reduce_q, reduce_delta) =
-            V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, request.reduce_q)?;
+            V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, reduce_budget)?;
         if reduce_q == 0 {
             return Err(V16Error::NonProgress);
         }

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -15679,7 +15679,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if account.header.pnl.get() < 0 {
             self.settle_resolved_bankruptcy_negative_pnl(account)?;
         }
-        self.detach_solvent_active_legs_for_resolved_close(account)?;
+        if self.detach_one_solvent_active_leg_for_resolved_close(account)? {
+            self.validate_shape()?;
+            self.validate_account_audit_scan(&account.as_view())?;
+            return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
+        }
         if !active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get))
             || account.header.pnl.get() < 0
             || decode_bool(account.header.b_stale_state)?
@@ -15752,10 +15756,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(ResolvedCloseOutcomeV16::Closed { payout })
     }
 
-    fn detach_solvent_active_legs_for_resolved_close(
+    fn detach_one_solvent_active_leg_for_resolved_close(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
-    ) -> V16Result<()> {
+    ) -> V16Result<bool> {
         if account.header.pnl.get() < 0
             || decode_bool(account.header.b_stale_state)?
             || decode_bool(account.header.stale_state)?
@@ -15765,23 +15769,25 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .try_to_runtime()?
                 .has_pending_residual()
         {
-            return Ok(());
+            return Ok(false);
         }
 
         let configured_max = self.header.config.max_market_slots.get() as usize;
+        // Readiness and teardown are account-local but potentially expensive per
+        // leg. Inspect only the deterministic first active leg in this step.
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
             if leg.active {
                 if leg.b_stale || leg.stale {
-                    return Ok(());
+                    return Ok(false);
                 }
                 let asset_index = leg.asset_index as usize;
                 if asset_index >= configured_max {
                     return Err(V16Error::InvalidLeg);
                 }
                 if self.has_pending_domain_loss_barrier(asset_index, leg.side)? {
-                    return Ok(());
+                    return Ok(false);
                 }
                 let asset = self.asset_state(asset_index)?;
                 if Self::leg_has_exhausted_effective_oi(asset, leg) {
@@ -15792,24 +15798,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 }
                 let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;
                 if k_target != leg.k_snap || f_target != leg.f_snap {
-                    return Ok(());
+                    return Ok(false);
                 }
                 if self.b_target_for_leg(asset_index, leg)? != leg.b_snap {
-                    return Ok(());
+                    return Ok(false);
                 }
+                self.clear_resolved_close_leg(account, asset_index)?;
+                return Ok(true);
             }
             slot += 1;
         }
-
-        let mut slot = 0usize;
-        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
-            let leg = account.header.legs[slot].try_to_runtime()?;
-            if leg.active {
-                self.clear_resolved_close_leg(account, leg.asset_index as usize)?;
-            }
-            slot += 1;
-        }
-        Ok(())
+        Ok(false)
     }
 
     pub fn deposit_not_atomic(

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1995,6 +1995,68 @@ impl V16Core {
         Ok(leg)
     }
 
+    /// PRODUCTION KERNEL: move an exhausted side behind a reset epoch without
+    /// touching the opposite side. Prior-epoch legs can then detach without
+    /// subtracting their stored basis from already-zero effective OI.
+    fn kernel_begin_full_drain_reset(
+        mut asset: AssetStateV16,
+        side: SideV16,
+    ) -> V16Result<AssetStateV16> {
+        match side {
+            SideV16::Long => {
+                if asset.mode_long == SideModeV16::ResetPending
+                    || asset.oi_eff_long_q != 0
+                    || asset.pending_obligation_count_long != 0
+                {
+                    return Err(V16Error::LockActive);
+                }
+                quarantine_remainder(
+                    &mut asset.social_loss_remainder_long_num,
+                    &mut asset.social_loss_dust_long_num,
+                )?;
+                asset.k_epoch_start_long = asset.k_long;
+                asset.f_epoch_start_long_num = asset.f_long_num;
+                asset.b_epoch_start_long_num = asset.b_long_num;
+                asset.k_long = 0;
+                asset.f_long_num = 0;
+                asset.b_long_num = 0;
+                asset.loss_weight_sum_long = 0;
+                asset.a_long = ADL_ONE;
+                asset.epoch_long = asset
+                    .epoch_long
+                    .checked_add(1)
+                    .ok_or(V16Error::CounterOverflow)?;
+                asset.mode_long = SideModeV16::ResetPending;
+            }
+            SideV16::Short => {
+                if asset.mode_short == SideModeV16::ResetPending
+                    || asset.oi_eff_short_q != 0
+                    || asset.pending_obligation_count_short != 0
+                {
+                    return Err(V16Error::LockActive);
+                }
+                quarantine_remainder(
+                    &mut asset.social_loss_remainder_short_num,
+                    &mut asset.social_loss_dust_short_num,
+                )?;
+                asset.k_epoch_start_short = asset.k_short;
+                asset.f_epoch_start_short_num = asset.f_short_num;
+                asset.b_epoch_start_short_num = asset.b_short_num;
+                asset.k_short = 0;
+                asset.f_short_num = 0;
+                asset.b_short_num = 0;
+                asset.loss_weight_sum_short = 0;
+                asset.a_short = ADL_ONE;
+                asset.epoch_short = asset
+                    .epoch_short
+                    .checked_add(1)
+                    .ok_or(V16Error::CounterOverflow)?;
+                asset.mode_short = SideModeV16::ResetPending;
+            }
+        }
+        Ok(asset)
+    }
+
     /// PRODUCTION KERNEL: the clear-leg asset transform — decrement the
     /// side's stored-position count (and pending-obligation count for a
     /// zero-basis obligation leg), and unless the leg predates a side reset,
@@ -13582,59 +13644,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if self.has_pending_domain_loss_barrier(asset_index, side)? {
             return Err(V16Error::LockActive);
         }
-        let mut asset = self.asset_state(asset_index)?;
-        match side {
-            SideV16::Long => {
-                if asset.mode_long == SideModeV16::ResetPending {
-                    return Err(V16Error::LockActive);
-                }
-                if asset.oi_eff_long_q != 0 || asset.pending_obligation_count_long != 0 {
-                    return Err(V16Error::LockActive);
-                }
-                quarantine_remainder(
-                    &mut asset.social_loss_remainder_long_num,
-                    &mut asset.social_loss_dust_long_num,
-                )?;
-                asset.k_epoch_start_long = asset.k_long;
-                asset.f_epoch_start_long_num = asset.f_long_num;
-                asset.b_epoch_start_long_num = asset.b_long_num;
-                asset.k_long = 0;
-                asset.f_long_num = 0;
-                asset.b_long_num = 0;
-                asset.loss_weight_sum_long = 0;
-                asset.a_long = ADL_ONE;
-                asset.epoch_long = asset
-                    .epoch_long
-                    .checked_add(1)
-                    .ok_or(V16Error::CounterOverflow)?;
-                asset.mode_long = SideModeV16::ResetPending;
-            }
-            SideV16::Short => {
-                if asset.mode_short == SideModeV16::ResetPending {
-                    return Err(V16Error::LockActive);
-                }
-                if asset.oi_eff_short_q != 0 || asset.pending_obligation_count_short != 0 {
-                    return Err(V16Error::LockActive);
-                }
-                quarantine_remainder(
-                    &mut asset.social_loss_remainder_short_num,
-                    &mut asset.social_loss_dust_short_num,
-                )?;
-                asset.k_epoch_start_short = asset.k_short;
-                asset.f_epoch_start_short_num = asset.f_short_num;
-                asset.b_epoch_start_short_num = asset.b_short_num;
-                asset.k_short = 0;
-                asset.f_short_num = 0;
-                asset.b_short_num = 0;
-                asset.loss_weight_sum_short = 0;
-                asset.a_short = ADL_ONE;
-                asset.epoch_short = asset
-                    .epoch_short
-                    .checked_add(1)
-                    .ok_or(V16Error::CounterOverflow)?;
-                asset.mode_short = SideModeV16::ResetPending;
-            }
-        }
+        let asset = V16Core::kernel_begin_full_drain_reset(self.asset_state(asset_index)?, side)?;
         self.set_asset_state(asset_index, asset)?;
         self.header.risk_epoch = V16PodU64::new(
             self.header

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -2489,6 +2489,44 @@ impl V16Core {
         Ok((bucket, source))
     }
 
+    fn prepare_counterparty_backing_expiry_delta(
+        mut bucket: BackingBucketV16,
+        mut source: SourceCreditStateV16,
+        now_slot: u64,
+    ) -> V16Result<(BackingBucketV16, SourceCreditStateV16)> {
+        if bucket.status != BackingBucketStatusV16::Fresh || now_slot < bucket.expiry_slot {
+            return Err(V16Error::Stale);
+        }
+        let expired_unliened = bucket.fresh_unliened_backing_num;
+        let expired_liened = bucket.valid_liened_backing_num;
+        let expired_total = expired_unliened
+            .checked_add(expired_liened)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        if source.fresh_reserved_backing_num < expired_total
+            || source.valid_liened_backing_num < expired_liened
+        {
+            return Err(V16Error::CounterUnderflow);
+        }
+        source.fresh_reserved_backing_num -= expired_total;
+        source.valid_liened_backing_num -= expired_liened;
+        source.impaired_liened_backing_num = source
+            .impaired_liened_backing_num
+            .checked_add(expired_liened)
+            .ok_or(V16Error::CounterOverflow)?;
+        bucket.fresh_unliened_backing_num = 0;
+        bucket.valid_liened_backing_num = 0;
+        bucket.impaired_liened_backing_num = bucket
+            .impaired_liened_backing_num
+            .checked_add(expired_liened)
+            .ok_or(V16Error::CounterOverflow)?;
+        bucket.status = if expired_liened == 0 && bucket.impaired_liened_backing_num == 0 {
+            BackingBucketStatusV16::Expired
+        } else {
+            BackingBucketStatusV16::Impaired
+        };
+        Ok((bucket, source))
+    }
+
     #[cfg(any(kani, feature = "fuzz"))]
     // Contract layer: lien release is the un-pledge relabel — valid liened
     // returns to fresh unliened atom-for-atom, fresh_reserved and all stock
@@ -7822,38 +7860,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         domain: usize,
         now_slot: u64,
     ) -> V16Result<()> {
-        let mut bucket = self.backing_bucket_for_domain(domain)?;
-        if bucket.status != BackingBucketStatusV16::Fresh || now_slot < bucket.expiry_slot {
-            return Err(V16Error::Stale);
-        }
-        let mut source = self.source_credit_for_domain(domain)?;
-        let expired_unliened = bucket.fresh_unliened_backing_num;
-        let expired_liened = bucket.valid_liened_backing_num;
-        let expired_total = expired_unliened
-            .checked_add(expired_liened)
-            .ok_or(V16Error::ArithmeticOverflow)?;
-        if source.fresh_reserved_backing_num < expired_total
-            || source.valid_liened_backing_num < expired_liened
-        {
-            return Err(V16Error::CounterUnderflow);
-        }
-        source.fresh_reserved_backing_num -= expired_total;
-        source.valid_liened_backing_num -= expired_liened;
-        source.impaired_liened_backing_num = source
-            .impaired_liened_backing_num
-            .checked_add(expired_liened)
-            .ok_or(V16Error::CounterOverflow)?;
-        bucket.fresh_unliened_backing_num = 0;
-        bucket.valid_liened_backing_num = 0;
-        bucket.impaired_liened_backing_num = bucket
-            .impaired_liened_backing_num
-            .checked_add(expired_liened)
-            .ok_or(V16Error::CounterOverflow)?;
-        bucket.status = if expired_liened == 0 && bucket.impaired_liened_backing_num == 0 {
-            BackingBucketStatusV16::Expired
-        } else {
-            BackingBucketStatusV16::Impaired
-        };
+        let (bucket, source) = V16Core::prepare_counterparty_backing_expiry_delta(
+            self.backing_bucket_for_domain(domain)?,
+            self.source_credit_for_domain(domain)?,
+            now_slot,
+        )?;
         self.set_backing_bucket_for_domain(domain, bucket)?;
         self.set_source_credit_for_domain(domain, source)?;
         self.refresh_source_credit_domain_after_mutation(domain)

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -15926,12 +15926,26 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         {
             return Err(V16Error::InvalidLeg);
         }
-        let leg = Self::active_leg_for_asset(&account.as_view(), asset_index)?;
+        let mut leg = Self::active_leg_for_asset(&account.as_view(), asset_index)?;
         if !leg.active {
             return Err(V16Error::InvalidLeg);
         }
         if !self.leg_is_dead_for_forfeit(asset_index, leg.side)? {
             return Err(V16Error::LockActive);
+        }
+        if Self::leg_has_exhausted_effective_oi(self.asset_state(asset_index)?, leg)
+            && !account
+                .header
+                .close_progress
+                .try_to_runtime()?
+                .has_pending_residual()
+            && !self.has_pending_domain_loss_barrier(asset_index, leg.side)?
+        {
+            // A matched Recovery close can consume the final effective OI while
+            // leaving an ADL-reduced account's larger stored basis behind. Move
+            // that terminal residue into the reset epoch before forfeit clears it.
+            self.begin_full_drain_reset_inner(asset_index, leg.side)?;
+            leg = Self::active_leg_for_asset(&account.as_view(), asset_index)?;
         }
 
         let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -14759,8 +14759,19 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if decode_bool(account.header.resolved_payout_receipt.present)? {
             return Ok(());
         }
-        self.initialize_resolved_payout_ledger_if_needed()?;
         let terminal_positive_claim_face = account.header.pnl.get().max(0) as u128;
+        self.append_resolved_payout_receipt_face_not_atomic(account, terminal_positive_claim_face)
+    }
+
+    fn append_resolved_payout_receipt_face_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        terminal_positive_claim_face: u128,
+    ) -> V16Result<()> {
+        if terminal_positive_claim_face == 0 {
+            return Ok(());
+        }
+        self.initialize_resolved_payout_ledger_if_needed()?;
         let prior_bound_contribution_num =
             V16Core::bound_num_from_amount(terminal_positive_claim_face)?;
         let mut ledger = self.header.resolved_payout_ledger.try_to_runtime()?;
@@ -14784,15 +14795,25 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             )?)
             .ok_or(V16Error::ArithmeticOverflow)?;
         self.header.resolved_payout_ledger = ResolvedPayoutLedgerV16Account::from_runtime(&ledger);
+        let mut receipt = account.header.resolved_payout_receipt.try_to_runtime()?;
+        if !receipt.present {
+            if !receipt.is_empty() {
+                return Err(V16Error::InvalidLeg);
+            }
+            receipt.present = true;
+        }
+        receipt.prior_bound_contribution_num = receipt
+            .prior_bound_contribution_num
+            .checked_add(prior_bound_contribution_num)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        receipt.terminal_positive_claim_face = receipt
+            .terminal_positive_claim_face
+            .checked_add(terminal_positive_claim_face)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        receipt.finalized = receipt.paid_effective == receipt.terminal_positive_claim_face;
+        validate_resolved_payout_receipt_value(receipt)?;
         account.header.resolved_payout_receipt =
-            ResolvedPayoutReceiptV16Account::from_runtime(&ResolvedPayoutReceiptV16 {
-                present: true,
-                prior_bound_contribution_num,
-                live_released_face_at_receipt: 0,
-                terminal_positive_claim_face,
-                paid_effective: 0,
-                finalized: false,
-            });
+            ResolvedPayoutReceiptV16Account::from_runtime(&receipt);
         self.recompute_resolved_payout_rate()
     }
 
@@ -15345,43 +15366,20 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
-    /// Terminal realization for a source-backed winner: realize the account's
-    /// outstanding source-credit claims against their domain backing at the
-    /// current credit rate (lien consumption -> capital credit) BEFORE the claim
-    /// face enters the junior receipt pool. A settlement-quality claim is
-    /// realizable at rate in Live (convert_released_pnl_to_capital); resolution
-    /// must not strip that entitlement -- without this step the wind-down
-    /// RELEASES the backing to the provider while the winner is haircut from a
-    /// residual pool that (correctly) excludes the very backing underwriting the
-    /// claim. Residual-neutral: capital/c_tot grow by exactly the consumed
-    /// backing atoms, so the payout snapshot does not depend on realization
-    /// order.
-    fn realize_source_backed_claims_for_resolved_close_not_atomic(
+    /// Perform at most one preparatory source-domain mutation before terminal
+    /// realization. Source claims cannot be removed piecemeal while their face
+    /// remains positive PnL: the persisted representation requires any nonempty
+    /// source roster to cover the account's full positive PnL. Lien release and
+    /// backing expiry preserve that invariant, so expose those as bounded
+    /// `ProgressOnly` steps and leave the existing aggregate realization intact.
+    fn prepare_one_source_domain_for_resolved_close_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
-    ) -> V16Result<u128> {
-        if decode_bool(account.header.resolved_payout_receipt.present)? {
-            // The face is already frozen into the receipt pool.
-            return Ok(0);
-        }
+    ) -> V16Result<Option<usize>> {
         if !Self::account_has_source_claims(&account.as_view())? {
-            return Ok(0);
+            return Ok(None);
         }
-        let pos = account.header.pnl.get().max(0) as u128;
-        if pos == 0 {
-            return Ok(0);
-        }
-        // Release the account's persisted liens first (the terminal burn would do
-        // this anyway): the conversion consumes only UNLIENED claims, so a still-
-        // liened claim would make the realizable estimate exceed what consumption
-        // can deliver and dead-lock the close with LockActive. In the same sweep,
-        // expire any domain whose backing bucket has lapsed (status Fresh but
-        // expiry_slot <= current_slot): realization is best-effort, and querying
-        // realizable support against a past-expiry bucket would otherwise return
-        // Stale and strand the winner's close. Expiry forfeits the lapsed
-        // principal to the junior pool (the documented expiry semantics), drops
-        // the domain's credit rate to zero, and lets this step fall through to
-        // the junior receipt path instead of reverting.
+        account.compact_source_domains();
         let current_slot = self.header.current_slot.get();
         let mut slot = 0usize;
         while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
@@ -15389,44 +15387,170 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             if source.has_default_sparse_tag() && !source.is_occupied() {
                 break;
             }
-            if source.is_occupied() {
-                let d = source.domain.get() as usize;
-                if source.source_claim_liened_num.get() != 0 {
-                    self.release_account_source_credit_lien_for_domain_not_atomic(account, d)?;
-                }
-                let bucket = self.backing_bucket_for_domain(d)?;
-                if bucket.status == BackingBucketStatusV16::Fresh
-                    && bucket.expiry_slot <= current_slot
-                {
-                    self.expire_source_backing_bucket_not_atomic(d, current_slot)?;
-                }
+            if !source.is_occupied() {
+                slot += 1;
+                continue;
+            }
+
+            let domain = source.domain.get() as usize;
+            self.domain_asset_side(domain)?;
+            if source.source_claim_liened_num.get() != 0 {
+                self.release_account_source_credit_lien_for_domain_not_atomic(account, domain)?;
+                account.header.health_cert.valid = 0;
+                self.validate_shape()?;
+                account.validate_with_market(&self.as_view())?;
+                return Ok(Some(domain));
+            }
+
+            let bucket = self.backing_bucket_for_domain(domain)?;
+            if bucket.status == BackingBucketStatusV16::Fresh && bucket.expiry_slot <= current_slot
+            {
+                self.expire_source_backing_bucket_not_atomic(domain, current_slot)?;
+                account.header.health_cert.valid = 0;
+                self.validate_shape()?;
+                account.validate_with_market(&self.as_view())?;
+                return Ok(Some(domain));
             }
             slot += 1;
         }
-        if self.account_source_realizable_support(&account.as_view(), pos)? == 0 {
-            return Ok(0);
+        Ok(None)
+    }
+
+    /// Settle exactly one prepared source domain. Realizable source support
+    /// becomes capital; any remaining face moves into the exact resolved payout
+    /// receipt. PnL falls by the full processed face, so the remaining source
+    /// roster still covers all remaining positive PnL at every committed step.
+    fn process_one_source_claim_for_resolved_close_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+    ) -> V16Result<Option<usize>> {
+        if !Self::account_has_source_claims(&account.as_view())? {
+            return Ok(None);
         }
-        // Terminal: PnL reservations no longer gate realization.
-        account.header.reserved_pnl = V16PodU128::new(0);
-        let converted = self.convert_released_pnl_to_capital_core_not_atomic(account)?;
-        // If the payout snapshot was captured before this account realized (another
-        // winner closed first), the realized face is still counted in the ledger's
-        // unreceipted bound. Refine it out, or the stale bound dilutes the payout
-        // rate forever and blocks every remaining receipt from reaching the
-        // terminal rate (never finalized, never clearable).
-        if decode_bool(self.header.payout_snapshot_captured)? {
-            let pos_after = account.header.pnl.get().max(0) as u128;
-            let face_burned = pos
-                .checked_sub(pos_after)
+
+        account.compact_source_domains();
+        let source = account.header.source_domains[0];
+        if !source.is_occupied() || source.source_claim_bound_num.get() == 0 {
+            return Err(V16Error::InvalidLeg);
+        }
+        let domain = source.domain.get() as usize;
+        self.domain_asset_side(domain)?;
+        if source.source_claim_liened_num.get() != 0 {
+            return Err(V16Error::LockActive);
+        }
+
+        let pos_before = account.header.pnl.get().max(0) as u128;
+        let pos_bound_num = V16Core::bound_num_from_amount(pos_before)?;
+        let realizable_claim_num =
+            Self::source_claim_unliened_num(&account.as_view(), domain)?.min(pos_bound_num);
+        let source_credit = self.source_credit_for_domain(domain)?;
+        self.validate_source_domain_ledger_current(domain)?;
+        let credited_num = U256::from_u128(realizable_claim_num)
+            .checked_mul(U256::from_u128(source_credit.credit_rate_num))
+            .and_then(|v| v.checked_div(U256::from_u128(CREDIT_RATE_SCALE)))
+            .and_then(|v| v.try_into_u128())
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        let effective = (credited_num / BOUND_SCALE)
+            .min(self.source_credit_available_backing_num(domain)? / BOUND_SCALE)
+            .min(pos_before);
+
+        if effective != 0 {
+            account.header.reserved_pnl = V16PodU128::new(0);
+            let vault_before = self.header.vault.get();
+            let consumption =
+                self.consume_source_domain_credit_for_effective_not_atomic(domain, effective)?;
+            let face_burn = consumption.face_burn.min(pos_before);
+            let face_i128 = i128::try_from(face_burn).map_err(|_| V16Error::ArithmeticOverflow)?;
+            let new_pnl = account
+                .header
+                .pnl
+                .get()
+                .checked_sub(face_i128)
+                .ok_or(V16Error::ArithmeticOverflow)?;
+            self.set_account_pnl(account, new_pnl)?;
+            account.header.capital = V16PodU128::new(
+                account
+                    .header
+                    .capital
+                    .get()
+                    .checked_add(effective)
+                    .ok_or(V16Error::ArithmeticOverflow)?,
+            );
+            self.header.c_tot = V16PodU128::new(
+                self.header
+                    .c_tot
+                    .get()
+                    .checked_add(effective)
+                    .ok_or(V16Error::ArithmeticOverflow)?,
+            );
+            self.header.pnl_matured_pos_tot = V16PodU128::new(
+                self.header
+                    .pnl_matured_pos_tot
+                    .get()
+                    .saturating_sub(face_burn),
+            );
+            let protocol_surplus_consumed = effective
+                .checked_sub(consumption.counterparty_credit_consumed)
+                .and_then(|v| v.checked_sub(consumption.insurance_credit_consumed))
                 .ok_or(V16Error::CounterUnderflow)?;
-            let ledger = self.header.resolved_payout_ledger.try_to_runtime()?;
-            let decrease_num = V16Core::bound_num_from_amount(face_burned)?
-                .min(ledger.terminal_claim_bound_unreceipted_num);
-            if decrease_num != 0 {
-                self.refine_resolved_unreceipted_bound_not_atomic(decrease_num)?;
+            TokenValueFlowProofV16::support_to_account_capital(
+                effective,
+                consumption.counterparty_credit_consumed,
+                consumption.insurance_credit_consumed,
+                protocol_surplus_consumed,
+                vault_before,
+                self.header.vault.get(),
+            )?
+            .validate()?;
+
+            if decode_bool(self.header.payout_snapshot_captured)? {
+                let ledger = self.header.resolved_payout_ledger.try_to_runtime()?;
+                let decrease_num = V16Core::bound_num_from_amount(face_burn)?
+                    .min(ledger.terminal_claim_bound_unreceipted_num);
+                if decrease_num != 0 {
+                    self.refine_resolved_unreceipted_bound_not_atomic(decrease_num)?;
+                }
             }
         }
-        Ok(converted)
+
+        let pnl_after_source = account.header.pnl.get().max(0) as u128;
+        let remaining_domain_claim_num = account
+            .as_view()
+            .source_domain(domain)?
+            .source_claim_bound_num
+            .get();
+        let total_claim_num = Self::account_source_claim_bound_sum_num(&account.as_view())?;
+        let claims_after_domain_num = total_claim_num
+            .checked_sub(remaining_domain_claim_num)
+            .ok_or(V16Error::CounterUnderflow)?;
+        let target_pnl = if claims_after_domain_num == 0 {
+            0
+        } else {
+            pnl_after_source.min(claims_after_domain_num / BOUND_SCALE)
+        };
+        let junior_face = pnl_after_source
+            .checked_sub(target_pnl)
+            .ok_or(V16Error::CounterUnderflow)?;
+        if junior_face != 0 {
+            self.initialize_resolved_payout_ledger_if_needed()?;
+            let target_i128 =
+                i128::try_from(target_pnl).map_err(|_| V16Error::ArithmeticOverflow)?;
+            self.set_account_pnl(account, target_i128)?;
+        }
+        if let Some(slot) = account.source_domain_slot(domain)? {
+            let remainder_num = account.header.source_domains[slot]
+                .source_claim_bound_num
+                .get();
+            self.burn_account_source_claim_bound_num(account, remainder_num)?;
+        }
+        if junior_face != 0 {
+            self.append_resolved_payout_receipt_face_not_atomic(account, junior_face)?;
+        }
+
+        account.header.health_cert.valid = 0;
+        self.validate_shape()?;
+        account.validate_with_market(&self.as_view())?;
+        Ok(Some(domain))
     }
 
     fn claim_resolved_payout_topup_core_not_atomic(
@@ -15539,7 +15663,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if account.header.pnl.get() > 0 && !self.resolved_positive_payout_ready()? {
             return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
         }
-        self.realize_source_backed_claims_for_resolved_close_not_atomic(account)?;
+        if self
+            .prepare_one_source_domain_for_resolved_close_not_atomic(account)?
+            .is_some()
+        {
+            return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
+        }
+        if self
+            .process_one_source_claim_for_resolved_close_not_atomic(account)?
+            .is_some()
+        {
+            return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
+        }
         let mut payout_receipt = None;
         let pnl_payout = if account.header.pnl.get() > 0
             || decode_bool(account.header.resolved_payout_receipt.present)?

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -7858,6 +7858,31 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.refresh_source_credit_domain_after_mutation(domain)
     }
 
+    fn expire_lapsed_source_backing_for_account_not_atomic(
+        &mut self,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<()> {
+        let current_slot = self.header.current_slot.get();
+        let mut slot = 0usize;
+        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let source = account.header.source_domains[slot];
+            if source.has_default_sparse_tag() && !source.is_occupied() {
+                break;
+            }
+            if source.is_occupied() {
+                let domain = source.domain.get() as usize;
+                let bucket = self.backing_bucket_for_domain(domain)?;
+                if bucket.status == BackingBucketStatusV16::Fresh
+                    && bucket.expiry_slot <= current_slot
+                {
+                    self.expire_source_backing_bucket_not_atomic(domain, current_slot)?;
+                }
+            }
+            slot += 1;
+        }
+        Ok(())
+    }
+
     #[cfg(any(kani, feature = "fuzz"))]
     pub fn create_source_credit_lien_from_counterparty_not_atomic(
         &mut self,
@@ -10859,6 +10884,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 source_claim_sum_num,
             )?;
         }
+        // A source-backed winner can remain Live past the backing bucket's expiry.
+        // Refresh is the permissionless continuation for that account, so apply the
+        // canonical expiry transition here before any support calculation consults
+        // the now-lapsed domain. Otherwise refresh returns Stale, SVM rollback
+        // restores the Fresh bucket, and every subsequent auto-crank repeats forever.
+        self.expire_lapsed_source_backing_for_account_not_atomic(&account.as_view())?;
         if decode_bool(account.header.b_stale_state)? && !allow_b_chunk {
             return Err(V16Error::BStale);
         }

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -5036,6 +5036,7 @@ struct PositionDeltaLookupV16 {
 enum AccountRefreshCertOutcomeV16 {
     Certified(HealthCertV16),
     BChunk(AccountBSettlementChunkV16),
+    SourceBackingExpired(usize),
 }
 
 #[cfg(kani)]
@@ -7858,10 +7859,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.refresh_source_credit_domain_after_mutation(domain)
     }
 
-    fn expire_lapsed_source_backing_for_account_not_atomic(
+    fn expire_first_lapsed_source_backing_for_account_not_atomic(
         &mut self,
         account: &PortfolioV16View<'_>,
-    ) -> V16Result<()> {
+    ) -> V16Result<Option<usize>> {
         let current_slot = self.header.current_slot.get();
         let mut slot = 0usize;
         while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
@@ -7876,11 +7877,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     && bucket.expiry_slot <= current_slot
                 {
                     self.expire_source_backing_bucket_not_atomic(domain, current_slot)?;
+                    return Ok(Some(domain));
                 }
             }
             slot += 1;
         }
-        Ok(())
+        Ok(None)
     }
 
     #[cfg(any(kani, feature = "fuzz"))]
@@ -10859,6 +10861,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         match self.refresh_account_and_certify_not_atomic(account, None, 0, false)? {
             AccountRefreshCertOutcomeV16::Certified(cert) => Ok(cert),
             AccountRefreshCertOutcomeV16::BChunk(_) => Err(V16Error::BStale),
+            AccountRefreshCertOutcomeV16::SourceBackingExpired(_) => Err(V16Error::Stale),
         }
     }
 
@@ -10885,11 +10888,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             )?;
         }
         // A source-backed winner can remain Live past the backing bucket's expiry.
-        // Refresh is the permissionless continuation for that account, so apply the
-        // canonical expiry transition here before any support calculation consults
-        // the now-lapsed domain. Otherwise refresh returns Stale, SVM rollback
-        // restores the Fresh bucket, and every subsequent auto-crank repeats forever.
-        self.expire_lapsed_source_backing_for_account_not_atomic(&account.as_view())?;
+        // The permissionless path commits exactly one canonical expiry transition
+        // per call, then returns before valuation. Repeated auto-cranks drain the
+        // bounded domain set without an O(source-domains) CU cliff.
+        if allow_b_chunk {
+            if let Some(domain) =
+                self.expire_first_lapsed_source_backing_for_account_not_atomic(&account.as_view())?
+            {
+                return Ok(AccountRefreshCertOutcomeV16::SourceBackingExpired(domain));
+            }
+        }
         if decode_bool(account.header.b_stale_state)? && !allow_b_chunk {
             return Err(V16Error::BStale);
         }
@@ -11740,6 +11748,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     AccountRefreshCertOutcomeV16::BChunk(out) => {
                         self.validate_shape_audit_scan()?;
                         return Ok(PermissionlessProgressOutcomeV16::AccountBChunk(out));
+                    }
+                    AccountRefreshCertOutcomeV16::SourceBackingExpired(domain) => {
+                        self.validate_shape_audit_scan()?;
+                        return Ok(PermissionlessProgressOutcomeV16::SourceBackingExpired {
+                            domain,
+                        });
                     }
                 }
                 touches_accrued_asset
@@ -13816,6 +13830,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         )? {
             AccountRefreshCertOutcomeV16::Certified(_) => {}
             AccountRefreshCertOutcomeV16::BChunk(_) => return Err(V16Error::BStale),
+            AccountRefreshCertOutcomeV16::SourceBackingExpired(_) => return Err(V16Error::Stale),
         }
         let cert = account.header.health_cert.try_to_runtime()?;
         if cert.certified_liq_deficit == 0 {
@@ -14020,6 +14035,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         match self.refresh_account_and_certify_not_atomic(account, None, 0, false)? {
             AccountRefreshCertOutcomeV16::Certified(cert) => Ok(cert),
             AccountRefreshCertOutcomeV16::BChunk(_) => Err(V16Error::BStale),
+            AccountRefreshCertOutcomeV16::SourceBackingExpired(_) => Err(V16Error::Stale),
         }
     }
 
@@ -16582,6 +16598,7 @@ impl RiskScoreV16 {
 pub enum PermissionlessProgressOutcomeV16 {
     AccountCurrent,
     AccountBChunk(AccountBSettlementChunkV16),
+    SourceBackingExpired { domain: usize },
     ResidualBooked(BResidualBookingOutcomeV16),
     RecoveryDeclared(PermissionlessRecoveryReasonV16),
 }

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -10752,6 +10752,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let bitmap = account.header.active_bitmap.map(V16PodU64::get);
         let mut seen_assets = [u32::MAX; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut seen_asset_count = 0usize;
+        let mut reset_obligation_cleared = false;
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
@@ -10827,6 +10828,23 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     ));
                 }
                 return Err(V16Error::BStale);
+            }
+            // A prior-reset leg no longer owns effective OI. Once its terminal
+            // K/F/B claims are settled above, detaching it is bookkeeping, not
+            // a position close. Clear at most one per call to keep max-shape CU
+            // bounded; the classifier keeps another obligation actionable.
+            if !reset_obligation_cleared
+                && Self::leg_is_prior_reset_obligation(asset, refreshed)
+                && !account
+                    .header
+                    .close_progress
+                    .try_to_runtime()?
+                    .has_pending_residual()
+            {
+                self.clear_leg(account, asset_index)?;
+                reset_obligation_cleared = true;
+                slot += 1;
+                continue;
             }
             let price = if let Some((override_asset, override_price)) = price_override {
                 if override_asset == asset_index {
@@ -11587,7 +11605,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     /// state to the ActionableState summary the self-classifying crank dispatches
     /// from. Each flag is exactly its production eligibility predicate, MODE-
     /// GATED so every flag that can be set has a currently-valid dispatch target:
-    ///   stale            — Live, health cert not current (kernel_cert_is_current==false)
+    ///   stale            — Live, health cert not current or a settled prior-reset
+    ///                      obligation still needs permissionless detachment
     ///   b_stale          — Live, some active leg flagged b-stale (has_b_stale_leg)
     ///   pending_close    — Live, a close-progress ledger is active
     ///   expired_close    — Live, that ledger is past its max-close slot
@@ -11617,13 +11636,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         );
         let ledger = account.header.close_progress.try_to_runtime()?;
 
-        let (_, dispatchable_active_asset) = self.auto_crank_selected_assets(account)?;
-        let has_open_risk = dispatchable_active_asset.is_some();
+        let (_, _, liquidatable_asset, reset_obligation_asset) =
+            self.auto_crank_selected_assets(account)?;
+        let has_open_risk = liquidatable_asset.is_some();
         // A close ledger with residual_remaining==0 is already fully booked/covered
         // (e.g. insurance absorbed the loss); only OUTSTANDING residual is real,
         // actionable close work. The `active` flag can linger past that.
         let close_outstanding = ledger.active && ledger.residual_remaining > 0;
-        let stale = live && !cert_current;
+        let stale = live && (!cert_current || reset_obligation_asset.is_some());
         let b_stale = live && Self::has_b_stale_leg(account)?;
         // pending_close is NOT proactively classified: the close-ledger residual is
         // booked ONLY inside the liquidation/resolved path that owns it
@@ -11638,11 +11658,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // Expired outstanding close -> terminal recovery (Recover needs no leg).
         let expired_close =
             live && close_outstanding && self.header.current_slot.get() > ledger.max_close_slot;
-        // liquidatable requires a current certified deficit AND actual open risk:
+        // liquidatable requires a current certified deficit AND actual open risk.
+        // Prior-reset obligations are settled/detached first through Refresh so
+        // they cannot block side finalization or poison liquidation dispatch:
         // a stale cert can still report a deficit after the position was already
         // closed, but with no active leg there is nothing to liquidate (the real
         // liquidate entrypoint requires an active leg), so the flag must be false.
-        let liquidatable = live && cert_current && cert.certified_liq_deficit != 0 && has_open_risk;
+        let liquidatable = live
+            && cert_current
+            && cert.certified_liq_deficit != 0
+            && has_open_risk
+            && reset_obligation_asset.is_none();
         // Permissionless recovery (declare_permissionless_recovery) is a LIVE-mode
         // action — it rejects Resolved mode with LockActive. The proactive Live
         // recovery condition the auto-crank declares is an EXPIRED outstanding
@@ -11685,29 +11711,59 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     /// dispatch target is valid in the mode that the classifier gated its flag to.
     /// ENGINE asset self-selection (engine.md): scan the account's bounded legs and
     /// return, for each asset-scoped continuation, the engine-chosen asset_index —
-    /// the FIRST active b-stale leg's asset (SettleBChunk), and the FIRST active
-    /// leg whose asset is currently accrual/reduction-dispatchable (Active or
-    /// DrainOnly, used for both Liquidate and the refresh accrual target). Recovery
-    /// legs remain refreshable as part of the account scan, but cannot be selected
-    /// as the action asset because both accrual and liquidation reject them. The
+    /// the FIRST active b-stale leg's asset (SettleBChunk), the FIRST active leg
+    /// whose asset is accrual-dispatchable (refresh), and the FIRST live-reducible
+    /// leg (liquidation). A prior-epoch ResetPending leg is still refreshable, but
+    /// its effective OI was already removed by ADL; selecting it for liquidation
+    /// would fail before a later current-epoch leg could make progress. Recovery
+    /// legs cannot be selected for refresh or liquidation because both reject
+    /// their lifecycle. The
     /// selection is proven in-range / actionable / first-match / complete by the
     /// first_actionable_slot contract; the slot->asset_index and lifecycle filter
     /// are bound to production state here.
+    fn leg_is_prior_reset_obligation(asset: AssetStateV16, leg: PortfolioLegV16) -> bool {
+        match leg.side {
+            SideV16::Long => {
+                asset.mode_long == SideModeV16::ResetPending
+                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_long)
+            }
+            SideV16::Short => {
+                asset.mode_short == SideModeV16::ResetPending
+                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_short)
+            }
+        }
+    }
+
     fn auto_crank_selected_assets(
         &self,
         account: &PortfolioV16View<'_>,
-    ) -> V16Result<(Option<usize>, Option<usize>)> {
+    ) -> V16Result<(Option<usize>, Option<usize>, Option<usize>, Option<usize>)> {
         let bitmap = account.header.active_bitmap.map(V16PodU64::get);
-        let mut dispatchable_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+        let mut refresh_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+        let mut liquidation_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+        let mut reset_obligation_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut b_stale_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
             let active = active_bitmap_get(bitmap, slot) && leg.active;
             if active {
-                dispatchable_flags[slot] = V16Core::kernel_auto_crank_lifecycle_dispatchable(
-                    self.asset_state(leg.asset_index as usize)?.lifecycle,
+                let asset = self.asset_state(leg.asset_index as usize)?;
+                let lifecycle_dispatchable = matches!(
+                    asset.lifecycle,
+                    AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
                 );
+                refresh_flags[slot] = lifecycle_dispatchable;
+                let side_oi = match leg.side {
+                    SideV16::Long => asset.oi_eff_long_q,
+                    SideV16::Short => asset.oi_eff_short_q,
+                };
+                let prior_reset_obligation = Self::leg_is_prior_reset_obligation(asset, leg);
+                reset_obligation_flags[slot] = prior_reset_obligation;
+                liquidation_flags[slot] = lifecycle_dispatchable
+                    && leg.basis_pos_q != 0
+                    && side_oi != 0
+                    && !prior_reset_obligation;
             }
             b_stale_flags[slot] = active && leg.b_stale;
             slot += 1;
@@ -11721,8 +11777,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
         };
         let b_stale_asset = asset_of(V16Core::first_actionable_slot(b_stale_flags))?;
-        let active_asset = asset_of(V16Core::first_actionable_slot(dispatchable_flags))?;
-        Ok((b_stale_asset, active_asset))
+        let refresh_asset = asset_of(V16Core::first_actionable_slot(refresh_flags))?;
+        let liquidatable_asset = asset_of(V16Core::first_actionable_slot(liquidation_flags))?;
+        let reset_obligation_asset =
+            asset_of(V16Core::first_actionable_slot(reset_obligation_flags))?;
+        Ok((
+            b_stale_asset,
+            refresh_asset,
+            liquidatable_asset,
+            reset_obligation_asset,
+        ))
     }
 
     /// THE SINGLE PUBLIC PERMISSIONLESS CRANK (engine.md): the only crank the
@@ -11756,7 +11820,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         work: AutoCrankWorkV16<'_>,
     ) -> V16Result<AutoCrankResultV16> {
         let summary = self.build_actionable_summary(&account.as_view())?;
-        let (b_stale_asset, active_asset) = self.auto_crank_selected_assets(&account.as_view())?;
+        let (b_stale_asset, refresh_asset, liquidatable_asset, _) =
+            self.auto_crank_selected_assets(&account.as_view())?;
         let recovery_reason = if summary.expired_close {
             PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
         } else {
@@ -11767,8 +11832,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let plan = V16Core::select_auto_crank_plan(
             summary,
             b_stale_asset.unwrap_or(0),
-            active_asset.unwrap_or(0),
-            active_asset,
+            liquidatable_asset.unwrap_or(0),
+            refresh_asset,
             recovery_reason,
         );
 

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1373,6 +1373,33 @@ impl V16Core {
         (payout, new_vault)
     }
 
+    fn resolved_close_terminal_payout_delta(
+        account_capital: u128,
+        resolved_claimable: u128,
+        vault: u128,
+        c_tot: u128,
+    ) -> V16Result<(u128, u128, u128, u128, u128)> {
+        let payout = account_capital
+            .checked_add(resolved_claimable)
+            .ok_or(V16Error::ArithmeticOverflow)?
+            .min(vault);
+        let capital_paid = account_capital.min(payout);
+        let resolved_paid = payout
+            .checked_sub(capital_paid)
+            .ok_or(V16Error::CounterUnderflow)?;
+        let vault_after = vault
+            .checked_sub(payout)
+            .ok_or(V16Error::CounterUnderflow)?;
+        let c_tot_after = c_tot.saturating_sub(account_capital.min(c_tot));
+        Ok((
+            payout,
+            capital_paid,
+            resolved_paid,
+            vault_after,
+            c_tot_after,
+        ))
+    }
+
     /// PRODUCTION KERNEL (roadmap 3A.1 trade spine): classify a position change
     /// from (current signed, new signed) into its leg route — the EXACT total
     /// decision the position-delta body dispatches on. `delta != 0` is enforced
@@ -15688,14 +15715,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             0
         };
         let account_capital = account.header.capital.get();
-        let payout = account_capital
-            .checked_add(pnl_payout)
-            .ok_or(V16Error::ArithmeticOverflow)?
-            .min(self.header.vault.get());
-        let capital_paid = account_capital.min(payout);
-        let resolved_paid = payout
-            .checked_sub(capital_paid)
-            .ok_or(V16Error::CounterUnderflow)?;
+        let vault_before = self.header.vault.get();
+        let (payout, capital_paid, resolved_paid, vault_after, c_tot_after) =
+            V16Core::resolved_close_terminal_payout_delta(
+                account_capital,
+                pnl_payout,
+                vault_before,
+                self.header.c_tot.get(),
+            )?;
         if let Some(mut receipt) = payout_receipt {
             receipt = apply_resolved_payout_receipt_payment(receipt, resolved_paid)?;
             account.header.resolved_payout_receipt =
@@ -15705,20 +15732,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // (insolvency bad-debt shortfall is not an open obligation) so this close fully
         // settles instead of leaving the portfolio stuck present-but-unfinalized.
         self.clear_fully_diluted_resolved_receipt_if_terminal(account)?;
-        let vault_before = self.header.vault.get();
-        self.header.vault = V16PodU128::new(
-            self.header
-                .vault
-                .get()
-                .checked_sub(payout)
-                .ok_or(V16Error::CounterUnderflow)?,
-        );
-        self.header.c_tot = V16PodU128::new(
-            self.header
-                .c_tot
-                .get()
-                .saturating_sub(account_capital.min(self.header.c_tot.get())),
-        );
+        self.header.vault = V16PodU128::new(vault_after);
+        self.header.c_tot = V16PodU128::new(c_tot_after);
         self.set_account_pnl(account, 0)?;
         account.header.capital = V16PodU128::new(0);
         account.header.reserved_pnl = V16PodU128::new(0);

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -9838,13 +9838,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
-    fn create_account_source_credit_lien_for_effective_not_atomic(
+    // The allocating caller validates once before this per-domain core runs, and
+    // finish_trade_checks_not_atomic performs the committed-state audit afterward.
+    fn create_account_source_credit_lien_for_effective_core_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
         domain: usize,
         effective_credit: u128,
     ) -> V16Result<()> {
-        account.validate_with_market(&self.as_view())?;
         self.domain_asset_side(domain)?;
         if effective_credit == 0 {
             return Ok(());
@@ -9869,7 +9870,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             self.header.current_slot.get(),
         )?;
         account.header.health_cert.valid = 0;
-        account.validate_with_market(&self.as_view())
+        Ok(())
     }
 
     fn create_account_source_credit_lien_for_effective_any_not_atomic(
@@ -9903,7 +9904,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 let by_backing = self.source_credit_available_backing_num(d)? / BOUND_SCALE;
                 let take = remaining.min(by_claim).min(by_backing);
                 if take != 0 {
-                    self.create_account_source_credit_lien_for_effective_not_atomic(
+                    self.create_account_source_credit_lien_for_effective_core_not_atomic(
                         account, d, take,
                     )?;
                     remaining -= take;

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1436,6 +1436,17 @@ impl V16Core {
         Ok((long_reduction_q, short_reduction_q))
     }
 
+    /// PRODUCTION KERNEL: cap unilateral close work by the account's stored
+    /// basis and by matched effective OI. Liquidation and owner rebalance share
+    /// this bound so neither can subtract more OI than either side contains.
+    fn kernel_unilateral_close_capacity(
+        stored_abs: u128,
+        oi_eff_long_q: u128,
+        oi_eff_short_q: u128,
+    ) -> u128 {
+        stored_abs.min(oi_eff_long_q).min(oi_eff_short_q)
+    }
+
     /// PRODUCTION KERNEL (roadmap 3A.2 risk-reduction / S-L3, A5.dec rank): the
     /// position-reduction core of liquidation/rebalance. Clamps the requested
     /// close to the leg and produces the toward-zero signed delta:
@@ -13691,9 +13702,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
 
     fn unilateral_close_capacity(&self, asset_index: usize, stored_abs: u128) -> V16Result<u128> {
         let asset = self.asset_state(asset_index)?;
-        Ok(stored_abs
-            .min(asset.oi_eff_long_q)
-            .min(asset.oi_eff_short_q))
+        Ok(V16Core::kernel_unilateral_close_capacity(
+            stored_abs,
+            asset.oi_eff_long_q,
+            asset.oi_eff_short_q,
+        ))
     }
 
     fn begin_side_reset_if_effective_oi_exhausted(

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -512,6 +512,26 @@ impl MarketGroupV16HeaderAccount {
 }
 
 impl<'a, T> MarketGroupV16ViewMut<'a, T> {
+    pub fn kani_kernel_unilateral_close_capacity(
+        stored_abs: u128,
+        oi_eff_long_q: u128,
+        oi_eff_short_q: u128,
+    ) -> u128 {
+        V16Core::kernel_unilateral_close_capacity(stored_abs, oi_eff_long_q, oi_eff_short_q)
+    }
+
+    pub fn kani_kernel_reduce_position_delta(
+        pre_basis_signed: i128,
+        side: SideV16,
+        requested: u128,
+    ) -> V16Result<(u128, i128)> {
+        V16Core::kernel_reduce_position_delta(pre_basis_signed, side, requested)
+    }
+
+    pub fn kani_leg_has_exhausted_effective_oi(asset: AssetStateV16, leg: PortfolioLegV16) -> bool {
+        Self::leg_has_exhausted_effective_oi(asset, leg)
+    }
+
     pub fn kani_clear_leg(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -1139,6 +1139,20 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.create_resolved_payout_receipt_if_needed(account)
     }
 
+    pub fn kani_resolved_close_terminal_payout_delta(
+        account_capital: u128,
+        resolved_claimable: u128,
+        vault: u128,
+        c_tot: u128,
+    ) -> V16Result<(u128, u128, u128, u128, u128)> {
+        V16Core::resolved_close_terminal_payout_delta(
+            account_capital,
+            resolved_claimable,
+            vault,
+            c_tot,
+        )
+    }
+
     pub fn kani_claim_resolved_payout_topup_core_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -1118,11 +1118,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Self::resolved_receipt_claimable_against_ledger(receipt, ledger)
     }
 
-    pub fn kani_realize_source_backed_claims_for_resolved_close_not_atomic(
+    pub fn kani_prepare_one_source_domain_for_resolved_close_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
-    ) -> V16Result<u128> {
-        self.realize_source_backed_claims_for_resolved_close_not_atomic(account)
+    ) -> V16Result<Option<usize>> {
+        self.prepare_one_source_domain_for_resolved_close_not_atomic(account)
+    }
+
+    pub fn kani_process_one_source_claim_for_resolved_close_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+    ) -> V16Result<Option<usize>> {
+        self.process_one_source_claim_for_resolved_close_not_atomic(account)
     }
 
     pub fn kani_create_resolved_payout_receipt_if_needed(

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -13,6 +13,40 @@ pub fn kani_auto_crank_lifecycle_dispatchable(lifecycle: AssetLifecycleV16) -> b
     V16Core::kernel_auto_crank_lifecycle_dispatchable(lifecycle)
 }
 
+pub fn kani_auto_crank_leg_flags(
+    active: bool,
+    lifecycle: AssetLifecycleV16,
+    basis_pos_q: i128,
+    side_oi_q: u128,
+    side_mode: SideModeV16,
+    asset_epoch: u64,
+    leg_epoch_snap: u64,
+    leg_b_stale: bool,
+) -> (bool, bool, bool, bool) {
+    V16Core::kernel_auto_crank_leg_flags(
+        active,
+        lifecycle,
+        basis_pos_q,
+        side_oi_q,
+        side_mode,
+        asset_epoch,
+        leg_epoch_snap,
+        leg_b_stale,
+    )
+}
+
+pub fn kani_should_clear_prior_reset_obligation(
+    already_cleared: bool,
+    prior_reset_obligation: bool,
+    pending_close_residual: bool,
+) -> bool {
+    V16Core::kernel_should_clear_prior_reset_obligation(
+        already_cleared,
+        prior_reset_obligation,
+        pending_close_residual,
+    )
+}
+
 pub fn kani_first_actionable_slot(flags: [bool; V16_MAX_PORTFOLIO_ASSETS_N]) -> Option<usize> {
     V16Core::first_actionable_slot(flags)
 }

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -1770,7 +1770,7 @@ pub enum TradeRejectReasonV16 {
 pub struct ResolvedCloseRankV16 {
     pub b_stale: bool,           // outstanding B settlement
     pub negative_pnl: bool,      // unsettled negative PnL
-    pub active_leg: bool,        // an open leg remains
+    pub active_leg_count: u32,   // exact number of open legs remaining
     pub receipt_claim: bool,     // an unpaid resolved receipt claim
     pub capital: bool,           // residual capital to disburse
     pub recovery_required: bool, // the explicit recovery predicate holds
@@ -1779,7 +1779,11 @@ pub struct ResolvedCloseRankV16 {
 impl ResolvedCloseRankV16 {
     #[cfg_attr(not(kani), allow(dead_code))] // PROOF-ONLY: used by kernel_resolved_close_progress (fidelity model)
     pub fn has_pending(self) -> bool {
-        self.b_stale || self.negative_pnl || self.active_leg || self.receipt_claim || self.capital
+        self.b_stale
+            || self.negative_pnl
+            || self.active_leg_count != 0
+            || self.receipt_claim
+            || self.capital
     }
 }
 
@@ -2022,14 +2026,14 @@ impl V16Core {
     /// PRODUCTION FIDELITY BUILDER (roadmap 3C step 3, A7 close-rank): map the
     /// real resolved-close per-component signals to the compact rank summary that
     /// kernel_resolved_close_progress classifies. Each rank flag is EXACTLY its
-    /// production predicate — b-stale bit, negative PnL, a live leg (non-empty
-    /// active bitmap), residual capital, an open receipt, and the explicit
+    /// production predicate — b-stale bit, negative PnL, the exact active-bitmap
+    /// population count, residual capital, an open receipt, and the explicit
     /// recovery predicate — so the close-rank summary faithfully represents the
     /// real account/market state (no hidden pending component outside it). Pure.
     #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|r: &ResolvedCloseRankV16| {
         r.b_stale == b_stale
             && r.negative_pnl == (pnl < 0)
-            && r.active_leg == !active_bitmap_is_empty(active_bitmap)
+            && r.active_leg_count == active_bitmap_count_ones(active_bitmap)
             && r.capital == (capital > 0)
             && r.receipt_claim == receipt_present
             && r.recovery_required == recovery_required
@@ -2046,7 +2050,7 @@ impl V16Core {
         ResolvedCloseRankV16 {
             b_stale,
             negative_pnl: pnl < 0,
-            active_leg: !active_bitmap_is_empty(active_bitmap),
+            active_leg_count: active_bitmap_count_ones(active_bitmap),
             capital: capital > 0,
             receipt_claim: receipt_present,
             recovery_required,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -532,6 +532,20 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Self::leg_has_exhausted_effective_oi(asset, leg)
     }
 
+    pub fn kani_kernel_begin_full_drain_reset(
+        asset: AssetStateV16,
+        side: SideV16,
+    ) -> V16Result<AssetStateV16> {
+        V16Core::kernel_begin_full_drain_reset(asset, side)
+    }
+
+    pub fn kani_kernel_clear_leg(
+        leg: PortfolioLegV16,
+        asset: AssetStateV16,
+    ) -> V16Result<AssetStateV16> {
+        V16Core::kernel_clear_leg(leg, asset)
+    }
+
     pub fn kani_clear_leg(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -777,6 +777,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         V16Core::prepare_counterparty_backing_withdraw_delta(bucket, source, amount)
     }
 
+    pub fn kani_prepare_counterparty_backing_expiry_delta(
+        bucket: BackingBucketV16,
+        source: SourceCreditStateV16,
+        now_slot: u64,
+    ) -> V16Result<(BackingBucketV16, SourceCreditStateV16)> {
+        V16Core::prepare_counterparty_backing_expiry_delta(bucket, source, now_slot)
+    }
+
     pub fn kani_source_credit_lien_amounts_for_effective(
         effective_credit: u128,
         credit_rate_num: u128,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -728,6 +728,30 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         )
     }
 
+    pub fn kani_apply_insurance_source_credit_lien_delta(
+        source: &mut PortfolioSourceDomainV16Account,
+        required_face_num: u128,
+        required_backing_num: u128,
+        effective_credit: u128,
+        current_slot: u64,
+    ) -> V16Result<()> {
+        Self::apply_account_source_credit_lien_delta(
+            source,
+            SourceCreditBackingSourceV16::Insurance,
+            required_face_num,
+            required_backing_num,
+            effective_credit,
+            current_slot,
+        )
+    }
+
+    pub fn kani_validate_account_source_credit_lien_entry(
+        source: PortfolioSourceDomainV16Account,
+        domain: usize,
+    ) -> V16Result<()> {
+        PortfolioV16View::source_credit_lien_aggregate_proof(source, domain)?.validate()
+    }
+
     pub fn kani_prepare_counterparty_lien_create_delta(
         bucket: BackingBucketV16,
         source: SourceCreditStateV16,
@@ -790,6 +814,20 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         credit_rate_num: u128,
     ) -> V16Result<(u128, u128)> {
         V16Core::source_credit_lien_amounts_for_effective(effective_credit, credit_rate_num)
+    }
+
+    pub fn kani_source_credit_lien_allocation_take(
+        remaining: u128,
+        unliened_face_num: u128,
+        available_backing_num: u128,
+        credit_rate_num: u128,
+    ) -> V16Result<u128> {
+        V16Core::source_credit_lien_allocation_take(
+            remaining,
+            unliened_face_num,
+            available_backing_num,
+            credit_rate_num,
+        )
     }
 
     pub fn kani_counterparty_cure_atoms_from_scaled_backing(amount: u128) -> V16Result<u128> {

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -9,6 +9,30 @@
 use super::*;
 use crate::wide_math::U256;
 
+pub fn kani_auto_crank_lifecycle_dispatchable(lifecycle: AssetLifecycleV16) -> bool {
+    V16Core::kernel_auto_crank_lifecycle_dispatchable(lifecycle)
+}
+
+pub fn kani_first_actionable_slot(flags: [bool; V16_MAX_PORTFOLIO_ASSETS_N]) -> Option<usize> {
+    V16Core::first_actionable_slot(flags)
+}
+
+pub fn kani_select_auto_crank_plan(
+    summary: ActionableSummaryV16,
+    b_stale_slot: usize,
+    liq_slot: usize,
+    refresh_asset: Option<usize>,
+    recovery_reason: PermissionlessRecoveryReasonV16,
+) -> AutoCrankPlanV16 {
+    V16Core::select_auto_crank_plan(
+        summary,
+        b_stale_slot,
+        liq_slot,
+        refresh_asset,
+        recovery_reason,
+    )
+}
+
 pub fn kani_apply_backing_utilization_fee_charge(
     account_capital: u128,
     group_c_tot: u128,

--- a/src/v16_proofs.rs
+++ b/src/v16_proofs.rs
@@ -2488,8 +2488,8 @@ fn contract_check_kernel_cert_is_current() {
 
 // ROADMAP 3C step 3 (A7 close-rank fidelity): full-domain contract check that
 // build_resolved_close_rank maps each real per-component signal to its rank flag
-// (b-stale, negative PnL, live leg via non-empty bitmap, capital, receipt,
-// recovery). unwind(16): the active-bitmap is-empty scan / memcmp.
+// (b-stale, negative PnL, exact live-leg count, capital, receipt,
+// recovery). unwind(16): the active-bitmap population scan.
 #[cfg(all(kani, feature = "contracts"))]
 #[kani::proof_for_contract(V16Core::build_resolved_close_rank)]
 #[kani::unwind(16)]

--- a/tests/backing_double_claim_fuzz.rs
+++ b/tests/backing_double_claim_fuzz.rs
@@ -16,7 +16,7 @@ use percolator::{
     Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PortfolioAccountV16Account,
     PortfolioV16ViewMut, ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedCloseOutcomeV16,
     SourceCreditStateV16, SourceCreditStateV16Account, V16Config, V16PodI128, V16PodU128,
-    V16PodU32, V16PodU64, CREDIT_RATE_SCALE,
+    V16PodU32, V16PodU64, CREDIT_RATE_SCALE, PORTFOLIO_SOURCE_DOMAIN_CAP,
 };
 use proptest::prelude::*;
 
@@ -88,6 +88,26 @@ fn winner_account(capital: u128, pnl: u128) -> PortfolioAccountV16Account {
     account_header
 }
 
+/// Drive the bounded resolved-close state machine to its terminal outcome.
+/// A source domain needs at most three successful mutations: release a lien,
+/// expire lapsed backing, and settle its source/junior claim split.
+fn close_resolved_to_completion(
+    market: &mut MarketGroupV16ViewMut<'_, u64>,
+    account: &mut PortfolioV16ViewMut<'_>,
+) -> (u128, usize) {
+    let max_progress_steps = 3 * PORTFOLIO_SOURCE_DOMAIN_CAP;
+    for progress_steps in 0..=max_progress_steps {
+        match market
+            .close_resolved_account_not_atomic(account, 0)
+            .expect("resolved close step must not revert")
+        {
+            ResolvedCloseOutcomeV16::ProgressOnly => {}
+            ResolvedCloseOutcomeV16::Closed { payout } => return (payout, progress_steps),
+        }
+    }
+    panic!("resolved close exceeded its bounded source-domain progress rank")
+}
+
 /// Close the winner, then (optionally first) withdraw the provider principal.
 /// Returns (winner_payout, vault_after_everything).
 fn run_order(
@@ -110,11 +130,7 @@ fn run_order(
             .withdraw_fresh_counterparty_backing_not_atomic(0, backing)
             .expect("provider principal must be withdrawable before the winner closes");
     }
-    let outcome = market
-        .close_resolved_account_not_atomic(&mut account, 0)
-        .expect("winner close must not revert");
-    let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { .. });
-    assert!(closed, "winner did not fully close");
+    close_resolved_to_completion(&mut market, &mut account);
     if !provider_first {
         market
             .withdraw_fresh_counterparty_backing_not_atomic(0, backing)
@@ -230,11 +246,8 @@ proptest! {
         prop_assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
 
         let vault_before = market.header.vault.get();
-        let outcome = market
-            .close_resolved_account_not_atomic(&mut account, 0)
-            .expect("backed winner close must not revert");
-        let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { payout: _ });
-        prop_assert!(closed, "backed winner did not fully close");
+        let (_, progress_steps) = close_resolved_to_completion(&mut market, &mut account);
+        prop_assert!(progress_steps >= 1);
         let paid = vault_before - market.header.vault.get();
 
         // The Live-realizable portion of the claim must reach the winner...
@@ -325,11 +338,8 @@ proptest! {
         prop_assume!(account.validate_with_market(&market.as_view()) == Ok(()));
 
         let vault_before = market.header.vault.get();
-        let outcome = market
-            .close_resolved_account_not_atomic(&mut account, 0)
-            .expect("liened backed winner close must not revert");
-        let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { payout: _ });
-        prop_assert!(closed, "liened backed winner did not fully close");
+        let (_, progress_steps) = close_resolved_to_completion(&mut market, &mut account);
+        prop_assert!(progress_steps >= 2);
         let paid = vault_before - market.header.vault.get();
 
         // Fully backed claim realizes in full after the terminal lien release.
@@ -406,7 +416,8 @@ fn realization_after_snapshot_refines_unreceipted_bound() {
 
     // B realizes against its backing at terminal close.
     let vault_before_b = market.header.vault.get();
-    market.close_resolved_account_not_atomic(&mut b, 0).unwrap();
+    let (_, progress_steps) = close_resolved_to_completion(&mut market, &mut b);
+    assert!(progress_steps >= 1);
     assert_eq!(vault_before_b - market.header.vault.get(), pnl_b);
     assert_eq!(b.header.pnl.get(), 0);
     assert_eq!(b.header.capital.get(), 0);
@@ -457,11 +468,8 @@ fn terminal_close_with_expired_backing_does_not_strand() {
     assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
 
     let vault_before = market.header.vault.get();
-    let outcome = market
-        .close_resolved_account_not_atomic(&mut account, 0)
-        .expect("expired-backing winner close must not revert (liveness)");
-    let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { payout: _ });
-    assert!(closed, "expired-backing winner did not fully close");
+    let (_, progress_steps) = close_resolved_to_completion(&mut market, &mut account);
+    assert!(progress_steps >= 2);
     let paid = vault_before - market.header.vault.get();
 
     // Expiry forfeits the lapsed principal to the junior pool: the winner is
@@ -481,6 +489,91 @@ fn terminal_close_with_expired_backing_does_not_strand() {
     assert!(market
         .withdraw_fresh_counterparty_backing_not_atomic(0, backing)
         .is_err());
+    assert_eq!(market.validate_shape(), Ok(()));
+}
+
+#[test]
+fn resolved_close_receipts_two_source_domains_one_bounded_step_at_a_time() {
+    let claim_per_domain = 10u128;
+    let total_claim = 2 * claim_per_domain;
+    let cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_id(), cfg, 1, 0).unwrap();
+    let mut markets = [Market::new(0u64, EngineAssetSlotV16Account::default())];
+    header
+        .activate_empty_asset_slot_not_atomic(0, &mut markets[0].engine, 100, 1)
+        .unwrap();
+    header.mode = 1;
+    header.resolved_slot = V16PodU64::new(1);
+    header.current_slot = V16PodU64::new(1);
+    header.vault = V16PodU128::new(total_claim);
+    header.pnl_pos_tot = V16PodU128::new(total_claim);
+    header.pnl_matured_pos_tot = V16PodU128::new(total_claim);
+    header.pnl_pos_bound_tot = V16PodU128::new(total_claim);
+    header.pnl_pos_bound_tot_num = V16PodU128::new(total_claim * BOUND_SCALE);
+    header.source_claim_bound_total_num = V16PodU128::new(total_claim * BOUND_SCALE);
+
+    let domain_claim_num = claim_per_domain * BOUND_SCALE;
+    let source = SourceCreditStateV16 {
+        positive_claim_bound_num: domain_claim_num,
+        exact_positive_claim_num: domain_claim_num,
+        credit_rate_num: 0,
+        ..SourceCreditStateV16::EMPTY
+    };
+    markets[0].engine.source_credit_long = SourceCreditStateV16Account::from_runtime(&source);
+    markets[0].engine.source_credit_short = SourceCreditStateV16Account::from_runtime(&source);
+
+    let engine_market_id = markets[0].engine.asset.market_id.get();
+    let mut account_header = winner_account(0, total_claim);
+    for domain in 0..2usize {
+        account_header.source_domains[domain].domain = V16PodU32::new(domain as u32);
+        account_header.source_domains[domain].source_claim_market_id =
+            V16PodU64::new(engine_market_id);
+        account_header.source_domains[domain].source_claim_bound_num =
+            V16PodU128::new(domain_claim_num);
+    }
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    assert_eq!(market.validate_shape(), Ok(()));
+    assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
+
+    for remaining_domains in [1usize, 0usize] {
+        assert_eq!(
+            market.close_resolved_account_not_atomic(&mut account, 0),
+            Ok(ResolvedCloseOutcomeV16::ProgressOnly),
+        );
+        let occupied = account
+            .header
+            .source_domains
+            .iter()
+            .filter(|source| source.source_claim_bound_num.get() != 0)
+            .count();
+        assert_eq!(occupied, remaining_domains);
+        assert_eq!(
+            account.header.pnl.get(),
+            (remaining_domains as i128) * (claim_per_domain as i128),
+        );
+        let receipt = account
+            .header
+            .resolved_payout_receipt
+            .try_to_runtime()
+            .unwrap();
+        assert_eq!(
+            receipt.terminal_positive_claim_face,
+            (2 - remaining_domains as u128) * claim_per_domain,
+        );
+        assert_eq!(market.validate_shape(), Ok(()));
+        assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
+    }
+
+    assert_eq!(
+        market.close_resolved_account_not_atomic(&mut account, 0),
+        Ok(ResolvedCloseOutcomeV16::Closed {
+            payout: total_claim,
+        }),
+    );
+    assert_eq!(market.header.vault.get(), 0);
+    assert_eq!(account.header.pnl.get(), 0);
     assert_eq!(market.validate_shape(), Ok(()));
 }
 
@@ -511,12 +604,8 @@ proptest! {
         prop_assume!(account.validate_with_market(&market.as_view()) == Ok(()));
 
         let vault_before = market.header.vault.get();
-        let outcome = market
-            .close_resolved_account_not_atomic(&mut account, 0)
-            .expect("backed winner close must not revert at any backing level (no DoS)");
-        // No DoS: the close fully settles rather than stalling.
-        let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { payout: _ });
-        prop_assert!(closed, "close did not finalize at backing={}", backing);
+        let (_, progress_steps) = close_resolved_to_completion(&mut market, &mut account);
+        prop_assert!(progress_steps >= 1);
         let paid = vault_before - market.header.vault.get();
 
         // No LoF: value conserved (paid out of the vault, nothing minted),

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -32,7 +32,7 @@ use percolator::v16::{
     ResolvedPayoutLedgerV16, ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16,
     ResolvedPayoutReceiptV16Account, SideModeV16, SideV16, SourceCreditStateV16,
     SourceCreditStateV16Account, StockReconciliationProofV16, TokenValueClassV16,
-    TokenValueFlowProofV16, V16Config, V16ConfigAccount, V16Error,
+    TokenValueFlowProofV16, TradeRequestV16, V16Config, V16ConfigAccount, V16Error,
     V16OptionalRecoveryReasonAccount, V16PodI128, V16PodU128, V16PodU32, V16PodU64,
     BACKING_FEE_RATE_DEN_E9, MAX_BACKING_FEE_RATE_E9_PER_SLOT, MAX_BACKING_FEE_UTIL_BPS,
     PORTFOLIO_SOURCE_DOMAIN_CAP, V16_EMPTY_ACTIVE_BITMAP, V16_MAX_PORTFOLIO_ASSETS_N,
@@ -8649,37 +8649,51 @@ fn proof_v16_two_resolved_receipts_are_order_independent_when_snapshot_funded() 
 }
 
 #[kani::proof]
-#[kani::unwind(40)]
+#[kani::unwind(8)]
 #[kani::solver(cadical)]
-fn proof_v16_public_resolved_close_flat_account_pays_only_capital_and_vault() {
-    let capital_raw: u8 = kani::any();
-    kani::assume((1..=5).contains(&capital_raw));
-    let capital = capital_raw as u128;
-    let (mut header, mut markets, mut account_header) = one_market_view_fixture();
-    header.mode = 1;
-    header.current_slot = V16PodU64::new(2);
-    header.resolved_slot = V16PodU64::new(2);
-    header.vault = V16PodU128::new(capital);
-    header.c_tot = V16PodU128::new(capital);
-    account_header.capital = V16PodU128::new(capital);
-    account_header.pnl = V16PodI128::new(0);
-    account_header.last_fee_slot = V16PodU64::new(2);
-    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
-    let mut account = PortfolioV16ViewMut::new(&mut account_header);
-
-    let outcome = market
-        .close_resolved_account_not_atomic(&mut account, 0)
+fn proof_v16_resolved_close_terminal_payout_conserves_vault_and_value_classes() {
+    let account_capital = kani::any::<u64>() as u128;
+    let resolved_claimable = kani::any::<u64>() as u128;
+    let vault = kani::any::<u64>() as u128;
+    let c_tot = kani::any::<u64>() as u128;
+    kani::assume(account_capital <= MAX_VAULT_TVL);
+    kani::assume(resolved_claimable <= MAX_VAULT_TVL);
+    kani::assume(vault <= MAX_VAULT_TVL);
+    kani::assume(c_tot <= MAX_VAULT_TVL);
+    let (payout, capital_paid, resolved_paid, vault_after, c_tot_after) =
+        MarketGroupV16ViewMut::<u64>::kani_resolved_close_terminal_payout_delta(
+            account_capital,
+            resolved_claimable,
+            vault,
+            c_tot,
+        )
         .unwrap();
 
-    kani::cover!(capital > 1, "resolved flat close pays nontrivial capital");
-    assert_eq!(outcome, ResolvedCloseOutcomeV16::Closed { payout: capital });
-    assert_eq!(market.header.vault.get(), 0);
-    assert_eq!(market.header.c_tot.get(), 0);
-    assert_eq!(account.header.capital.get(), 0);
-    assert_eq!(account.header.pnl.get(), 0);
-    assert_eq!(account.header.reserved_pnl.get(), 0);
-    assert_eq!(market.validate_shape(), Ok(()));
-    assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
+    kani::cover!(
+        vault < account_capital && vault > 0,
+        "scarce vault pays only part of account capital"
+    );
+    kani::cover!(
+        vault > account_capital && vault < account_capital + resolved_claimable,
+        "scarce vault pays capital plus part of the resolved claim"
+    );
+    kani::cover!(
+        vault >= account_capital + resolved_claimable
+            && account_capital > 0
+            && resolved_claimable > 0,
+        "funded vault pays both value classes in full"
+    );
+
+    assert_eq!(payout, (account_capital + resolved_claimable).min(vault));
+    assert_eq!(capital_paid + resolved_paid, payout);
+    assert!(capital_paid <= account_capital);
+    assert!(resolved_paid <= resolved_claimable);
+    assert_eq!(vault_after + payout, vault);
+    assert_eq!(c_tot_after + account_capital.min(c_tot), c_tot);
+    if vault >= account_capital + resolved_claimable {
+        assert_eq!(capital_paid, account_capital);
+        assert_eq!(resolved_paid, resolved_claimable);
+    }
 }
 
 #[kani::proof]

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -5,20 +5,21 @@ use percolator::v16::{
     backing_domain_fee_split_for_lien_delta_num, kani_active_bitmap_set as active_bitmap_set,
     kani_add_open_interest_for_new_position, kani_apply_backing_provider_earnings_withdraw,
     kani_apply_backing_utilization_fee_charge, kani_apply_resolved_payout_receipt_payment,
-    kani_available_backing_num_for_source_credit_state,
+    kani_auto_crank_lifecycle_dispatchable, kani_available_backing_num_for_source_credit_state,
     kani_backing_utilization_fee_quote_atoms_for_lien,
     kani_backing_utilization_rate_e9_for_source_state, kani_cert_is_current,
-    kani_expected_source_credit_rate_num_for_state, kani_health_cert_after_capital_debit,
-    kani_health_requirements_from_base_and_target_lag,
+    kani_expected_source_credit_rate_num_for_state, kani_first_actionable_slot,
+    kani_health_cert_after_capital_debit, kani_health_requirements_from_base_and_target_lag,
     kani_liquidation_close_would_leave_uncovered_loss_with_open_risk,
     kani_liquidation_engine_close_request_q, kani_liquidation_fee_from_raw_fee,
     kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
     kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
-    kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
-    kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
-    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
-    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
+    kani_prepare_asset_recovery_transition, kani_select_auto_crank_plan,
+    kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
+    kani_trade_preexisting_oi_reduction_gate, kani_trade_preflight_risk_gate,
+    kani_validate_positive_pnl_source_attribution, ActionableSummaryV16, AssetLifecycleV16,
+    AssetStateV16, AssetStateV16Account, AutoCrankPlanV16, BackingBucketStatusV16,
     BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
     CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
     HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
@@ -15401,4 +15402,147 @@ fn proof_v16_backing_utilization_zero_fee_carries_accrual_forward() {
     assert_eq!(market.header.c_tot.get(), c_tot_before);
     assert_eq!(market.header.vault.get(), vault_before);
     assert_eq!(market.header.insurance.get(), insurance_before);
+}
+
+// Permissionless mixed-lifecycle liveness theorem. Symbolic masks cover every
+// ordering and multiplicity across the full 16-leg account shape. Recovery
+// obligations must never be selected as ordinary refresh/liquidation targets;
+// when any Active or DrainOnly leg exists, first-match selection and both plans
+// must carry a dispatchable leg. Recovery-only portfolios advertise no fake
+// liquidation target.
+#[kani::proof]
+#[kani::unwind(18)]
+#[kani::solver(cadical)]
+fn proof_v16_recovery_legs_cannot_starve_dispatchable_auto_crank_work() {
+    let recovery_mask: u16 = kani::any();
+    let active_mask: u16 = kani::any();
+    let drain_only_mask: u16 = kani::any();
+    kani::assume(recovery_mask != 0);
+    kani::assume(recovery_mask & active_mask == 0);
+    kani::assume(recovery_mask & drain_only_mask == 0);
+    kani::assume(active_mask & drain_only_mask == 0);
+
+    let dispatchable_mask = active_mask | drain_only_mask;
+    let mut dispatchable_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+    let mut slot = 0usize;
+    while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+        let bit = 1u16 << slot;
+        let lifecycle = if recovery_mask & bit != 0 {
+            AssetLifecycleV16::Recovery
+        } else if active_mask & bit != 0 {
+            AssetLifecycleV16::Active
+        } else if drain_only_mask & bit != 0 {
+            AssetLifecycleV16::DrainOnly
+        } else {
+            AssetLifecycleV16::Retired
+        };
+        let dispatchable = kani_auto_crank_lifecycle_dispatchable(lifecycle);
+        assert_eq!(dispatchable, dispatchable_mask & bit != 0);
+        dispatchable_flags[slot] = dispatchable;
+        slot += 1;
+    }
+
+    let selected = kani_first_actionable_slot(dispatchable_flags);
+    let mut recovery_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+    slot = 0;
+    while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+        recovery_flags[slot] = recovery_mask & (1u16 << slot) != 0;
+        slot += 1;
+    }
+    let first_recovery = kani_first_actionable_slot(recovery_flags).unwrap();
+
+    if dispatchable_mask == 0 {
+        assert!(selected.is_none());
+        let plan = kani_select_auto_crank_plan(
+            ActionableSummaryV16 {
+                stale: false,
+                b_stale: false,
+                pending_close: false,
+                expired_close: false,
+                liquidatable: false,
+                recovery_eligible: false,
+                resolved_winner: false,
+            },
+            0,
+            0,
+            None,
+            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+        );
+        assert_eq!(plan, AutoCrankPlanV16::NoAction);
+    } else {
+        let selected = selected.unwrap();
+        let selected_bit = 1u16 << selected;
+        assert!(dispatchable_mask & selected_bit != 0);
+        assert!(recovery_mask & selected_bit == 0);
+        slot = 0;
+        while slot < selected {
+            assert!(dispatchable_mask & (1u16 << slot) == 0);
+            slot += 1;
+        }
+
+        let refresh = kani_select_auto_crank_plan(
+            ActionableSummaryV16 {
+                stale: true,
+                b_stale: false,
+                pending_close: false,
+                expired_close: false,
+                liquidatable: false,
+                recovery_eligible: false,
+                resolved_winner: false,
+            },
+            0,
+            selected,
+            Some(selected),
+            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+        );
+        assert_eq!(
+            refresh,
+            AutoCrankPlanV16::RefreshAccount {
+                asset_index: Some(selected)
+            }
+        );
+        let liquidate = kani_select_auto_crank_plan(
+            ActionableSummaryV16 {
+                stale: false,
+                b_stale: false,
+                pending_close: false,
+                expired_close: false,
+                liquidatable: true,
+                recovery_eligible: false,
+                resolved_winner: false,
+            },
+            0,
+            selected,
+            Some(selected),
+            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+        );
+        assert_eq!(
+            liquidate,
+            AutoCrankPlanV16::Liquidate {
+                asset_index: selected
+            }
+        );
+
+        kani::cover!(
+            first_recovery < selected,
+            "Recovery obligation can precede dispatchable work"
+        );
+        kani::cover!(
+            selected < first_recovery,
+            "dispatchable work can precede Recovery obligation"
+        );
+        kani::cover!(
+            active_mask & selected_bit != 0,
+            "Active candidate is selected"
+        );
+        kani::cover!(
+            drain_only_mask & selected_bit != 0,
+            "DrainOnly candidate is selected"
+        );
+    }
+
+    kani::cover!(
+        dispatchable_mask == 0,
+        "Recovery-only account has no fake liquidation target"
+    );
 }

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -15728,3 +15728,89 @@ fn proof_v16_prior_reset_cleanup_cannot_starve_live_liquidation() {
     assert!(!kani_should_clear_prior_reset_obligation(false, true, true));
     assert!(!kani_should_clear_prior_reset_obligation(true, true, false));
 }
+
+// Shared liquidation/rebalance theorem for partially ADL-reduced positions.
+// Live assets have equal effective OI on both sides, while an account's stored
+// basis can be larger. The production capacity must prevent OI underflow and
+// make the resulting zero-OI residue permissionlessly actionable.
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_unilateral_close_capacity_is_safe_progress_and_residue_complete() {
+    let side = if kani::any::<bool>() {
+        SideV16::Long
+    } else {
+        SideV16::Short
+    };
+    let stored_abs: u128 = kani::any();
+    let matched_oi: u128 = kani::any();
+    let request: u128 = kani::any();
+    kani::assume((1..=MAX_POSITION_ABS_Q).contains(&stored_abs));
+    kani::assume((1..=MAX_OI_SIDE_Q).contains(&matched_oi));
+    kani::assume(request > 0);
+
+    let capacity = MarketGroupV16ViewMut::<u64>::kani_kernel_unilateral_close_capacity(
+        stored_abs, matched_oi, matched_oi,
+    );
+    let work = request.min(capacity);
+    let pre_basis_signed = match side {
+        SideV16::Long => stored_abs as i128,
+        SideV16::Short => -(stored_abs as i128),
+    };
+    let (reduced_q, delta) = MarketGroupV16ViewMut::<u64>::kani_kernel_reduce_position_delta(
+        pre_basis_signed,
+        side,
+        work,
+    )
+    .unwrap();
+    let expected = request.min(stored_abs).min(matched_oi);
+    let post_basis_signed = pre_basis_signed.checked_add(delta).unwrap();
+    let long_oi_after = matched_oi.checked_sub(reduced_q).unwrap();
+    let short_oi_after = matched_oi.checked_sub(reduced_q).unwrap();
+
+    assert_eq!(capacity, stored_abs.min(matched_oi));
+    assert_eq!(reduced_q, expected);
+    assert!(reduced_q > 0);
+    assert!(reduced_q <= stored_abs);
+    assert!(reduced_q <= matched_oi);
+    assert_eq!(post_basis_signed.unsigned_abs(), stored_abs - reduced_q);
+    assert!(
+        post_basis_signed == 0 || post_basis_signed.signum() == pre_basis_signed.signum(),
+        "risk reduction cannot flip the user's side"
+    );
+
+    if request >= capacity && stored_abs > matched_oi {
+        assert_eq!(long_oi_after, 0);
+        assert_eq!(short_oi_after, 0);
+        assert_ne!(post_basis_signed, 0);
+        let mut asset = AssetStateV16::default();
+        asset.oi_eff_long_q = long_oi_after;
+        asset.oi_eff_short_q = short_oi_after;
+        match side {
+            SideV16::Long => asset.stored_pos_count_long = 1,
+            SideV16::Short => asset.stored_pos_count_short = 1,
+        }
+        let leg = PortfolioLegV16 {
+            active: true,
+            side,
+            basis_pos_q: post_basis_signed,
+            ..PortfolioLegV16::EMPTY
+        };
+        assert!(
+            MarketGroupV16ViewMut::<u64>::kani_leg_has_exhausted_effective_oi(asset, leg),
+            "a nonzero basis after matched OI exhaustion must remain crank-actionable"
+        );
+    }
+
+    kani::cover!(side == SideV16::Long, "capacity covers long reductions");
+    kani::cover!(side == SideV16::Short, "capacity covers short reductions");
+    kani::cover!(request < capacity, "capacity covers partial requested work");
+    kani::cover!(
+        request >= capacity && stored_abs > matched_oi,
+        "capacity covers an ADL terminal residue"
+    );
+    kani::cover!(
+        request >= capacity && stored_abs <= matched_oi,
+        "capacity covers a full account close"
+    );
+}

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -10133,6 +10133,204 @@ fn proof_v16_view_initial_margin_source_lien_creation_is_backed() {
 }
 
 #[kani::proof]
+#[kani::unwind(16)]
+#[kani::solver(cadical)]
+fn proof_v16_source_lien_allocation_plan_is_complete_bounded_and_ordered() {
+    let claim_raw: [u8; PORTFOLIO_SOURCE_DOMAIN_CAP] = kani::any();
+    let backing_raw: [u8; PORTFOLIO_SOURCE_DOMAIN_CAP] = kani::any();
+    let rate_raw: [u8; PORTFOLIO_SOURCE_DOMAIN_CAP] = kani::any();
+    let request_raw: u8 = kani::any();
+    let request = (request_raw & 31) as u128;
+    let mut remaining = request;
+    let mut total_capacity = 0u128;
+    let mut domain = 0usize;
+    let mut touched = 0usize;
+    let mut used_fractional_rate = false;
+    while domain < PORTFOLIO_SOURCE_DOMAIN_CAP {
+        let claim = (claim_raw[domain] & 7) as u128;
+        let backing = (backing_raw[domain] & 7) as u128;
+        let rate_code = rate_raw[domain] & 3;
+        let rate = if rate_code == 3 {
+            0
+        } else {
+            CREDIT_RATE_SCALE >> rate_code
+        };
+        let claim_capacity = claim * rate / CREDIT_RATE_SCALE;
+        let capacity = claim_capacity.min(backing);
+        let take = MarketGroupV16ViewMut::<u64>::kani_source_credit_lien_allocation_take(
+            remaining,
+            claim * BOUND_SCALE,
+            backing * BOUND_SCALE,
+            rate,
+        )
+        .unwrap();
+        assert_eq!(take, remaining.min(capacity));
+        assert!(take <= remaining);
+        assert!(take <= claim);
+        assert!(take <= backing);
+        if remaining == 0 {
+            assert_eq!(take, 0);
+        }
+        if take != 0 {
+            touched += 1;
+            used_fractional_rate |= rate != CREDIT_RATE_SCALE;
+        }
+        remaining -= take;
+        total_capacity += capacity;
+        domain += 1;
+    }
+
+    let allocated = request - remaining;
+    kani::cover!(request == 0, "zero source-credit request is the identity");
+    kani::cover!(
+        request > total_capacity && total_capacity > 0,
+        "insufficient aggregate backing exhausts every source"
+    );
+    kani::cover!(
+        request < total_capacity && touched > 1,
+        "allocation crosses source boundaries and stops with surplus"
+    );
+    kani::cover!(
+        touched == PORTFOLIO_SOURCE_DOMAIN_CAP,
+        "allocation can consume every bounded source"
+    );
+    kani::cover!(
+        used_fractional_rate && touched > 1,
+        "allocation composes independently haircutted sources"
+    );
+    assert_eq!(allocated, request.min(total_capacity));
+    assert_eq!(remaining, request.saturating_sub(total_capacity));
+}
+
+#[kani::proof]
+#[kani::unwind(64)]
+#[kani::solver(cadical)]
+fn proof_v16_source_lien_entry_relabel_preserves_persisted_aggregate_invariant() {
+    let pre_effective = (kani::any::<u8>() & 7) as u128;
+    let added_effective = 1 + (kani::any::<u8>() & 3) as u128;
+    let claim_slack = (kani::any::<u8>() & 7) as u128;
+    let pre_counterparty: bool = kani::any();
+    let add_counterparty: bool = kani::any();
+    let current_slot = 2 + (kani::any::<u8>() & 7) as u64;
+    let pre_num = pre_effective * BOUND_SCALE;
+    let added_num = added_effective * BOUND_SCALE;
+    let claim_bound_num = (pre_effective + added_effective + claim_slack) * BOUND_SCALE;
+    let pre_counterparty_num = if pre_counterparty { pre_num } else { 0 };
+    let pre_insurance_num = if pre_counterparty { 0 } else { pre_num };
+    let prior_fee_slot = if pre_counterparty_num == 0 {
+        0
+    } else {
+        current_slot - 1
+    };
+    let mut source = PortfolioSourceDomainV16Account {
+        domain: V16PodU32::new(1),
+        source_claim_market_id: V16PodU64::new(9),
+        source_claim_bound_num: V16PodU128::new(claim_bound_num),
+        source_claim_liened_num: V16PodU128::new(pre_num),
+        source_claim_counterparty_liened_num: V16PodU128::new(pre_counterparty_num),
+        source_claim_insurance_liened_num: V16PodU128::new(pre_insurance_num),
+        source_lien_effective_reserved: V16PodU128::new(pre_effective),
+        source_lien_counterparty_backing_num: V16PodU128::new(pre_counterparty_num),
+        source_lien_insurance_backing_num: V16PodU128::new(pre_insurance_num),
+        source_lien_fee_last_slot: V16PodU64::new(prior_fee_slot),
+        ..PortfolioSourceDomainV16Account::default()
+    };
+    MarketGroupV16ViewMut::<u64>::kani_validate_account_source_credit_lien_entry(source, 1)
+        .unwrap();
+    let before = source;
+
+    if add_counterparty {
+        MarketGroupV16ViewMut::<u64>::kani_apply_counterparty_source_credit_lien_delta(
+            &mut source,
+            added_num,
+            added_num,
+            added_effective,
+            current_slot,
+        )
+        .unwrap();
+    } else {
+        MarketGroupV16ViewMut::<u64>::kani_apply_insurance_source_credit_lien_delta(
+            &mut source,
+            added_num,
+            added_num,
+            added_effective,
+            current_slot,
+        )
+        .unwrap();
+    }
+    MarketGroupV16ViewMut::<u64>::kani_validate_account_source_credit_lien_entry(source, 1)
+        .unwrap();
+
+    let added_counterparty_num = if add_counterparty { added_num } else { 0 };
+    let added_insurance_num = if add_counterparty { 0 } else { added_num };
+    kani::cover!(
+        pre_effective > 0 && pre_counterparty && add_counterparty,
+        "an existing counterparty lien can be extended"
+    );
+    kani::cover!(
+        pre_effective > 0 && !pre_counterparty && add_counterparty,
+        "a counterparty lien can be added beside an insurance lien"
+    );
+    kani::cover!(
+        pre_effective > 0 && pre_counterparty && !add_counterparty,
+        "an insurance lien can be added beside a counterparty lien"
+    );
+    kani::cover!(
+        pre_effective == 0 && claim_slack > 0,
+        "a first lien can reserve only part of a larger claim"
+    );
+    assert_eq!(source.domain, before.domain);
+    assert_eq!(source.source_claim_market_id, before.source_claim_market_id);
+    assert_eq!(source.source_claim_bound_num, before.source_claim_bound_num);
+    assert_eq!(source.source_claim_liened_num.get(), pre_num + added_num);
+    assert_eq!(
+        source.source_claim_counterparty_liened_num.get(),
+        pre_counterparty_num + added_counterparty_num
+    );
+    assert_eq!(
+        source.source_claim_insurance_liened_num.get(),
+        pre_insurance_num + added_insurance_num
+    );
+    assert_eq!(
+        source.source_lien_effective_reserved.get(),
+        pre_effective + added_effective
+    );
+    assert_eq!(
+        source.source_lien_counterparty_backing_num.get(),
+        pre_counterparty_num + added_counterparty_num
+    );
+    assert_eq!(
+        source.source_lien_insurance_backing_num.get(),
+        pre_insurance_num + added_insurance_num
+    );
+    assert_eq!(
+        source.source_lien_fee_last_slot.get(),
+        if add_counterparty && pre_counterparty_num == 0 {
+            current_slot
+        } else {
+            prior_fee_slot
+        }
+    );
+    assert_eq!(
+        source
+            .source_lien_counterparty_backing_num
+            .get()
+            .checked_add(source.source_lien_insurance_backing_num.get())
+            .unwrap(),
+        source.source_lien_effective_reserved.get() * BOUND_SCALE
+    );
+    assert!(source.source_claim_liened_num.get() <= source.source_claim_bound_num.get());
+    assert_eq!(
+        source.source_claim_impaired_num,
+        before.source_claim_impaired_num
+    );
+    assert_eq!(
+        source.source_lien_impaired_effective_reserved,
+        before.source_lien_impaired_effective_reserved
+    );
+}
+
+#[kani::proof]
 #[kani::unwind(48)]
 #[kani::solver(cadical)]
 fn proof_v16_public_counterparty_lien_create_moves_fresh_to_valid_without_value_movement() {

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -6394,105 +6394,108 @@ fn proof_v16_public_counterparty_backing_deposit_refills_expired_receivable_buck
 }
 
 #[kani::proof]
-#[kani::unwind(48)]
+#[kani::unwind(8)]
 #[kani::solver(cadical)]
-fn proof_v16_public_counterparty_backing_expiry_is_value_neutral_and_impairs_liened_backing() {
-    let fresh_raw: u8 = kani::any();
-    let liened_raw: u8 = kani::any();
-    kani::assume(fresh_raw <= 8);
-    kani::assume(liened_raw <= 8);
-    kani::assume(fresh_raw != 0 || liened_raw != 0);
-    let fresh_atoms = fresh_raw as u128;
-    let liened_atoms = liened_raw as u128;
+fn proof_v16_counterparty_backing_expiry_reclassifies_principal_and_impairs_lien() {
+    let fresh_atoms: u128 = kani::any();
+    let liened_atoms: u128 = kani::any();
+    kani::assume(fresh_atoms <= MAX_VAULT_TVL);
+    kani::assume(liened_atoms <= MAX_VAULT_TVL - fresh_atoms);
+    let total_atoms = fresh_atoms + liened_atoms;
+    kani::assume(total_atoms > 0);
     let fresh_num = fresh_atoms * BOUND_SCALE;
     let liened_num = liened_atoms * BOUND_SCALE;
-    let (mut header, mut markets) = one_market_only_fixture();
-    let market_id = markets[0].engine.asset.market_id.get();
-    header.vault = V16PodU128::new(fresh_atoms + liened_atoms);
-    header.source_fresh_backing_total_num = V16PodU128::new(fresh_num + liened_num);
-    markets[0].engine.backing_long = BackingBucketV16Account::from_runtime(&BackingBucketV16 {
-        market_id,
+    let bucket = BackingBucketV16 {
+        market_id: 1,
         fresh_unliened_backing_num: fresh_num,
         valid_liened_backing_num: liened_num,
         expiry_slot: 5,
         status: BackingBucketStatusV16::Fresh,
         ..BackingBucketV16::EMPTY
-    });
-    markets[0].engine.source_credit_long =
-        SourceCreditStateV16Account::from_runtime(&SourceCreditStateV16 {
-            fresh_reserved_backing_num: fresh_num + liened_num,
-            valid_liened_backing_num: liened_num,
-            credit_rate_num: CREDIT_RATE_SCALE,
-            ..SourceCreditStateV16::EMPTY
-        });
-    let vault_before = header.vault.get();
-    let c_tot_before = header.c_tot.get();
-    let insurance_before = header.insurance.get();
-    let risk_epoch_before = header.risk_epoch.get();
-    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
-    let residual_before = market.kani_residual();
-
-    market
-        .expire_source_backing_bucket_not_atomic(0, 10)
-        .unwrap();
-    let bucket = market.markets[0]
-        .engine
-        .backing_long
-        .try_to_runtime()
-        .unwrap();
-    let source = market.markets[0]
-        .engine
-        .source_credit_long
-        .try_to_runtime()
+    };
+    let source = SourceCreditStateV16 {
+        fresh_reserved_backing_num: fresh_num + liened_num,
+        valid_liened_backing_num: liened_num,
+        credit_rate_num: CREDIT_RATE_SCALE,
+        ..SourceCreditStateV16::EMPTY
+    };
+    let (bucket_after, source_after) =
+        MarketGroupV16ViewMut::<u64>::kani_prepare_counterparty_backing_expiry_delta(
+            bucket, source, 10,
+        )
         .unwrap();
 
     kani::cover!(
-        fresh_raw > 0 && liened_raw == 0,
-        "public backing expiry covers fresh-only expired bucket"
+        fresh_atoms > 0 && liened_atoms == 0,
+        "expiry reclassifies fresh-only backing"
     );
-    kani::cover!(
-        liened_raw > 0,
-        "public backing expiry covers liened backing impairment"
+    kani::cover!(liened_atoms > 0, "expiry impairs liened backing");
+    assert_eq!(bucket_after.fresh_unliened_backing_num, 0);
+    assert_eq!(bucket_after.valid_liened_backing_num, 0);
+    assert_eq!(bucket_after.impaired_liened_backing_num, liened_num);
+    assert_eq!(bucket_after.consumed_liened_backing_num, 0);
+    assert_eq!(source_after.fresh_reserved_backing_num, 0);
+    assert_eq!(source_after.valid_liened_backing_num, 0);
+    assert_eq!(source_after.impaired_liened_backing_num, liened_num);
+    assert_eq!(source_after.provider_receivable_num, 0);
+    assert_eq!(source_after.spent_backing_num, 0);
+    assert_eq!(source_after.credit_rate_num, CREDIT_RATE_SCALE);
+    assert_eq!(source_after.credit_epoch, source.credit_epoch);
+    assert_eq!(
+        source.fresh_reserved_backing_num - source_after.fresh_reserved_backing_num,
+        fresh_num + liened_num,
+        "all recoverable provider principal leaves the senior backing class"
     );
-    assert_eq!(market.header.vault.get(), vault_before);
-    assert_eq!(market.header.c_tot.get(), c_tot_before);
-    assert_eq!(market.header.insurance.get(), insurance_before);
-    assert_eq!(market.header.risk_epoch.get(), risk_epoch_before + 1);
-    assert_eq!(bucket.fresh_unliened_backing_num, 0);
-    assert_eq!(bucket.valid_liened_backing_num, 0);
-    assert_eq!(bucket.impaired_liened_backing_num, liened_num);
-    assert_eq!(bucket.consumed_liened_backing_num, 0);
-    assert_eq!(source.fresh_reserved_backing_num, 0);
-    assert_eq!(source.valid_liened_backing_num, 0);
-    assert_eq!(source.impaired_liened_backing_num, liened_num);
-    assert_eq!(source.provider_receivable_num, 0);
-    assert_eq!(source.spent_backing_num, 0);
-    assert_eq!(source.credit_rate_num, CREDIT_RATE_SCALE);
-    assert_eq!(source.credit_epoch, 1);
     if liened_num == 0 {
-        assert_eq!(bucket.status, BackingBucketStatusV16::Expired);
+        assert_eq!(bucket_after.status, BackingBucketStatusV16::Expired);
     } else {
-        assert_eq!(bucket.status, BackingBucketStatusV16::Impaired);
+        assert_eq!(bucket_after.status, BackingBucketStatusV16::Impaired);
     }
     assert_eq!(
-        bucket.impaired_liened_backing_num,
-        source.impaired_liened_backing_num
+        bucket_after.impaired_liened_backing_num,
+        source_after.impaired_liened_backing_num
     );
-    // Stock destination of the expired atoms (review finding): expiry forfeits
-    // the WHOLE bucket (unliened and liened alike) out of
-    // counterparty_backing_principal into the JUNIOR RESIDUAL pool, vault flat.
-    // No class disappears; the junior pool rises by EXACTLY the forfeit — this
-    // exact equality is also the LoF-horn falsifier (no atoms split off into
-    // movable surplus or anywhere else).
+
+    // Expiry forfeits recoverable provider principal into the junior pool. It
+    // must not create or destroy vault atoms, even at the configured TVL bound.
+    let other_senior: u128 = kani::any();
+    kani::assume(other_senior <= MAX_VAULT_TVL - total_atoms);
+    let junior_before: u128 = kani::any();
+    kani::assume(junior_before <= MAX_VAULT_TVL - total_atoms - other_senior);
+    let vault = other_senior + total_atoms + junior_before;
+    let junior_after = vault - other_senior;
+    kani::cover!(junior_before == 0, "expiry covers a tight senior vault");
+    kani::cover!(
+        junior_before > 0,
+        "expiry covers pre-existing junior surplus"
+    );
+    assert_eq!(junior_after, junior_before + total_atoms);
     assert_eq!(
-        market.kani_residual(),
-        residual_before + fresh_atoms + liened_atoms
+        StockReconciliationProofV16 {
+            token_vault: vault,
+            senior_capital_total: other_senior,
+            insurance_capital: 0,
+            backing_provider_earnings: 0,
+            counterparty_backing_principal: total_atoms,
+            settlement_rounding_residue_total: 0,
+            unallocated_protocol_surplus: junior_before,
+        }
+        .validate(),
+        Ok(())
     );
-    // DoS-horn falsifier (review): the mandatory stock reconciliation MUST hold
-    // on the post-expiry impaired state, or the next insurance/close/recovery
-    // checkpoint would revert (frozen vault). expire runs validate_shape
-    // internally via refresh; assert it explicitly so the property is pinned.
-    assert_eq!(market.validate_shape(), Ok(()));
+    assert_eq!(
+        StockReconciliationProofV16 {
+            token_vault: vault,
+            senior_capital_total: other_senior,
+            insurance_capital: 0,
+            backing_provider_earnings: 0,
+            counterparty_backing_principal: 0,
+            settlement_rounding_residue_total: 0,
+            unallocated_protocol_surplus: junior_after,
+        }
+        .validate(),
+        Ok(())
+    );
 }
 
 #[kani::proof]

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -15814,3 +15814,139 @@ fn proof_v16_unilateral_close_capacity_is_safe_progress_and_residue_complete() {
         "capacity covers a full account close"
     );
 }
+
+// A partial ADL can leave stored basis after matched effective OI reaches zero.
+// Prove the exact production reset+clear composition: reset preserves the old
+// K/F/B epoch targets, and the prior-epoch clear cannot subtract basis or loss
+// weight from the already-zero current epoch.
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_full_drain_reset_then_prior_epoch_clear_is_total_and_exact() {
+    let side = if kani::any::<bool>() {
+        SideV16::Long
+    } else {
+        SideV16::Short
+    };
+    let mode = if kani::any::<bool>() {
+        SideModeV16::Normal
+    } else {
+        SideModeV16::DrainOnly
+    };
+    let epoch: u64 = kani::any();
+    let stored_count: u64 = kani::any();
+    let basis_abs: u128 = kani::any();
+    let k: i128 = kani::any();
+    let f: i128 = kani::any();
+    let b: u128 = kani::any();
+    let loss_weight: u128 = kani::any();
+    let remainder: u128 = kani::any();
+    let dust: u128 = kani::any();
+    kani::assume(epoch < u64::MAX);
+    kani::assume(stored_count > 0);
+    kani::assume((1..=MAX_POSITION_ABS_Q).contains(&basis_abs));
+    kani::assume(remainder < SOCIAL_LOSS_DEN);
+    kani::assume(dust < SOCIAL_LOSS_DEN - remainder);
+
+    let mut asset = AssetStateV16::default();
+    asset.lifecycle = AssetLifecycleV16::Recovery;
+    match side {
+        SideV16::Long => {
+            asset.a_long = ADL_ONE / 2;
+            asset.k_long = k;
+            asset.f_long_num = f;
+            asset.b_long_num = b;
+            asset.oi_eff_long_q = 0;
+            asset.stored_pos_count_long = stored_count;
+            asset.pending_obligation_count_long = 0;
+            asset.loss_weight_sum_long = loss_weight;
+            asset.social_loss_remainder_long_num = remainder;
+            asset.social_loss_dust_long_num = dust;
+            asset.epoch_long = epoch;
+            asset.mode_long = mode;
+        }
+        SideV16::Short => {
+            asset.a_short = ADL_ONE / 2;
+            asset.k_short = k;
+            asset.f_short_num = f;
+            asset.b_short_num = b;
+            asset.oi_eff_short_q = 0;
+            asset.stored_pos_count_short = stored_count;
+            asset.pending_obligation_count_short = 0;
+            asset.loss_weight_sum_short = loss_weight;
+            asset.social_loss_remainder_short_num = remainder;
+            asset.social_loss_dust_short_num = dust;
+            asset.epoch_short = epoch;
+            asset.mode_short = mode;
+        }
+    }
+    let before = asset;
+    let reset =
+        MarketGroupV16ViewMut::<u64>::kani_kernel_begin_full_drain_reset(asset, side).unwrap();
+    let mut expected_reset = before;
+    match side {
+        SideV16::Long => {
+            expected_reset.k_epoch_start_long = k;
+            expected_reset.f_epoch_start_long_num = f;
+            expected_reset.b_epoch_start_long_num = b;
+            expected_reset.k_long = 0;
+            expected_reset.f_long_num = 0;
+            expected_reset.b_long_num = 0;
+            expected_reset.loss_weight_sum_long = 0;
+            expected_reset.social_loss_remainder_long_num = 0;
+            expected_reset.social_loss_dust_long_num = dust + remainder;
+            expected_reset.a_long = ADL_ONE;
+            expected_reset.epoch_long = epoch + 1;
+            expected_reset.mode_long = SideModeV16::ResetPending;
+        }
+        SideV16::Short => {
+            expected_reset.k_epoch_start_short = k;
+            expected_reset.f_epoch_start_short_num = f;
+            expected_reset.b_epoch_start_short_num = b;
+            expected_reset.k_short = 0;
+            expected_reset.f_short_num = 0;
+            expected_reset.b_short_num = 0;
+            expected_reset.loss_weight_sum_short = 0;
+            expected_reset.social_loss_remainder_short_num = 0;
+            expected_reset.social_loss_dust_short_num = dust + remainder;
+            expected_reset.a_short = ADL_ONE;
+            expected_reset.epoch_short = epoch + 1;
+            expected_reset.mode_short = SideModeV16::ResetPending;
+        }
+    }
+    assert_eq!(reset, expected_reset);
+
+    let basis_pos_q = match side {
+        SideV16::Long => basis_abs as i128,
+        SideV16::Short => -(basis_abs as i128),
+    };
+    let leg = PortfolioLegV16 {
+        active: true,
+        side,
+        basis_pos_q,
+        epoch_snap: epoch,
+        loss_weight,
+        b_rem: remainder,
+        ..PortfolioLegV16::EMPTY
+    };
+    let cleared = MarketGroupV16ViewMut::<u64>::kani_kernel_clear_leg(leg, reset).unwrap();
+    let mut expected_clear = expected_reset;
+    match side {
+        SideV16::Long => expected_clear.stored_pos_count_long = stored_count - 1,
+        SideV16::Short => expected_clear.stored_pos_count_short = stored_count - 1,
+    }
+
+    kani::cover!(side == SideV16::Long, "reset+clear covers long residues");
+    kani::cover!(side == SideV16::Short, "reset+clear covers short residues");
+    kani::cover!(
+        mode == SideModeV16::DrainOnly,
+        "reset+clear covers DrainOnly"
+    );
+    kani::cover!(remainder > 0, "reset+clear quarantines nonzero remainder");
+    kani::cover!(stored_count > 1, "reset+clear preserves sibling residues");
+    kani::cover!(
+        k != 0 && f != 0 && b != 0,
+        "reset+clear preserves nonzero K/F/B targets"
+    );
+    assert_eq!(cleared, expected_clear);
+}

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -5,7 +5,8 @@ use percolator::v16::{
     backing_domain_fee_split_for_lien_delta_num, kani_active_bitmap_set as active_bitmap_set,
     kani_add_open_interest_for_new_position, kani_apply_backing_provider_earnings_withdraw,
     kani_apply_backing_utilization_fee_charge, kani_apply_resolved_payout_receipt_payment,
-    kani_auto_crank_lifecycle_dispatchable, kani_available_backing_num_for_source_credit_state,
+    kani_auto_crank_leg_flags, kani_auto_crank_lifecycle_dispatchable,
+    kani_available_backing_num_for_source_credit_state,
     kani_backing_utilization_fee_quote_atoms_for_lien,
     kani_backing_utilization_rate_e9_for_source_state, kani_cert_is_current,
     kani_expected_source_credit_rate_num_for_state, kani_first_actionable_slot,
@@ -16,18 +17,18 @@ use percolator::v16::{
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
     kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
     kani_prepare_asset_recovery_transition, kani_select_auto_crank_plan,
-    kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
-    kani_trade_preexisting_oi_reduction_gate, kani_trade_preflight_risk_gate,
-    kani_validate_positive_pnl_source_attribution, ActionableSummaryV16, AssetLifecycleV16,
-    AssetStateV16, AssetStateV16Account, AutoCrankPlanV16, BackingBucketStatusV16,
-    BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
-    CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
-    HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
-    Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
-    PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
-    PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
-    PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
-    ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedCloseOutcomeV16,
+    kani_should_clear_prior_reset_obligation, kani_source_credit_state_realizable_support_for_face,
+    kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
+    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
+    ActionableSummaryV16, AssetLifecycleV16, AssetStateV16, AssetStateV16Account, AutoCrankPlanV16,
+    BackingBucketStatusV16, BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16,
+    CloseProgressLedgerV16, CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16,
+    HealthCertV16, HealthCertV16Account, InsuranceCreditReservationV16,
+    InsuranceCreditReservationV16Account, Market, MarketGroupV16HeaderAccount, MarketGroupV16View,
+    MarketGroupV16ViewMut, PermissionlessCrankActionV16, PermissionlessCrankRequestV16,
+    PermissionlessProgressOutcomeV16, PermissionlessRecoveryReasonV16, PortfolioAccountV16Account,
+    PortfolioLegV16, PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View,
+    PortfolioV16ViewMut, ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedCloseOutcomeV16,
     ResolvedPayoutLedgerV16, ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16,
     ResolvedPayoutReceiptV16Account, SideModeV16, SideV16, SourceCreditStateV16,
     SourceCreditStateV16Account, StockReconciliationProofV16, TokenValueClassV16,
@@ -41,7 +42,7 @@ use percolator::v16::{
     kani_eq_portfolio_account_v16_account,
 };
 use percolator::{
-    ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, MAX_ACCOUNT_NOTIONAL, MAX_MARGIN_BPS,
+    ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, MAX_ACCOUNT_NOTIONAL, MAX_MARGIN_BPS, MAX_OI_SIDE_Q,
     MAX_ORACLE_PRICE, MAX_POSITION_ABS_Q, MAX_TRADE_SIZE_Q, MAX_VAULT_TVL, POS_SCALE,
     SOCIAL_LOSS_DEN, V16_ACTIVE_BITMAP_WORDS,
 };
@@ -15545,4 +15546,185 @@ fn proof_v16_recovery_legs_cannot_starve_dispatchable_auto_crank_work() {
         dispatchable_mask == 0,
         "Recovery-only account has no fake liquidation target"
     );
+}
+
+// Permissionless liveness theorem for mixed prior-reset obligations and live
+// liquidation candidates. The two symbolic bitmasks cover every multiplicity
+// and ordering across the full production 16-leg account shape. Each refresh
+// removes exactly the first prior-reset obligation, so that rank reaches zero
+// within 16 calls; prior-reset legs are never selected as liquidation work, and
+// the first real live-risk leg is selected once cleanup completes.
+#[kani::proof]
+#[kani::unwind(18)]
+#[kani::solver(cadical)]
+fn proof_v16_prior_reset_cleanup_cannot_starve_live_liquidation() {
+    let reset_mask: u16 = kani::any();
+    let live_mask: u16 = kani::any();
+    let drain_only_mask: u16 = kani::any();
+    let basis_abs: u128 = kani::any();
+    let live_oi_q: u128 = kani::any();
+    let reset_epoch: u64 = kani::any();
+    let negative_basis: bool = kani::any();
+    kani::assume(reset_mask != 0);
+    kani::assume(live_mask != 0);
+    kani::assume(reset_mask & live_mask == 0);
+    kani::assume((1..=MAX_POSITION_ABS_Q).contains(&basis_abs));
+    kani::assume((1..=MAX_OI_SIDE_Q).contains(&live_oi_q));
+    kani::assume(reset_epoch > 0);
+
+    let basis_pos_q = if negative_basis {
+        -(basis_abs as i128)
+    } else {
+        basis_abs as i128
+    };
+    let mut reset_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+    let mut liquidation_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+    let mut refresh_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+    let mut slot = 0usize;
+    while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+        let bit = 1u16 << slot;
+        let is_reset = reset_mask & bit != 0;
+        let is_live = live_mask & bit != 0;
+        let active = is_reset || is_live;
+        let lifecycle = if drain_only_mask & bit != 0 {
+            AssetLifecycleV16::DrainOnly
+        } else {
+            AssetLifecycleV16::Active
+        };
+        let side_mode = if is_reset {
+            SideModeV16::ResetPending
+        } else {
+            SideModeV16::Normal
+        };
+        let asset_epoch = if is_reset { reset_epoch } else { 0 };
+        let leg_epoch_snap = if is_reset { reset_epoch - 1 } else { 0 };
+        let side_oi_q = if is_live { live_oi_q } else { 0 };
+        let (b_stale, refresh, liquidatable, reset_obligation) = kani_auto_crank_leg_flags(
+            active,
+            lifecycle,
+            basis_pos_q,
+            side_oi_q,
+            side_mode,
+            asset_epoch,
+            leg_epoch_snap,
+            false,
+        );
+
+        assert!(!b_stale);
+        assert_eq!(refresh, active);
+        assert_eq!(liquidatable, is_live);
+        assert_eq!(reset_obligation, is_reset);
+        assert!(!(liquidatable && reset_obligation));
+        refresh_flags[slot] = refresh;
+        liquidation_flags[slot] = liquidatable;
+        reset_flags[slot] = reset_obligation;
+        slot += 1;
+    }
+
+    let initial_reset_count = reset_mask.count_ones();
+    let first_reset = kani_first_actionable_slot(reset_flags).unwrap();
+    let first_live = kani_first_actionable_slot(liquidation_flags).unwrap();
+    kani::cover!(
+        initial_reset_count == 1,
+        "single reset obligation is reachable"
+    );
+    kani::cover!(
+        initial_reset_count > 1,
+        "multiple reset obligations are reachable"
+    );
+    kani::cover!(first_reset < first_live, "reset can precede live risk");
+    kani::cover!(first_live < first_reset, "live risk can precede reset");
+    kani::cover!(
+        drain_only_mask & (reset_mask | live_mask) != 0,
+        "DrainOnly legs share the bounded progress classification"
+    );
+
+    let mut calls = 0usize;
+    while calls < V16_MAX_PORTFOLIO_ASSETS_N {
+        let mut pre_reset_count = 0u32;
+        slot = 0;
+        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+            pre_reset_count += reset_flags[slot] as u32;
+            slot += 1;
+        }
+        if pre_reset_count != 0 {
+            let selected_reset = kani_first_actionable_slot(reset_flags).unwrap();
+            let refresh_asset = kani_first_actionable_slot(refresh_flags);
+            let plan = kani_select_auto_crank_plan(
+                ActionableSummaryV16 {
+                    stale: true,
+                    b_stale: false,
+                    pending_close: false,
+                    expired_close: false,
+                    liquidatable: false,
+                    recovery_eligible: false,
+                    resolved_winner: false,
+                },
+                0,
+                first_live,
+                refresh_asset,
+                PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+            );
+            assert_eq!(
+                plan,
+                AutoCrankPlanV16::RefreshAccount {
+                    asset_index: refresh_asset
+                }
+            );
+
+            let mut already_cleared = false;
+            slot = 0;
+            while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+                if kani_should_clear_prior_reset_obligation(
+                    already_cleared,
+                    reset_flags[slot],
+                    false,
+                ) {
+                    assert_eq!(slot, selected_reset);
+                    reset_flags[slot] = false;
+                    refresh_flags[slot] = false;
+                    already_cleared = true;
+                }
+                slot += 1;
+            }
+            assert!(already_cleared);
+
+            let mut post_reset_count = 0u32;
+            slot = 0;
+            while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+                post_reset_count += reset_flags[slot] as u32;
+                slot += 1;
+            }
+            assert_eq!(post_reset_count + 1, pre_reset_count);
+        }
+        calls += 1;
+    }
+
+    assert!(kani_first_actionable_slot(reset_flags).is_none());
+    let selected_live = kani_first_actionable_slot(liquidation_flags).unwrap();
+    assert_eq!(selected_live, first_live);
+    let final_plan = kani_select_auto_crank_plan(
+        ActionableSummaryV16 {
+            stale: false,
+            b_stale: false,
+            pending_close: false,
+            expired_close: false,
+            liquidatable: true,
+            recovery_eligible: false,
+            resolved_winner: false,
+        },
+        0,
+        selected_live,
+        kani_first_actionable_slot(refresh_flags),
+        PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+    );
+    assert_eq!(
+        final_plan,
+        AutoCrankPlanV16::Liquidate {
+            asset_index: first_live
+        }
+    );
+
+    assert!(!kani_should_clear_prior_reset_obligation(false, true, true));
+    assert!(!kani_should_clear_prior_reset_obligation(true, true, false));
 }

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3222,7 +3222,6 @@ fn v16_auto_crank_skips_prior_reset_obligation_for_live_liquidation() {
             AutoCrankWorkV16 {
                 now_slot: 10,
                 observations: &[],
-                liquidation_max_close_q: POS_SCALE,
                 resolved_close_fee_rate_per_slot: 0,
             },
         )
@@ -3243,7 +3242,6 @@ fn v16_auto_crank_skips_prior_reset_obligation_for_live_liquidation() {
             AutoCrankWorkV16 {
                 now_slot: 10,
                 observations: &[],
-                liquidation_max_close_q: POS_SCALE,
                 resolved_close_fee_rate_per_slot: 0,
             },
         )

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1,6 +1,6 @@
 use percolator::{
-    auto_crank_plan_requires_caller_observation, AutoCrankObservationV16, AutoCrankOutcomeV16,
-    AutoCrankPlanV16, AutoCrankWorkV16,
+    active_bitmap_is_empty, auto_crank_plan_requires_caller_observation, AutoCrankObservationV16,
+    AutoCrankOutcomeV16, AutoCrankPlanV16, AutoCrankWorkV16,
 };
 use percolator::{
     v16_domain_count_for_market_slots, AssetLifecycleV16, AssetStateV16Account,
@@ -856,6 +856,75 @@ fn v16_batch_trade_applies_multiple_fills_after_inline_refresh() {
     );
     market.validate_shape().unwrap();
     long.validate_with_market(&market.as_view()).unwrap();
+    short.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_resolved_close_detaches_one_active_leg_per_progress_step() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut long_header = account_fixture(2, 203);
+    let mut short_header = account_fixture(2, 204);
+    let requests = [
+        TradeRequestV16 {
+            asset_index: 0,
+            size_q: signed_q(POS_SCALE),
+            exec_price: 100,
+            fee_bps: 0,
+        },
+        TradeRequestV16 {
+            asset_index: 1,
+            size_q: signed_q(POS_SCALE),
+            exec_price: 100,
+            fee_bps: 0,
+        },
+    ];
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market.deposit_not_atomic(&mut long, 1_000).unwrap();
+    market.deposit_not_atomic(&mut short, 1_000).unwrap();
+    market
+        .execute_batch_with_fee_loss_stale_scoped_not_atomic(&mut long, &mut short, &requests)
+        .unwrap();
+    market.resolve_market_not_atomic(2).unwrap();
+
+    assert_eq!(
+        market
+            .close_resolved_account_not_atomic(&mut short, 0)
+            .unwrap(),
+        percolator::ResolvedCloseOutcomeV16::ProgressOnly,
+    );
+    assert_eq!(
+        short
+            .header
+            .active_bitmap
+            .iter()
+            .map(|word| word.get().count_ones())
+            .sum::<u32>(),
+        1,
+        "one successful close continuation must detach exactly one active leg",
+    );
+    assert_eq!(short.header.capital.get(), 1_000);
+
+    assert_eq!(
+        market
+            .close_resolved_account_not_atomic(&mut short, 0)
+            .unwrap(),
+        percolator::ResolvedCloseOutcomeV16::ProgressOnly,
+    );
+    assert!(active_bitmap_is_empty(
+        short.header.active_bitmap.map(V16PodU64::get)
+    ));
+    assert_eq!(short.header.capital.get(), 1_000);
+
+    assert_eq!(
+        market
+            .close_resolved_account_not_atomic(&mut short, 0)
+            .unwrap(),
+        percolator::ResolvedCloseOutcomeV16::Closed { payout: 1_000 },
+    );
+    market.validate_shape().unwrap();
     short.validate_with_market(&market.as_view()).unwrap();
 }
 
@@ -3594,9 +3663,13 @@ fn v16_resolved_close_migrates_legacy_normal_adl_residue_before_detach() {
     let mut account = PortfolioV16ViewMut::new(&mut account_header);
     market.deposit_not_atomic(&mut account, 1_000).unwrap();
     market.resolve_market_not_atomic(1).unwrap();
-    let outcome = market
+    let progress = market
         .close_resolved_account_not_atomic(&mut account, 0)
         .expect("resolution must not strand an upgraded zero-effective-OI residue");
+    assert_eq!(progress, percolator::ResolvedCloseOutcomeV16::ProgressOnly);
+    let outcome = market
+        .close_resolved_account_not_atomic(&mut account, 0)
+        .expect("the next bounded continuation must pay the detached account");
     assert_eq!(
         outcome,
         percolator::ResolvedCloseOutcomeV16::Closed { payout: 1_000 }

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3030,6 +3030,113 @@ fn v16_auto_crank_classifies_fresh_account_stale_then_refreshes_to_clean() {
     account.validate_with_market(&market.as_view()).unwrap();
 }
 
+#[test]
+fn v16_auto_crank_skips_recovery_first_leg_for_live_refresh() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut account_header = account_fixture(2, 22);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut account_header);
+        market.deposit_not_atomic(&mut account, 1_000).unwrap();
+    }
+
+    header.current_slot = V16PodU64::new(10);
+    header.slot_last = V16PodU64::new(10);
+    let mut asset0 = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset0.lifecycle = AssetLifecycleV16::Recovery;
+    asset0.slot_last = 10;
+    asset0.oi_eff_long_q = POS_SCALE;
+    asset0.oi_eff_short_q = POS_SCALE;
+    asset0.loss_weight_sum_long = POS_SCALE;
+    asset0.loss_weight_sum_short = POS_SCALE;
+    asset0.stored_pos_count_long = 1;
+    asset0.stored_pos_count_short = 1;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset0);
+
+    let mut asset1 = markets[1].engine.asset.try_to_runtime().unwrap();
+    asset1.slot_last = 10;
+    asset1.oi_eff_long_q = POS_SCALE;
+    asset1.oi_eff_short_q = POS_SCALE;
+    asset1.loss_weight_sum_long = POS_SCALE;
+    asset1.loss_weight_sum_short = POS_SCALE;
+    asset1.stored_pos_count_long = 1;
+    asset1.stored_pos_count_short = 1;
+    markets[1].engine.asset = AssetStateV16Account::from_runtime(&asset1);
+    header.resolved_payout_blocker_count = V16PodU64::new(4);
+
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset0.market_id,
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset0.k_long,
+        f_snap: asset0.f_long_num,
+        epoch_snap: asset0.epoch_long,
+        loss_weight: POS_SCALE,
+        b_snap: asset0.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset0.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.legs[1] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 1,
+        market_id: asset1.market_id,
+        side: SideV16::Short,
+        basis_pos_q: -(POS_SCALE as i128),
+        a_basis: ADL_ONE,
+        k_snap: asset1.k_short,
+        f_snap: asset1.f_short_num,
+        epoch_snap: asset1.epoch_short,
+        loss_weight: POS_SCALE,
+        b_snap: asset1.b_short_num,
+        b_rem: 0,
+        b_epoch_snap: asset1.epoch_short,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(3);
+
+    let obs = [AutoCrankObservationV16 {
+        asset_index: 1,
+        effective_price: 100,
+        funding_rate_e9: 0,
+    }];
+    let work = AutoCrankWorkV16 {
+        now_slot: 10,
+        observations: &obs,
+        liquidation_max_close_q: POS_SCALE,
+        resolved_close_fee_rate_per_slot: 0,
+    };
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    assert!(
+        market
+            .build_actionable_summary(&account.as_view())
+            .unwrap()
+            .stale
+    );
+
+    let result = market
+        .permissionless_auto_crank_not_atomic(&mut account, work)
+        .expect("a Recovery first leg must not block the live asset refresh");
+    assert_eq!(
+        result.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(1),
+        },
+    );
+    assert_eq!(
+        result.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent),
+    );
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
 // ROADMAP 3C step 4 / NB2 finite-multi-step liveness via the self-classifying
 // crank: an uncertified, underwater account must be driven to a de-risked fixed
 // point by repeated auto-cranks — the classifier ESCALATES (stale -> refresh,

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3321,7 +3321,6 @@ fn v16_adl_reduced_basis_caps_exit_to_effective_oi_then_detaches_residue() {
             AutoCrankWorkV16 {
                 now_slot: 1,
                 observations: &[],
-                liquidation_max_close_q: 2 * POS_SCALE,
                 resolved_close_fee_rate_per_slot: 0,
             },
         )
@@ -3378,7 +3377,6 @@ fn v16_auto_crank_migrates_legacy_normal_adl_residue_into_reset_cleanup() {
             AutoCrankWorkV16 {
                 now_slot: 1,
                 observations: &[],
-                liquidation_max_close_q: POS_SCALE,
                 resolved_close_fee_rate_per_slot: 0,
             },
         )

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -10,7 +10,7 @@ use percolator::{
     PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
-    ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedPayoutLedgerV16,
+    ProvenanceHeaderV16, ProvenanceHeaderV16Account, RebalanceRequestV16, ResolvedPayoutLedgerV16,
     ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16, ResolvedPayoutReceiptV16Account,
     SideModeV16, SideV16, SourceCreditStateV16, SourceCreditStateV16Account, TradeRequestV16,
     V16Config, V16Error, V16PodI128, V16PodU128, V16PodU32, V16PodU64, V16_EMPTY_ACTIVE_BITMAP,
@@ -3251,6 +3251,149 @@ fn v16_auto_crank_skips_prior_reset_obligation_for_live_liquidation() {
         AutoCrankPlanV16::Liquidate { asset_index: 1 }
     );
     assert!(!account.header.legs[1].try_to_runtime().unwrap().active);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_adl_reduced_basis_caps_exit_to_effective_oi_then_detaches_residue() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 24);
+
+    // A partial ADL can leave a winner's stored basis larger than the side's
+    // remaining effective OI. This is the exact state reached by the public
+    // wrapper regression: basis=2 lots, matched effective OI=1 lot.
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.oi_eff_long_q = POS_SCALE;
+    asset.oi_eff_short_q = POS_SCALE;
+    asset.a_long = ADL_ONE / 2;
+    asset.loss_weight_sum_long = 2 * POS_SCALE;
+    asset.loss_weight_sum_short = POS_SCALE;
+    asset.stored_pos_count_long = 1;
+    asset.stored_pos_count_short = 1;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(2);
+
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Long,
+        basis_pos_q: (2 * POS_SCALE) as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset.k_long,
+        f_snap: asset.f_long_num,
+        epoch_snap: asset.epoch_long,
+        loss_weight: 2 * POS_SCALE,
+        b_snap: asset.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(1);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market.deposit_not_atomic(&mut account, 1_000).unwrap();
+
+    let reduced = market
+        .rebalance_reduce_position_not_atomic(
+            &mut account,
+            RebalanceRequestV16 {
+                asset_index: 0,
+                reduce_q: 2 * POS_SCALE,
+            },
+        )
+        .expect("max-work exit must clamp to matched effective OI");
+    assert_eq!(reduced.reduced_q, POS_SCALE);
+    let residue = account.header.legs[0].try_to_runtime().unwrap();
+    assert_eq!(residue.basis_pos_q, POS_SCALE as i128);
+    let reset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(reset.oi_eff_long_q, 0);
+    assert_eq!(reset.oi_eff_short_q, 0);
+    assert_eq!(reset.mode_long, SideModeV16::ResetPending);
+    assert_eq!(reset.mode_short, SideModeV16::ResetPending);
+
+    let cleanup = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 1,
+                observations: &[],
+                liquidation_max_close_q: 2 * POS_SCALE,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("terminal ADL residue must be permissionlessly detachable");
+    assert_eq!(
+        cleanup.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    );
+    assert!(!account.header.legs[0].try_to_runtime().unwrap().active);
+    assert_eq!(account.header.active_bitmap[0].get(), 0);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_auto_crank_migrates_legacy_normal_adl_residue_into_reset_cleanup() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 25);
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.oi_eff_long_q = 0;
+    asset.oi_eff_short_q = 0;
+    asset.a_long = ADL_ONE / 2;
+    asset.loss_weight_sum_long = POS_SCALE;
+    asset.stored_pos_count_long = 1;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(1);
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset.k_long,
+        f_snap: asset.f_long_num,
+        epoch_snap: asset.epoch_long,
+        loss_weight: POS_SCALE,
+        b_snap: asset.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(1);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market.deposit_not_atomic(&mut account, 1_000).unwrap();
+    let result = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 1,
+                observations: &[],
+                liquidation_max_close_q: POS_SCALE,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("a legacy zero-effective-OI residue must remain crankable after upgrade");
+    assert_eq!(
+        result.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    );
+    assert_eq!(account.header.active_bitmap[0].get(), 0);
+    assert!(!account.header.legs[0].try_to_runtime().unwrap().active);
+    let reset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(reset.mode_long, SideModeV16::ResetPending);
+    assert_eq!(reset.stored_pos_count_long, 0);
     market.validate_shape().unwrap();
     account.validate_with_market(&market.as_view()).unwrap();
 }

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3108,7 +3108,6 @@ fn v16_auto_crank_skips_recovery_first_leg_for_live_refresh() {
     let work = AutoCrankWorkV16 {
         now_slot: 10,
         observations: &obs,
-        liquidation_max_close_q: POS_SCALE,
         resolved_close_fee_rate_per_slot: 0,
     };
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3398,6 +3398,58 @@ fn v16_auto_crank_migrates_legacy_normal_adl_residue_into_reset_cleanup() {
     account.validate_with_market(&market.as_view()).unwrap();
 }
 
+#[test]
+fn v16_resolved_close_migrates_legacy_normal_adl_residue_before_detach() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 26);
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.oi_eff_long_q = 0;
+    asset.oi_eff_short_q = 0;
+    asset.a_long = ADL_ONE / 2;
+    asset.loss_weight_sum_long = POS_SCALE;
+    asset.stored_pos_count_long = 1;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(1);
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset.k_long,
+        f_snap: asset.f_long_num,
+        epoch_snap: asset.epoch_long,
+        loss_weight: POS_SCALE,
+        b_snap: asset.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(1);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market.deposit_not_atomic(&mut account, 1_000).unwrap();
+    market.resolve_market_not_atomic(1).unwrap();
+    let outcome = market
+        .close_resolved_account_not_atomic(&mut account, 0)
+        .expect("resolution must not strand an upgraded zero-effective-OI residue");
+    assert_eq!(
+        outcome,
+        percolator::ResolvedCloseOutcomeV16::Closed { payout: 1_000 }
+    );
+    assert_eq!(account.header.active_bitmap[0].get(), 0);
+    assert_eq!(account.header.capital.get(), 0);
+    assert_eq!(market.header.vault.get(), 0);
+    let reset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(reset.mode_long, SideModeV16::ResetPending);
+    assert_eq!(reset.stored_pos_count_long, 0);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
 // ROADMAP 3C step 4 / NB2 finite-multi-step liveness via the self-classifying
 // crank: an uncertified, underwater account must be driven to a de-risked fixed
 // point by repeated auto-cranks — the classifier ESCALATES (stale -> refresh,

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3136,6 +3136,127 @@ fn v16_auto_crank_skips_recovery_first_leg_for_live_refresh() {
     account.validate_with_market(&market.as_view()).unwrap();
 }
 
+#[test]
+fn v16_auto_crank_skips_prior_reset_obligation_for_live_liquidation() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut account_header = account_fixture(2, 23);
+    header.current_slot = V16PodU64::new(10);
+    header.slot_last = V16PodU64::new(10);
+
+    let mut asset0 = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset0.slot_last = 10;
+    asset0.epoch_long = 1;
+    asset0.mode_long = SideModeV16::ResetPending;
+    asset0.oi_eff_long_q = 0;
+    asset0.oi_eff_short_q = 0;
+    asset0.loss_weight_sum_long = 0;
+    asset0.loss_weight_sum_short = 0;
+    asset0.stored_pos_count_long = 1;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset0);
+
+    let mut asset1 = markets[1].engine.asset.try_to_runtime().unwrap();
+    asset1.slot_last = 10;
+    asset1.oi_eff_long_q = 2 * POS_SCALE;
+    asset1.oi_eff_short_q = 2 * POS_SCALE;
+    asset1.loss_weight_sum_long = 2 * POS_SCALE;
+    asset1.loss_weight_sum_short = 2 * POS_SCALE;
+    asset1.stored_pos_count_long = 2;
+    asset1.stored_pos_count_short = 2;
+    markets[1].engine.asset = AssetStateV16Account::from_runtime(&asset1);
+    header.resolved_payout_blocker_count = V16PodU64::new(5);
+
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset0.market_id,
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset0.k_epoch_start_long,
+        f_snap: asset0.f_epoch_start_long_num,
+        epoch_snap: 0,
+        loss_weight: POS_SCALE,
+        b_snap: asset0.b_epoch_start_long_num,
+        b_rem: 0,
+        b_epoch_snap: 0,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.legs[1] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 1,
+        market_id: asset1.market_id,
+        side: SideV16::Short,
+        basis_pos_q: -(POS_SCALE as i128),
+        a_basis: ADL_ONE,
+        k_snap: asset1.k_short,
+        f_snap: asset1.f_short_num,
+        epoch_snap: asset1.epoch_short,
+        loss_weight: POS_SCALE,
+        b_snap: asset1.b_short_num,
+        b_rem: 0,
+        b_epoch_snap: asset1.epoch_short,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(3);
+    account_header.health_cert = HealthCertV16Account::from_runtime(&HealthCertV16 {
+        certified_equity: 0,
+        certified_initial_req: 2,
+        certified_maintenance_req: 2,
+        certified_liq_deficit: 2,
+        certified_worst_case_loss: 200,
+        cert_oracle_epoch: header.oracle_epoch.get(),
+        cert_funding_epoch: header.funding_epoch.get(),
+        cert_risk_epoch: header.risk_epoch.get(),
+        cert_asset_set_epoch: header.asset_set_epoch.get(),
+        active_bitmap_at_cert: [3],
+        valid: true,
+    });
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let refresh = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &[],
+                liquidation_max_close_q: POS_SCALE,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the prior-reset first leg must be detached permissionlessly");
+
+    assert_eq!(
+        refresh.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    );
+    assert!(!account.header.legs[0].try_to_runtime().unwrap().active);
+    assert!(account.header.legs[1].try_to_runtime().unwrap().active);
+
+    let liquidation = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &[],
+                liquidation_max_close_q: POS_SCALE,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the next step must liquidate the remaining live asset");
+    assert_eq!(
+        liquidation.selected,
+        AutoCrankPlanV16::Liquidate { asset_index: 1 }
+    );
+    assert!(!account.header.legs[1].try_to_runtime().unwrap().active);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
 // ROADMAP 3C step 4 / NB2 finite-multi-step liveness via the self-classifying
 // crank: an uncertified, underwater account must be driven to a de-risked fixed
 // point by repeated auto-cranks — the classifier ESCALATES (stale -> refresh,

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3448,6 +3448,53 @@ fn v16_resolved_close_migrates_legacy_normal_adl_residue_before_detach() {
     account.validate_with_market(&market.as_view()).unwrap();
 }
 
+#[test]
+fn v16_recovery_forfeit_migrates_legacy_normal_adl_residue_before_detach() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 27);
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.oi_eff_long_q = 0;
+    asset.oi_eff_short_q = 0;
+    asset.a_long = ADL_ONE / 2;
+    asset.loss_weight_sum_long = POS_SCALE;
+    asset.stored_pos_count_long = 1;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(1);
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset.k_long,
+        f_snap: asset.f_long_num,
+        epoch_snap: asset.epoch_long,
+        loss_weight: POS_SCALE,
+        b_snap: asset.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(1);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market.deposit_not_atomic(&mut account, 1_000).unwrap();
+    market.force_asset_recovery_not_atomic(0, 1).unwrap();
+    let outcome = market
+        .forfeit_recovery_leg_not_atomic(&mut account, 0, POS_SCALE)
+        .expect("Recovery forfeit must detach a zero-effective-OI ADL residue");
+    assert!(outcome.detached);
+    assert_eq!(account.header.active_bitmap[0].get(), 0);
+    let reset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(reset.mode_long, SideModeV16::ResetPending);
+    assert_eq!(reset.stored_pos_count_long, 0);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
 // ROADMAP 3C step 4 / NB2 finite-multi-step liveness via the self-classifying
 // crank: an uncertified, underwater account must be driven to a de-risked fixed
 // point by repeated auto-cranks — the classifier ESCALATES (stale -> refresh,

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3031,6 +3031,73 @@ fn v16_auto_crank_classifies_fresh_account_stale_then_refreshes_to_clean() {
 }
 
 #[test]
+fn v16_auto_crank_expires_lapsed_live_source_backing_before_refresh() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 22);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut account_header);
+        market.deposit_not_atomic(&mut account, 100).unwrap();
+        market
+            .deposit_fresh_counterparty_backing_not_atomic(1, 40, 5)
+            .unwrap();
+        market
+            .add_account_source_positive_pnl_not_atomic(&mut account, 1, 40)
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(0, 10, 100, 0, true)
+            .unwrap();
+    }
+
+    let before = markets[0].engine.backing_short.try_to_runtime().unwrap();
+    assert_eq!(before.status, BackingBucketStatusV16::Fresh);
+    assert_eq!(before.expiry_slot, 5);
+    assert!(header.current_slot.get() > before.expiry_slot);
+    let vault_before = header.vault.get();
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let observations = [AutoCrankObservationV16 {
+        asset_index: 0,
+        effective_price: 100,
+        funding_rate_e9: 0,
+    }];
+    let result = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &observations,
+                liquidation_max_close_q: 0,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("Live auto-crank must expire lapsed backing instead of returning Stale");
+
+    assert!(matches!(
+        result.selected,
+        AutoCrankPlanV16::RefreshAccount { .. }
+    ));
+    assert_eq!(
+        result.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+    );
+    let after = market.markets[0]
+        .engine
+        .backing_short
+        .try_to_runtime()
+        .unwrap();
+    assert_eq!(after.status, BackingBucketStatusV16::Expired);
+    assert_eq!(after.fresh_unliened_backing_num, 0);
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(account.header.capital.get(), 100);
+    assert_eq!(account.header.pnl.get(), 40);
+    assert!(account.header.health_cert.try_to_runtime().unwrap().valid);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_auto_crank_skips_recovery_first_leg_for_live_refresh() {
     let (mut header, mut markets) = market_fixture(2, 100);
     let mut account_header = account_fixture(2, 22);

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3031,9 +3031,9 @@ fn v16_auto_crank_classifies_fresh_account_stale_then_refreshes_to_clean() {
 }
 
 #[test]
-fn v16_auto_crank_expires_lapsed_live_source_backing_before_refresh() {
-    let (mut header, mut markets) = market_fixture(1, 100);
-    let mut account_header = account_fixture(1, 22);
+fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut account_header = account_fixture(2, 22);
     {
         let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
         let mut account = PortfolioV16ViewMut::new(&mut account_header);
@@ -3042,16 +3042,34 @@ fn v16_auto_crank_expires_lapsed_live_source_backing_before_refresh() {
             .deposit_fresh_counterparty_backing_not_atomic(1, 40, 5)
             .unwrap();
         market
+            .deposit_fresh_counterparty_backing_not_atomic(3, 40, 5)
+            .unwrap();
+        market
             .add_account_source_positive_pnl_not_atomic(&mut account, 1, 40)
             .unwrap();
         market
+            .add_account_source_positive_pnl_not_atomic(&mut account, 3, 40)
+            .unwrap();
+        market
             .accrue_asset_to_not_atomic(0, 10, 100, 0, true)
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(1, 10, 100, 0, true)
             .unwrap();
     }
 
     let before = markets[0].engine.backing_short.try_to_runtime().unwrap();
     assert_eq!(before.status, BackingBucketStatusV16::Fresh);
     assert_eq!(before.expiry_slot, 5);
+    assert_eq!(
+        markets[1]
+            .engine
+            .backing_short
+            .try_to_runtime()
+            .unwrap()
+            .status,
+        BackingBucketStatusV16::Fresh
+    );
     assert!(header.current_slot.get() > before.expiry_slot);
     let vault_before = header.vault.get();
 
@@ -3062,7 +3080,7 @@ fn v16_auto_crank_expires_lapsed_live_source_backing_before_refresh() {
         effective_price: 100,
         funding_rate_e9: 0,
     }];
-    let result = market
+    let expiry = market
         .permissionless_auto_crank_not_atomic(
             &mut account,
             AutoCrankWorkV16 {
@@ -3075,12 +3093,14 @@ fn v16_auto_crank_expires_lapsed_live_source_backing_before_refresh() {
         .expect("Live auto-crank must expire lapsed backing instead of returning Stale");
 
     assert!(matches!(
-        result.selected,
+        expiry.selected,
         AutoCrankPlanV16::RefreshAccount { .. }
     ));
     assert_eq!(
-        result.outcome,
-        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+        expiry.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::SourceBackingExpired {
+            domain: 1
+        })
     );
     let after = market.markets[0]
         .engine
@@ -3089,9 +3109,63 @@ fn v16_auto_crank_expires_lapsed_live_source_backing_before_refresh() {
         .unwrap();
     assert_eq!(after.status, BackingBucketStatusV16::Expired);
     assert_eq!(after.fresh_unliened_backing_num, 0);
+    assert_eq!(
+        market.markets[1]
+            .engine
+            .backing_short
+            .try_to_runtime()
+            .unwrap()
+            .status,
+        BackingBucketStatusV16::Fresh,
+        "one auto-crank expires exactly one source domain"
+    );
     assert_eq!(market.header.vault.get(), vault_before);
     assert_eq!(account.header.capital.get(), 100);
-    assert_eq!(account.header.pnl.get(), 40);
+    assert_eq!(account.header.pnl.get(), 80);
+    assert!(!account.header.health_cert.try_to_runtime().unwrap().valid);
+
+    let second_expiry = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &observations,
+                liquidation_max_close_q: 0,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the next bounded auto-crank must expire the next domain");
+    assert_eq!(
+        second_expiry.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::SourceBackingExpired {
+            domain: 3
+        })
+    );
+    assert_eq!(
+        market.markets[1]
+            .engine
+            .backing_short
+            .try_to_runtime()
+            .unwrap()
+            .status,
+        BackingBucketStatusV16::Expired
+    );
+
+    let refresh = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &observations,
+                liquidation_max_close_q: 0,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the final bounded auto-crank must finish account refresh");
+    assert_eq!(
+        refresh.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+    );
     assert!(account.header.health_cert.try_to_runtime().unwrap().valid);
     market.validate_shape().unwrap();
     account.validate_with_market(&market.as_view()).unwrap();

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3072,6 +3072,11 @@ fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
     );
     assert!(header.current_slot.get() > before.expiry_slot);
     let vault_before = header.vault.get();
+    let c_tot_before = header.c_tot.get();
+    let insurance_before = header.insurance.get();
+    let earnings_before = header.backing_provider_earnings_total.get();
+    let source_backing_before = header.source_fresh_backing_total_num.get();
+    let risk_epoch_before = header.risk_epoch.get();
 
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
     let mut account = PortfolioV16ViewMut::new(&mut account_header);
@@ -3086,7 +3091,6 @@ fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
             AutoCrankWorkV16 {
                 now_slot: 10,
                 observations: &observations,
-                liquidation_max_close_q: 0,
                 resolved_close_fee_rate_per_slot: 0,
             },
         )
@@ -3120,6 +3124,17 @@ fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
         "one auto-crank expires exactly one source domain"
     );
     assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), c_tot_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
+    assert_eq!(
+        market.header.backing_provider_earnings_total.get(),
+        earnings_before
+    );
+    assert_eq!(
+        market.header.source_fresh_backing_total_num.get(),
+        source_backing_before - 40 * BOUND_SCALE
+    );
+    assert_eq!(market.header.risk_epoch.get(), risk_epoch_before + 1);
     assert_eq!(account.header.capital.get(), 100);
     assert_eq!(account.header.pnl.get(), 80);
     assert!(!account.header.health_cert.try_to_runtime().unwrap().valid);
@@ -3130,7 +3145,6 @@ fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
             AutoCrankWorkV16 {
                 now_slot: 10,
                 observations: &observations,
-                liquidation_max_close_q: 0,
                 resolved_close_fee_rate_per_slot: 0,
             },
         )
@@ -3150,6 +3164,15 @@ fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
             .status,
         BackingBucketStatusV16::Expired
     );
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), c_tot_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
+    assert_eq!(
+        market.header.backing_provider_earnings_total.get(),
+        earnings_before
+    );
+    assert_eq!(market.header.source_fresh_backing_total_num.get(), 0);
+    assert_eq!(market.header.risk_epoch.get(), risk_epoch_before + 2);
 
     let refresh = market
         .permissionless_auto_crank_not_atomic(
@@ -3157,7 +3180,6 @@ fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
             AutoCrankWorkV16 {
                 now_slot: 10,
                 observations: &observations,
-                liquidation_max_close_q: 0,
                 resolved_close_fee_rate_per_slot: 0,
             },
         )

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3100,6 +3100,144 @@ fn v16_auto_crank_classifies_fresh_account_stale_then_refreshes_to_clean() {
 }
 
 #[test]
+fn v16_auto_crank_settles_each_stale_kf_tail_leg_before_certifying() {
+    const PRICE: u64 = 1_000_000;
+    let (mut header, mut markets) = market_fixture(14, PRICE);
+    let mut long_header = account_fixture(14, 211);
+    let mut short_header = account_fixture(14, 212);
+    let requests = [
+        TradeRequestV16 {
+            asset_index: 0,
+            size_q: signed_q(POS_SCALE),
+            exec_price: PRICE,
+            fee_bps: 0,
+        },
+        TradeRequestV16 {
+            asset_index: 1,
+            size_q: signed_q(POS_SCALE),
+            exec_price: PRICE,
+            fee_bps: 0,
+        },
+        TradeRequestV16 {
+            asset_index: 2,
+            size_q: signed_q(POS_SCALE),
+            exec_price: PRICE,
+            fee_bps: 0,
+        },
+    ];
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market.deposit_not_atomic(&mut long, 10_000_000).unwrap();
+    market.deposit_not_atomic(&mut short, 10_000_000).unwrap();
+    market
+        .execute_batch_with_fee_loss_stale_scoped_not_atomic(&mut long, &mut short, &requests)
+        .unwrap();
+    // The old aggregate threshold treated 11 source domains + 3 pending
+    // legs as a safe 14-item tail and folded all three settlements into the
+    // certification call. The public SBF route exhausted its CU meter.
+    for domain in 0..11 {
+        market
+            .add_account_source_positive_pnl_not_atomic(&mut long, domain, 1)
+            .unwrap();
+    }
+    market
+        .accrue_asset_to_not_atomic(0, 20, 1_001_000, 0, true)
+        .unwrap();
+    market
+        .accrue_asset_to_not_atomic(1, 20, 1_001_000, 0, true)
+        .unwrap();
+    market
+        .accrue_asset_to_not_atomic(2, 20, 1_001_000, 0, true)
+        .unwrap();
+    assert_eq!(
+        long.header
+            .source_domains
+            .iter()
+            .filter(|source| source.is_occupied())
+            .count(),
+        11
+    );
+    assert_ne!(
+        long.header.legs[0].try_to_runtime().unwrap().k_snap,
+        market.markets[0]
+            .engine
+            .asset
+            .try_to_runtime()
+            .unwrap()
+            .k_long,
+    );
+
+    let work = AutoCrankWorkV16 {
+        now_slot: 20,
+        observations: &[],
+        resolved_close_fee_rate_per_slot: 0,
+    };
+    let first = market
+        .permissionless_auto_crank_not_atomic(&mut long, work)
+        .unwrap();
+    assert_eq!(
+        first.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountLegSettled {
+            asset_index: 0
+        })
+    );
+    assert!(!long.header.health_cert.try_to_runtime().unwrap().valid);
+    assert_eq!(
+        long.header.legs[0].try_to_runtime().unwrap().k_snap,
+        market.markets[0]
+            .engine
+            .asset
+            .try_to_runtime()
+            .unwrap()
+            .k_long,
+    );
+    assert_ne!(
+        long.header.legs[1].try_to_runtime().unwrap().k_snap,
+        market.markets[1]
+            .engine
+            .asset
+            .try_to_runtime()
+            .unwrap()
+            .k_long,
+    );
+
+    let second = market
+        .permissionless_auto_crank_not_atomic(&mut long, work)
+        .unwrap();
+    assert_eq!(
+        second.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountLegSettled {
+            asset_index: 1
+        })
+    );
+    assert!(!long.header.health_cert.try_to_runtime().unwrap().valid);
+
+    let third = market
+        .permissionless_auto_crank_not_atomic(&mut long, work)
+        .unwrap();
+    assert_eq!(
+        third.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountLegSettled {
+            asset_index: 2
+        })
+    );
+    assert!(!long.header.health_cert.try_to_runtime().unwrap().valid);
+
+    let certified = market
+        .permissionless_auto_crank_not_atomic(&mut long, work)
+        .unwrap();
+    assert_eq!(
+        certified.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+    );
+    assert!(long.header.health_cert.try_to_runtime().unwrap().valid);
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
     let (mut header, mut markets) = market_fixture(2, 100);
     let mut account_header = account_fixture(2, 22);

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3483,6 +3483,11 @@ fn v16_recovery_forfeit_migrates_legacy_normal_adl_residue_before_detach() {
     let mut account = PortfolioV16ViewMut::new(&mut account_header);
     market.deposit_not_atomic(&mut account, 1_000).unwrap();
     market.force_asset_recovery_not_atomic(0, 1).unwrap();
+    let vault_before = market.header.vault.get();
+    let c_tot_before = market.header.c_tot.get();
+    let insurance_before = market.header.insurance.get();
+    let capital_before = account.header.capital.get();
+    let pnl_before = account.header.pnl.get();
     let outcome = market
         .forfeit_recovery_leg_not_atomic(&mut account, 0, POS_SCALE)
         .expect("Recovery forfeit must detach a zero-effective-OI ADL residue");
@@ -3491,6 +3496,11 @@ fn v16_recovery_forfeit_migrates_legacy_normal_adl_residue_before_detach() {
     let reset = market.markets[0].engine.asset.try_to_runtime().unwrap();
     assert_eq!(reset.mode_long, SideModeV16::ResetPending);
     assert_eq!(reset.stored_pos_count_long, 0);
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), c_tot_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
+    assert_eq!(account.header.capital.get(), capital_before);
+    assert_eq!(account.header.pnl.get(), pnl_before);
     market.validate_shape().unwrap();
     account.validate_with_market(&market.as_view()).unwrap();
 }


### PR DESCRIPTION
Public LiteSVM construction can retain 20 source-claim domains. After one source lien is allocated, a one-position risk increase that needs a second lien exhausts the 1.4M SVM budget.

The per-domain allocator redundantly ran full account/market validation before and after each allocation, even though the allocating loop validates once and the trade runs its committed-state audit. Convert the inner helper to an explicitly named core and rely on those existing boundary validations.

The paired wrapper TDD reproduces the public lifecycle and measures the fixed second-lien trade at 898,270 CU. Kani does not model SBF compute units, so that LiteSVM regression is the direct DoS witness.

## Proof-driven verification

The production allocator and persisted account-source aggregate builder are shared directly by runtime validation and the proofs.

- `proof_v16_source_lien_allocation_plan_is_complete_bounded_and_ordered` symbolically composes four independent source domains with arbitrary claims, backing, rates, and request size. It proves exact greedy allocation, per-source claim/backing caps, zero allocation after completion, sufficient/insufficient aggregate behavior, and reachability of every source. Result: 208 checks, 5/5 covers, 37.49s.
- `proof_v16_source_lien_entry_relabel_preserves_persisted_aggregate_invariant` applies symbolic mixed counterparty/insurance liens through production mutation functions, then validates the persisted aggregate invariant used by full account validation. It proves partition totals, exact effective/backing scaling, claim-bound preservation, fee-cursor behavior, and impaired-state noninterference. Result: 243 checks, 4/4 covers, 7.55s.
- Existing production-path lien creation and scaled-unit proofs also pass: 121 checks in 1.05s and 422 checks with 3/3 covers in 194.77s.
- Mutation checks are effective: removing the backing cap fails the allocation theorem; omitting the counterparty backing aggregate update fails persisted validation.
- `cargo test --all-targets`: 139 passed, 0 failed.
- `cargo fmt --all -- --check` and `git diff --check`: pass.
- `spec.md` is unchanged.

Stacked on the max-source refresh branch because that branch makes the 20-domain public setup reachable.