### PR TITLE
[REAL DoS] Commit recovery-required auto-crank progress

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -172,10 +172,10 @@ pub fn v16_domain_pair_for_asset_index(asset_index: usize) -> V16Result<(usize, 
 /// price. `RefreshAccount { asset_index: Some(_) }` and EVERY other plan are
 /// dispatchable from committed on-chain state alone — `SettleBChunk` ignores
 /// price, `Liquidate` reads the current health cert, `DeclareRecovery` /
-/// `CloseResolved` / `NoAction` take no price — so a keeper holding no fresh
-/// observation can still drive the account forward (no liveness stall). A wrapper
-/// may call this to decide whether it must source an oracle observation before
-/// cranking.
+/// `FinalizeRecovery` / `CloseResolved` / `NoAction` take no price — so a keeper
+/// holding no fresh observation can still drive the account forward (no liveness
+/// stall). A wrapper may call this to decide whether it must source an oracle
+/// observation before cranking.
 ///
 /// The exhaustive match forces a conscious classification if a plan variant is
 /// added. `proof_v16_auto_crank_refresh_is_unique_observation_requiring_plan` pins
@@ -190,6 +190,7 @@ pub fn auto_crank_plan_requires_caller_observation(plan: &AutoCrankPlanV16) -> b
         AutoCrankPlanV16::SettleBChunk { .. }
         | AutoCrankPlanV16::Liquidate { .. }
         | AutoCrankPlanV16::DeclareRecovery { .. }
+        | AutoCrankPlanV16::FinalizeRecovery
         | AutoCrankPlanV16::CloseResolved
         | AutoCrankPlanV16::NoAction => false,
     }
@@ -1548,6 +1549,7 @@ impl V16Core {
         match r {
             AutoCrankPlanV16::NoAction => !summary.is_actionable(),
             AutoCrankPlanV16::DeclareRecovery { reason } => recovery && *reason == recovery_reason,
+            AutoCrankPlanV16::FinalizeRecovery => false,
             AutoCrankPlanV16::CloseResolved => !recovery && summary.resolved_winner,
             AutoCrankPlanV16::SettleBChunk { asset_index } =>
                 !recovery && !summary.resolved_winner && summary.b_stale && *asset_index == b_stale_slot,
@@ -4845,16 +4847,18 @@ pub enum AutoCrankPlanV16 {
     DeclareRecovery {
         reason: PermissionlessRecoveryReasonV16,
     },
+    FinalizeRecovery,
     CloseResolved,
 }
 
 /// The outcome of one self-classifying crank step: nothing actionable, a
 /// permissionless-progress outcome (refresh / settle-B / liquidate / recovery),
-/// or a resolved-close outcome.
+/// a Recovery-to-Resolved transition, or a resolved-close outcome.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AutoCrankOutcomeV16 {
     NoAction,
     Progressed(PermissionlessProgressOutcomeV16),
+    RecoveryResolved,
     ResolvedClose(ResolvedCloseOutcomeV16),
 }
 
@@ -9262,14 +9266,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(used)
     }
 
-    fn preflight_liquidation_residual_durability(
-        &mut self,
+    fn liquidation_residual_after_principal_and_insurance(
+        &self,
         asset_index: usize,
         bankrupt_side: SideV16,
         account: &PortfolioV16View<'_>,
-    ) -> V16Result<()> {
+    ) -> V16Result<u128> {
         let domain = self.insurance_domain_index(asset_index, opposite_side(bankrupt_side))?;
-        let residual_after_principal_and_insurance = if account.header.pnl.get() < 0 {
+        Ok(if account.header.pnl.get() < 0 {
             account
                 .header
                 .pnl
@@ -9279,16 +9283,46 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .saturating_sub(self.available_domain_insurance(domain)?)
         } else {
             0
-        };
+        })
+    }
+
+    fn liquidation_residual_exceeds_single_step_capacity(
+        &self,
+        asset_index: usize,
+        bankrupt_side: SideV16,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<bool> {
+        let residual_after_principal_and_insurance = self
+            .liquidation_residual_after_principal_and_insurance(
+                asset_index,
+                bankrupt_side,
+                account,
+            )?;
         if residual_after_principal_and_insurance == 0 {
-            return Ok(());
+            return Ok(false);
+        }
+        if self.header.config.public_b_chunk_atoms.get() < residual_after_principal_and_insurance {
+            return Ok(true);
         }
         let capacity = self.bankruptcy_residual_single_step_capacity(
             asset_index,
             bankrupt_side,
             residual_after_principal_and_insurance,
         )?;
-        if capacity < residual_after_principal_and_insurance {
+        Ok(capacity < residual_after_principal_and_insurance)
+    }
+
+    fn preflight_liquidation_residual_durability(
+        &mut self,
+        asset_index: usize,
+        bankrupt_side: SideV16,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<()> {
+        if self.liquidation_residual_exceeds_single_step_capacity(
+            asset_index,
+            bankrupt_side,
+            account,
+        )? {
             self.declare_permissionless_recovery(
                 PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
             )?;
@@ -11573,6 +11607,87 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(PermissionlessProgressOutcomeV16::AccountCurrent)
     }
 
+    fn liquidation_requires_recovery_from_current_state(
+        &self,
+        account: &PortfolioV16View<'_>,
+        asset_index: usize,
+    ) -> V16Result<bool> {
+        let config = self.header.config.try_to_runtime_shape()?;
+        if asset_index >= config.max_market_slots as usize {
+            return Err(V16Error::InvalidConfig);
+        }
+        let cert = account.header.health_cert.try_to_runtime()?;
+        if cert.certified_liq_deficit == 0 {
+            return Ok(false);
+        }
+        let leg_slot = Self::require_active_leg_slot_for_asset(account, asset_index)?;
+        let leg = account.header.legs[leg_slot].try_to_runtime()?;
+        let asset = self.asset_state(asset_index)?;
+        if !matches!(
+            asset.lifecycle,
+            AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
+        ) {
+            return Ok(false);
+        }
+        if self.has_pending_domain_loss_barrier(asset_index, leg.side)? {
+            return Ok(false);
+        }
+        let uncovered_loss = liquidation_uncovered_loss_after_principal(
+            account.header.pnl.get(),
+            account.header.capital.get(),
+        );
+        if uncovered_loss == 0 {
+            return Ok(false);
+        }
+        let active_bitmap = account.header.active_bitmap.map(V16PodU64::get);
+        if active_bitmap
+            .iter()
+            .map(|word| word.count_ones())
+            .sum::<u32>()
+            > 1
+        {
+            return Ok(true);
+        }
+        let residual_after_principal_and_insurance = self
+            .liquidation_residual_after_principal_and_insurance(asset_index, leg.side, account)?;
+        if self.header.config.public_b_chunk_atoms.get() < residual_after_principal_and_insurance {
+            return Ok(true);
+        }
+        let close_request_q = liquidation_engine_close_request_q(
+            config,
+            cert,
+            account.header.capital.get(),
+            account.header.pnl.get(),
+            leg,
+            asset.effective_price,
+            asset.raw_oracle_target_price,
+            config.liquidation_fee_bps,
+        )?;
+        let (close_q, _) =
+            V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, close_request_q)?;
+        if close_q == 0 {
+            return Ok(false);
+        }
+        if liquidation_close_would_leave_uncovered_loss_with_open_risk(
+            account.header.pnl.get(),
+            account.header.capital.get(),
+            account.header.active_bitmap.map(V16PodU64::get),
+            leg_slot,
+            close_q,
+            leg.basis_pos_q.unsigned_abs(),
+        )? {
+            return Ok(true);
+        }
+        if residual_after_principal_and_insurance == 0 {
+            return Ok(false);
+        }
+        Ok(self.bankruptcy_residual_single_step_capacity(
+            asset_index,
+            leg.side,
+            residual_after_principal_and_insurance,
+        )? < residual_after_principal_and_insurance)
+    }
+
     /// PRODUCTION CLASSIFIER (roadmap 3C step 4): map the real account/market
     /// state to the ActionableState summary the self-classifying crank dispatches
     /// from. Each flag is exactly its production eligibility predicate, MODE-
@@ -11582,7 +11697,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     ///   pending_close    — Live, a close-progress ledger is active
     ///   expired_close    — Live, that ledger is past its max-close slot
     ///   liquidatable     — Live, current cert with nonzero certified liq deficit
-    ///   recovery_eligible— Resolved, unattributed-insolvent negative-PnL recovery
+    ///   recovery_eligible— Live liquidation whose only bounded terminal is Recovery
     ///   resolved_winner  — Resolved, positive PnL, resolved payout ready
     /// Assembled via the proven actionable_summary_from_signals kernel. Live-only
     /// flags need cert currentness only where their entrypoint does (liquidate),
@@ -11609,6 +11724,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
 
         let has_open_risk =
             !active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get));
+        let (_, first_active_asset) = Self::auto_crank_selected_assets(account)?;
         // A close ledger with residual_remaining==0 is already fully booked/covered
         // (e.g. insurance absorbed the loss); only OUTSTANDING residual is real,
         // actionable close work. The `active` flag can linger past that.
@@ -11633,17 +11749,19 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // closed, but with no active leg there is nothing to liquidate (the real
         // liquidate entrypoint requires an active leg), so the flag must be false.
         let liquidatable = live && cert_current && cert.certified_liq_deficit != 0 && has_open_risk;
-        // Permissionless recovery (declare_permissionless_recovery) is a LIVE-mode
-        // action — it rejects Resolved mode with LockActive. The proactive Live
-        // recovery condition the auto-crank declares is an EXPIRED outstanding
-        // close (expired_close -> DeclareRecovery, reason
-        // ActiveBankruptCloseCannotProgress); every other recovery reason is
-        // declared REACTIVELY inside the dispatched crank op when it detects
-        // non-progress (BIndexHeadroomExhausted, etc.). Resolved bad-debt
-        // wind-down is handled by CloseResolved itself, not by the recovery
-        // selector flag, so recovery_eligible stays in the summary type for the
-        // proven selector but is driven by expired_close.
-        let recovery_eligible = false;
+        // Recovery must be selected before entering a liquidation route that can
+        // only return RecoveryRequired. Returning that error after mutating the
+        // market to Recovery is not progress on SVM: instruction rollback erases
+        // the declaration. Classify the same engine-selected close and residual
+        // capacity here so the public auto-crank commits Recovery as an Ok outcome.
+        let recovery_eligible = liquidatable
+            && !b_stale
+            && match first_active_asset {
+                Some(asset_index) => {
+                    self.liquidation_requires_recovery_from_current_state(account, asset_index)?
+                }
+                None => false,
+            };
         // resolved_winner routes to close_resolved, which LAZILY captures the
         // payout snapshot itself (initialize_resolved_payout_ledger_if_needed is
         // reached only via close_resolved -> create_resolved_payout_receipt) — so
@@ -11727,18 +11845,29 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     /// 5. On `Ok(result)`, mirror any wrapper-owned token/custody movement keyed off
     ///    `result.selected` (the `AutoCrankPlanV16`): refresh / settle-B move no
     ///    custody; liquidate / close-resolved may. `NoAction` => nothing was needed.
-    ///    `Err(NonProgress)` => the selected step needed an observation the caller
-    ///    did not supply (currently the no-active-asset refresh fallback, or a
-    ///    stale/late tx whose task changed) — no mutation, so SVM rollback is a
-    ///    clean no-op and arbitrary landing order is safe.
+    ///    In Recovery, the next call selects `FinalizeRecovery` and performs the
+    ///    value-neutral transition to Resolved so terminal account close remains
+    ///    publicly reachable. `Err(NonProgress)` => the selected step needed an
+    ///    observation the caller did not supply (currently the no-active-asset
+    ///    refresh fallback, or a stale/late tx whose task changed) — no mutation,
+    ///    so SVM rollback is a clean no-op and arbitrary landing order is safe.
     pub fn permissionless_auto_crank_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
         work: AutoCrankWorkV16<'_>,
     ) -> V16Result<AutoCrankResultV16> {
+        if decode_market_mode(self.header.mode)? == MarketModeV16::Recovery {
+            account.validate_with_market(&self.as_view())?;
+            self.resolve_market_not_atomic(work.now_slot)?;
+            account.validate_with_market(&self.as_view())?;
+            return Ok(AutoCrankResultV16 {
+                selected: AutoCrankPlanV16::FinalizeRecovery,
+                outcome: AutoCrankOutcomeV16::RecoveryResolved,
+            });
+        }
         let summary = self.build_actionable_summary(&account.as_view())?;
         let (b_stale_asset, active_asset) = Self::auto_crank_selected_assets(&account.as_view())?;
-        let recovery_reason = if summary.expired_close {
+        let recovery_reason = if summary.expired_close || summary.recovery_eligible {
             PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
         } else {
             PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow
@@ -11847,6 +11976,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     },
                 )?)
             }
+            AutoCrankPlanV16::FinalizeRecovery => return Err(V16Error::InvalidConfig),
             AutoCrankPlanV16::CloseResolved => {
                 AutoCrankOutcomeV16::ResolvedClose(self.close_resolved_account_not_atomic(
                     account,
@@ -14981,9 +15111,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     }
 
     pub fn resolve_market_not_atomic(&mut self, resolved_slot: u64) -> V16Result<()> {
-        if decode_market_mode(self.header.mode)? == MarketModeV16::Recovery {
-            return Err(V16Error::LockActive);
-        }
+        decode_market_mode(self.header.mode)?;
         if resolved_slot < self.header.current_slot.get() {
             return Err(V16Error::Stale);
         }

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1533,36 +1533,19 @@ impl V16Core {
         None
     }
 
-    /// PRODUCTION KERNEL: classify the liquidation terminals known before
-    /// residual-capacity work. `None` means the single-leg path must continue.
-    fn kernel_liquidation_recovery_before_residual(
-        uncovered_loss: u128,
-        active_leg_count: u32,
-    ) -> Option<bool> {
-        if uncovered_loss == 0 {
-            Some(false)
-        } else if active_leg_count > 1 {
-            Some(true)
-        } else {
-            None
-        }
-    }
-
-    /// PRODUCTION KERNEL: classify terminals after the engine computes its
-    /// bounded close. `None` means residual capacity decides the outcome.
-    fn kernel_liquidation_recovery_after_close(
-        close_q: u128,
-        leaves_uncovered_loss_with_open_risk: bool,
-        residual_after_principal_and_insurance: u128,
-    ) -> Option<bool> {
-        if close_q == 0 {
-            Some(false)
-        } else if leaves_uncovered_loss_with_open_risk {
-            Some(true)
-        } else if residual_after_principal_and_insurance == 0 {
-            Some(false)
-        } else {
-            None
+    /// PRODUCTION KERNEL: a liquidation error is successful public progress only
+    /// when the same call committed the matching Recovery state. Every other
+    /// error, including an incomplete Recovery marker, remains unchanged.
+    fn kernel_commit_declared_liquidation_recovery(
+        error: V16Error,
+        mode: MarketModeV16,
+        reason: Option<PermissionlessRecoveryReasonV16>,
+    ) -> V16Result<PermissionlessProgressOutcomeV16> {
+        match (error, mode, reason) {
+            (V16Error::RecoveryRequired, MarketModeV16::Recovery, Some(reason)) => {
+                Ok(PermissionlessProgressOutcomeV16::RecoveryDeclared(reason))
+            }
+            _ => Err(error),
         }
     }
 
@@ -11620,7 +11603,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             PermissionlessCrankActionV16::Liquidate(_) => {
                 if let PermissionlessCrankActionV16::Liquidate(liq) = request.action {
                     let liquidated_asset_index = liq.asset_index;
-                    self.liquidate_account_not_atomic(account, liq)?;
+                    if let Err(error) = self.liquidate_account_not_atomic(account, liq) {
+                        let mode = decode_market_mode(self.header.mode)?;
+                        let reason = self.header.recovery_reason.try_to_runtime()?;
+                        return V16Core::kernel_commit_declared_liquidation_recovery(
+                            error, mode, reason,
+                        );
+                    }
                     liquidated_asset_index == request.asset_index
                 } else {
                     unreachable!()
@@ -11640,85 +11629,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(PermissionlessProgressOutcomeV16::AccountCurrent)
     }
 
-    fn liquidation_requires_recovery_from_current_state(
-        &self,
-        account: &PortfolioV16View<'_>,
-        asset_index: usize,
-    ) -> V16Result<bool> {
-        let config = self.header.config.try_to_runtime_shape()?;
-        if asset_index >= config.max_market_slots as usize {
-            return Err(V16Error::InvalidConfig);
-        }
-        let cert = account.header.health_cert.try_to_runtime()?;
-        if cert.certified_liq_deficit == 0 {
-            return Ok(false);
-        }
-        let leg_slot = Self::require_active_leg_slot_for_asset(account, asset_index)?;
-        let leg = account.header.legs[leg_slot].try_to_runtime()?;
-        let asset = self.asset_state(asset_index)?;
-        if !matches!(
-            asset.lifecycle,
-            AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
-        ) {
-            return Ok(false);
-        }
-        if self.has_pending_domain_loss_barrier(asset_index, leg.side)? {
-            return Ok(false);
-        }
-        let uncovered_loss = liquidation_uncovered_loss_after_principal(
-            account.header.pnl.get(),
-            account.header.capital.get(),
-        );
-        let active_bitmap = account.header.active_bitmap.map(V16PodU64::get);
-        let active_leg_count = active_bitmap
-            .iter()
-            .map(|word| word.count_ones())
-            .sum::<u32>();
-        if let Some(requires_recovery) =
-            V16Core::kernel_liquidation_recovery_before_residual(uncovered_loss, active_leg_count)
-        {
-            return Ok(requires_recovery);
-        }
-        let residual_after_principal_and_insurance = self
-            .liquidation_residual_after_principal_and_insurance(asset_index, leg.side, account)?;
-        if self.header.config.public_b_chunk_atoms.get() < residual_after_principal_and_insurance {
-            return Ok(true);
-        }
-        let close_request_q = liquidation_engine_close_request_q(
-            config,
-            cert,
-            account.header.capital.get(),
-            account.header.pnl.get(),
-            leg,
-            asset.effective_price,
-            asset.raw_oracle_target_price,
-            config.liquidation_fee_bps,
-        )?;
-        let (close_q, _) =
-            V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, close_request_q)?;
-        let leaves_uncovered_loss_with_open_risk =
-            liquidation_close_would_leave_uncovered_loss_with_open_risk(
-                account.header.pnl.get(),
-                account.header.capital.get(),
-                account.header.active_bitmap.map(V16PodU64::get),
-                leg_slot,
-                close_q,
-                leg.basis_pos_q.unsigned_abs(),
-            )?;
-        if let Some(requires_recovery) = V16Core::kernel_liquidation_recovery_after_close(
-            close_q,
-            leaves_uncovered_loss_with_open_risk,
-            residual_after_principal_and_insurance,
-        ) {
-            return Ok(requires_recovery);
-        }
-        Ok(self.bankruptcy_residual_single_step_capacity(
-            asset_index,
-            leg.side,
-            residual_after_principal_and_insurance,
-        )? < residual_after_principal_and_insurance)
-    }
-
     /// PRODUCTION CLASSIFIER (roadmap 3C step 4): map the real account/market
     /// state to the ActionableState summary the self-classifying crank dispatches
     /// from. Each flag is exactly its production eligibility predicate, MODE-
@@ -11728,7 +11638,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     ///   pending_close    — Live, a close-progress ledger is active
     ///   expired_close    — Live, that ledger is past its max-close slot
     ///   liquidatable     — Live, current cert with nonzero certified liq deficit
-    ///   recovery_eligible— Live liquidation whose only bounded terminal is Recovery
+    ///   recovery_eligible— reserved for selector-level proactive Recovery
     ///   resolved_winner  — Resolved, positive PnL, resolved payout ready
     /// Assembled via the proven actionable_summary_from_signals kernel. Live-only
     /// flags need cert currentness only where their entrypoint does (liquidate),
@@ -11755,7 +11665,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
 
         let has_open_risk =
             !active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get));
-        let (_, first_active_asset) = Self::auto_crank_selected_assets(account)?;
         // A close ledger with residual_remaining==0 is already fully booked/covered
         // (e.g. insurance absorbed the loss); only OUTSTANDING residual is real,
         // actionable close work. The `active` flag can linger past that.
@@ -11780,19 +11689,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // closed, but with no active leg there is nothing to liquidate (the real
         // liquidate entrypoint requires an active leg), so the flag must be false.
         let liquidatable = live && cert_current && cert.certified_liq_deficit != 0 && has_open_risk;
-        // Recovery must be selected before entering a liquidation route that can
-        // only return RecoveryRequired. Returning that error after mutating the
-        // market to Recovery is not progress on SVM: instruction rollback erases
-        // the declaration. Classify the same engine-selected close and residual
-        // capacity here so the public auto-crank commits Recovery as an Ok outcome.
-        let recovery_eligible = liquidatable
-            && !b_stale
-            && match first_active_asset {
-                Some(asset_index) => {
-                    self.liquidation_requires_recovery_from_current_state(account, asset_index)?
-                }
-                None => false,
-            };
+        // Liquidation-only recovery is discovered by the liquidation itself. The
+        // auto-crank converts that exact committed terminal into successful
+        // progress without repeating liquidation sizing or residual scans here.
+        let recovery_eligible = false;
         // resolved_winner routes to close_resolved, which LAZILY captures the
         // payout snapshot itself (initialize_resolved_payout_ledger_if_needed is
         // reached only via close_resolved -> create_resolved_payout_receipt) — so
@@ -11898,7 +11798,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         let summary = self.build_actionable_summary(&account.as_view())?;
         let (b_stale_asset, active_asset) = Self::auto_crank_selected_assets(&account.as_view())?;
-        let recovery_reason = if summary.expired_close || summary.recovery_eligible {
+        let recovery_reason = if summary.expired_close {
             PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
         } else {
             PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1533,6 +1533,39 @@ impl V16Core {
         None
     }
 
+    /// PRODUCTION KERNEL: classify the liquidation terminals known before
+    /// residual-capacity work. `None` means the single-leg path must continue.
+    fn kernel_liquidation_recovery_before_residual(
+        uncovered_loss: u128,
+        active_leg_count: u32,
+    ) -> Option<bool> {
+        if uncovered_loss == 0 {
+            Some(false)
+        } else if active_leg_count > 1 {
+            Some(true)
+        } else {
+            None
+        }
+    }
+
+    /// PRODUCTION KERNEL: classify terminals after the engine computes its
+    /// bounded close. `None` means residual capacity decides the outcome.
+    fn kernel_liquidation_recovery_after_close(
+        close_q: u128,
+        leaves_uncovered_loss_with_open_risk: bool,
+        residual_after_principal_and_insurance: u128,
+    ) -> Option<bool> {
+        if close_q == 0 {
+            Some(false)
+        } else if leaves_uncovered_loss_with_open_risk {
+            Some(true)
+        } else if residual_after_principal_and_insurance == 0 {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
     /// PRODUCTION KERNEL (engine.md selection semantics): from the actionable
     /// summary and the ENGINE-selected assets, choose the single highest-priority
     /// bounded plan, carrying the engine-chosen asset (the caller chooses neither
@@ -11636,17 +11669,15 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             account.header.pnl.get(),
             account.header.capital.get(),
         );
-        if uncovered_loss == 0 {
-            return Ok(false);
-        }
         let active_bitmap = account.header.active_bitmap.map(V16PodU64::get);
-        if active_bitmap
+        let active_leg_count = active_bitmap
             .iter()
             .map(|word| word.count_ones())
-            .sum::<u32>()
-            > 1
+            .sum::<u32>();
+        if let Some(requires_recovery) =
+            V16Core::kernel_liquidation_recovery_before_residual(uncovered_loss, active_leg_count)
         {
-            return Ok(true);
+            return Ok(requires_recovery);
         }
         let residual_after_principal_and_insurance = self
             .liquidation_residual_after_principal_and_insurance(asset_index, leg.side, account)?;
@@ -11665,21 +11696,21 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         )?;
         let (close_q, _) =
             V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, close_request_q)?;
-        if close_q == 0 {
-            return Ok(false);
-        }
-        if liquidation_close_would_leave_uncovered_loss_with_open_risk(
-            account.header.pnl.get(),
-            account.header.capital.get(),
-            account.header.active_bitmap.map(V16PodU64::get),
-            leg_slot,
+        let leaves_uncovered_loss_with_open_risk =
+            liquidation_close_would_leave_uncovered_loss_with_open_risk(
+                account.header.pnl.get(),
+                account.header.capital.get(),
+                account.header.active_bitmap.map(V16PodU64::get),
+                leg_slot,
+                close_q,
+                leg.basis_pos_q.unsigned_abs(),
+            )?;
+        if let Some(requires_recovery) = V16Core::kernel_liquidation_recovery_after_close(
             close_q,
-            leg.basis_pos_q.unsigned_abs(),
-        )? {
-            return Ok(true);
-        }
-        if residual_after_principal_and_insurance == 0 {
-            return Ok(false);
+            leaves_uncovered_loss_with_open_risk,
+            residual_after_principal_and_insurance,
+        ) {
+            return Ok(requires_recovery);
         }
         Ok(self.bankruptcy_residual_single_step_capacity(
             asset_index,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -9,6 +9,41 @@
 use super::*;
 use crate::wide_math::U256;
 
+pub fn kani_liquidation_recovery_before_residual(
+    uncovered_loss: u128,
+    active_leg_count: u32,
+) -> Option<bool> {
+    V16Core::kernel_liquidation_recovery_before_residual(uncovered_loss, active_leg_count)
+}
+
+pub fn kani_liquidation_recovery_after_close(
+    close_q: u128,
+    leaves_uncovered_loss_with_open_risk: bool,
+    residual_after_principal_and_insurance: u128,
+) -> Option<bool> {
+    V16Core::kernel_liquidation_recovery_after_close(
+        close_q,
+        leaves_uncovered_loss_with_open_risk,
+        residual_after_principal_and_insurance,
+    )
+}
+
+pub fn kani_select_auto_crank_plan(
+    summary: ActionableSummaryV16,
+    b_stale_slot: usize,
+    liq_slot: usize,
+    refresh_asset: Option<usize>,
+    recovery_reason: PermissionlessRecoveryReasonV16,
+) -> AutoCrankPlanV16 {
+    V16Core::select_auto_crank_plan(
+        summary,
+        b_stale_slot,
+        liq_slot,
+        refresh_asset,
+        recovery_reason,
+    )
+}
+
 pub fn kani_apply_backing_utilization_fee_charge(
     account_capital: u128,
     group_c_tot: u128,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -9,39 +9,12 @@
 use super::*;
 use crate::wide_math::U256;
 
-pub fn kani_liquidation_recovery_before_residual(
-    uncovered_loss: u128,
-    active_leg_count: u32,
-) -> Option<bool> {
-    V16Core::kernel_liquidation_recovery_before_residual(uncovered_loss, active_leg_count)
-}
-
-pub fn kani_liquidation_recovery_after_close(
-    close_q: u128,
-    leaves_uncovered_loss_with_open_risk: bool,
-    residual_after_principal_and_insurance: u128,
-) -> Option<bool> {
-    V16Core::kernel_liquidation_recovery_after_close(
-        close_q,
-        leaves_uncovered_loss_with_open_risk,
-        residual_after_principal_and_insurance,
-    )
-}
-
-pub fn kani_select_auto_crank_plan(
-    summary: ActionableSummaryV16,
-    b_stale_slot: usize,
-    liq_slot: usize,
-    refresh_asset: Option<usize>,
-    recovery_reason: PermissionlessRecoveryReasonV16,
-) -> AutoCrankPlanV16 {
-    V16Core::select_auto_crank_plan(
-        summary,
-        b_stale_slot,
-        liq_slot,
-        refresh_asset,
-        recovery_reason,
-    )
+pub fn kani_commit_declared_liquidation_recovery(
+    error: V16Error,
+    mode: MarketModeV16,
+    reason: Option<PermissionlessRecoveryReasonV16>,
+) -> V16Result<PermissionlessProgressOutcomeV16> {
+    V16Core::kernel_commit_declared_liquidation_recovery(error, mode, reason)
 }
 
 pub fn kani_apply_backing_utilization_fee_charge(

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -3175,6 +3175,7 @@ fn proof_v16_recovery_mode_blocks_fee_sync_and_pnl_conversion_before_mutation() 
 #[kani::unwind(32)]
 #[kani::solver(cadical)]
 fn proof_v16_public_resolve_market_is_value_neutral_and_clears_loss_stale() {
+    let start_in_recovery: bool = kani::any();
     let current_slot_raw: u8 = kani::any();
     let stale_lag_raw: u8 = kani::any();
     let resolved_delta_raw: u8 = kani::any();
@@ -3197,10 +3198,17 @@ fn proof_v16_public_resolve_market_is_value_neutral_and_clears_loss_stale() {
     header.loss_stale_active = if slot_last < current_slot { 1 } else { 0 };
     header.current_slot = V16PodU64::new(current_slot);
     header.slot_last = V16PodU64::new(slot_last);
+    if start_in_recovery {
+        header.mode = 2;
+        header.recovery_reason = V16OptionalRecoveryReasonAccount::from_runtime(Some(
+            PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+        ));
+    }
     let vault_before = header.vault;
     let c_tot_before = header.c_tot;
     let insurance_before = header.insurance;
     let slot_last_before = header.slot_last;
+    let recovery_reason_before = header.recovery_reason;
     let asset_before = markets[0].engine.asset;
     let long_budget_before = markets[0].engine.insurance_domain_budget_long;
     let short_budget_before = markets[0].engine.insurance_domain_budget_short;
@@ -3221,11 +3229,16 @@ fn proof_v16_public_resolve_market_is_value_neutral_and_clears_loss_stale() {
             && surplus > 255,
         "resolved market transition covers future authenticated slot over wide symbolic value state"
     );
+    kani::cover!(
+        start_in_recovery && c_tot > 255 && insurance > 255,
+        "permissionless Recovery-to-Resolved transition preserves nontrivial senior value"
+    );
     assert_eq!(market.header.mode, 1);
     assert_eq!(market.header.resolved_slot.get(), resolved_slot);
     assert_eq!(market.header.current_slot.get(), resolved_slot);
     assert_eq!(market.header.slot_last, slot_last_before);
     assert_eq!(market.header.loss_stale_active, 0);
+    assert_eq!(market.header.recovery_reason, recovery_reason_before);
     assert_eq!(market.header.vault, vault_before);
     assert_eq!(market.header.c_tot, c_tot_before);
     assert_eq!(market.header.insurance, insurance_before);
@@ -14647,9 +14660,16 @@ fn proof_v16_frame_earnings_withdraw_touches_only_declared_state() {
 #[kani::unwind(40)]
 #[kani::solver(cadical)]
 fn proof_v16_frame_resolve_market_touches_only_declared_state() {
+    let start_in_recovery: bool = kani::any();
     let delta_raw: u8 = kani::any();
     kani::assume(delta_raw >= 1 && delta_raw <= 8);
     let (mut header, mut markets, _) = one_market_view_fixture();
+    if start_in_recovery {
+        header.mode = 2;
+        header.recovery_reason = V16OptionalRecoveryReasonAccount::from_runtime(Some(
+            PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+        ));
+    }
     let resolved_slot = header.current_slot.get() + delta_raw as u64;
     let h0 = header;
     let s0 = markets[0].engine;
@@ -14657,7 +14677,7 @@ fn proof_v16_frame_resolve_market_touches_only_declared_state() {
         let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
         market.resolve_market_not_atomic(resolved_slot).unwrap();
     }
-    kani::cover!(true, "resolve frame reached");
+    kani::cover!(start_in_recovery, "Recovery-to-Resolved frame reached");
     let mut eh = h0;
     eh.mode = 1;
     eh.resolved_slot = V16PodU64::new(resolved_slot);
@@ -15253,7 +15273,7 @@ fn proof_v16_validator_sound_account_reserves() {
 // asset refresh and every other plan are dispatchable from committed state.
 // Pinning this truth table means a future arm that gates committed-state progress
 // on an observation contradicts a machine-checked theorem. Exhaustive over the
-// six AutoCrankPlanV16 variants; the spec matrix ties the predicate to the real
+// seven AutoCrankPlanV16 variants; the spec matrix ties the predicate to the real
 // dispatch for each reachable class.
 #[kani::proof]
 fn proof_v16_auto_crank_refresh_is_unique_observation_requiring_plan() {
@@ -15274,6 +15294,7 @@ fn proof_v16_auto_crank_refresh_is_unique_observation_requiring_plan() {
     }));
     assert!(!needs_obs(&AutoCrankPlanV16::Liquidate { asset_index: i }));
     assert!(!needs_obs(&AutoCrankPlanV16::NoAction));
+    assert!(!needs_obs(&AutoCrankPlanV16::FinalizeRecovery));
     assert!(!needs_obs(&AutoCrankPlanV16::CloseResolved));
     // The predicate matches DeclareRecovery { .. } regardless of reason, so a
     // concrete variant exercises the arm (the reason enum isn't Arbitrary here).

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -13,12 +13,14 @@ use percolator::v16::{
     kani_liquidation_close_would_leave_uncovered_loss_with_open_risk,
     kani_liquidation_engine_close_request_q, kani_liquidation_fee_from_raw_fee,
     kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
-    kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
+    kani_liquidation_projected_healthy_after_close, kani_liquidation_recovery_after_close,
+    kani_liquidation_recovery_before_residual, kani_loss_stale_trade_scope_allowed,
     kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
-    kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
-    kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
-    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
-    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
+    kani_prepare_asset_recovery_transition, kani_select_auto_crank_plan,
+    kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
+    kani_trade_preexisting_oi_reduction_gate, kani_trade_preflight_risk_gate,
+    kani_validate_positive_pnl_source_attribution, ActionableSummaryV16, AssetLifecycleV16,
+    AssetStateV16, AssetStateV16Account, AutoCrankPlanV16, BackingBucketStatusV16,
     BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
     CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
     HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
@@ -15422,4 +15424,118 @@ fn proof_v16_backing_utilization_zero_fee_carries_accrual_forward() {
     assert_eq!(market.header.c_tot.get(), c_tot_before);
     assert_eq!(market.header.vault.get(), vault_before);
     assert_eq!(market.header.insurance.get(), insurance_before);
+}
+
+// Rollback-sensitive auto-crank liveness theorem. This composes every
+// liquidation terminal that must select DeclareRecovery before entering a path
+// that would otherwise mutate Recovery and return an error. The scalar inputs
+// span their full production bounds; the resulting plan must be recovery iff
+// no bounded liquidation terminal can commit normally.
+#[kani::proof]
+#[kani::unwind(4)]
+#[kani::solver(cadical)]
+fn proof_v16_recovery_required_liquidation_is_classified_before_dispatch() {
+    let uncovered_loss: u128 = kani::any();
+    let active_leg_count_raw: u8 = kani::any();
+    let residual: u128 = kani::any();
+    let public_chunk_cap: u128 = kani::any();
+    let close_q: u128 = kani::any();
+    let leaves_uncovered_open_risk: bool = kani::any();
+    let residual_capacity: u128 = kani::any();
+    kani::assume(uncovered_loss <= MAX_VAULT_TVL);
+    kani::assume((1..=V16_MAX_PORTFOLIO_ASSETS_N as u8).contains(&active_leg_count_raw));
+    kani::assume(residual <= MAX_VAULT_TVL);
+    kani::assume(public_chunk_cap <= MAX_VAULT_TVL);
+    kani::assume(close_q <= MAX_POSITION_ABS_Q);
+    kani::assume(residual_capacity <= MAX_VAULT_TVL);
+    let active_leg_count = active_leg_count_raw as u32;
+
+    let requires_recovery =
+        match kani_liquidation_recovery_before_residual(uncovered_loss, active_leg_count) {
+            Some(decision) => decision,
+            None if public_chunk_cap < residual => true,
+            None => match kani_liquidation_recovery_after_close(
+                close_q,
+                leaves_uncovered_open_risk,
+                residual,
+            ) {
+                Some(decision) => decision,
+                None => residual_capacity < residual,
+            },
+        };
+    let expected = uncovered_loss != 0
+        && (active_leg_count > 1
+            || public_chunk_cap < residual
+            || (close_q != 0
+                && (leaves_uncovered_open_risk
+                    || (residual != 0 && residual_capacity < residual))));
+    assert_eq!(requires_recovery, expected);
+
+    let selected_asset: usize = kani::any();
+    let plan = kani_select_auto_crank_plan(
+        ActionableSummaryV16 {
+            stale: false,
+            b_stale: false,
+            pending_close: false,
+            expired_close: false,
+            liquidatable: true,
+            recovery_eligible: requires_recovery,
+            resolved_winner: false,
+        },
+        0,
+        selected_asset,
+        Some(selected_asset),
+        PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+    );
+    if requires_recovery {
+        assert_eq!(
+            plan,
+            AutoCrankPlanV16::DeclareRecovery {
+                reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
+            }
+        );
+    } else {
+        assert_eq!(
+            plan,
+            AutoCrankPlanV16::Liquidate {
+                asset_index: selected_asset
+            }
+        );
+    }
+
+    kani::cover!(
+        uncovered_loss != 0 && active_leg_count > 1,
+        "cross-margin uncovered loss selects recovery"
+    );
+    kani::cover!(
+        uncovered_loss != 0 && active_leg_count == 1 && public_chunk_cap < residual,
+        "public residual cap exhaustion selects recovery"
+    );
+    kani::cover!(
+        uncovered_loss != 0
+            && active_leg_count == 1
+            && public_chunk_cap >= residual
+            && close_q != 0
+            && leaves_uncovered_open_risk,
+        "partial close leaving uncovered open risk selects recovery"
+    );
+    kani::cover!(
+        uncovered_loss != 0
+            && active_leg_count == 1
+            && public_chunk_cap >= residual
+            && close_q != 0
+            && !leaves_uncovered_open_risk
+            && residual != 0
+            && residual_capacity < residual,
+        "insufficient residual capacity selects recovery"
+    );
+    kani::cover!(
+        uncovered_loss != 0
+            && active_leg_count == 1
+            && public_chunk_cap >= residual
+            && close_q != 0
+            && !leaves_uncovered_open_risk
+            && (residual == 0 || residual_capacity >= residual),
+        "ordinary single-leg liquidation remains dispatchable"
+    );
 }

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -8,23 +8,22 @@ use percolator::v16::{
     kani_available_backing_num_for_source_credit_state,
     kani_backing_utilization_fee_quote_atoms_for_lien,
     kani_backing_utilization_rate_e9_for_source_state, kani_cert_is_current,
-    kani_expected_source_credit_rate_num_for_state, kani_health_cert_after_capital_debit,
-    kani_health_requirements_from_base_and_target_lag,
+    kani_commit_declared_liquidation_recovery, kani_expected_source_credit_rate_num_for_state,
+    kani_health_cert_after_capital_debit, kani_health_requirements_from_base_and_target_lag,
     kani_liquidation_close_would_leave_uncovered_loss_with_open_risk,
     kani_liquidation_engine_close_request_q, kani_liquidation_fee_from_raw_fee,
     kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
-    kani_liquidation_projected_healthy_after_close, kani_liquidation_recovery_after_close,
-    kani_liquidation_recovery_before_residual, kani_loss_stale_trade_scope_allowed,
+    kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
     kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
-    kani_prepare_asset_recovery_transition, kani_select_auto_crank_plan,
-    kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
-    kani_trade_preexisting_oi_reduction_gate, kani_trade_preflight_risk_gate,
-    kani_validate_positive_pnl_source_attribution, ActionableSummaryV16, AssetLifecycleV16,
-    AssetStateV16, AssetStateV16Account, AutoCrankPlanV16, BackingBucketStatusV16,
-    BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
-    CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
-    HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
-    Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
+    kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
+    kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
+    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
+    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
+    BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16,
+    CloseProgressLedgerV16, CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16,
+    HealthCertV16, HealthCertV16Account, InsuranceCreditReservationV16,
+    InsuranceCreditReservationV16Account, Market, MarketGroupV16HeaderAccount,
+    MarketGroupV16ViewMut, MarketModeV16, PermissionlessCrankActionV16,
     PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
@@ -15426,116 +15425,82 @@ fn proof_v16_backing_utilization_zero_fee_carries_accrual_forward() {
     assert_eq!(market.header.insurance.get(), insurance_before);
 }
 
-// Rollback-sensitive auto-crank liveness theorem. This composes every
-// liquidation terminal that must select DeclareRecovery before entering a path
-// that would otherwise mutate Recovery and return an error. The scalar inputs
-// span their full production bounds; the resulting plan must be recovery iff
-// no bounded liquidation terminal can commit normally.
+// Rollback-sensitive auto-crank theorem: no engine error may be swallowed unless
+// the same liquidation call left a complete committed Recovery marker. This is
+// exhaustive over every V16Error, market mode, recovery reason, and missing-reason
+// state. The production integration test drives the real cross-margin liquidation
+// into this kernel; this theorem pins the fail-closed conversion boundary.
 #[kani::proof]
 #[kani::unwind(4)]
 #[kani::solver(cadical)]
-fn proof_v16_recovery_required_liquidation_is_classified_before_dispatch() {
-    let uncovered_loss: u128 = kani::any();
-    let active_leg_count_raw: u8 = kani::any();
-    let residual: u128 = kani::any();
-    let public_chunk_cap: u128 = kani::any();
-    let close_q: u128 = kani::any();
-    let leaves_uncovered_open_risk: bool = kani::any();
-    let residual_capacity: u128 = kani::any();
-    kani::assume(uncovered_loss <= MAX_VAULT_TVL);
-    kani::assume((1..=V16_MAX_PORTFOLIO_ASSETS_N as u8).contains(&active_leg_count_raw));
-    kani::assume(residual <= MAX_VAULT_TVL);
-    kani::assume(public_chunk_cap <= MAX_VAULT_TVL);
-    kani::assume(close_q <= MAX_POSITION_ABS_Q);
-    kani::assume(residual_capacity <= MAX_VAULT_TVL);
-    let active_leg_count = active_leg_count_raw as u32;
+fn proof_v16_liquidation_error_commits_only_fully_declared_recovery() {
+    let error_tag: u8 = kani::any();
+    let mode_tag: u8 = kani::any();
+    let reason_tag: u8 = kani::any();
+    kani::assume(error_tag < 12);
+    kani::assume(mode_tag < 3);
+    kani::assume(reason_tag <= 8);
 
-    let requires_recovery =
-        match kani_liquidation_recovery_before_residual(uncovered_loss, active_leg_count) {
-            Some(decision) => decision,
-            None if public_chunk_cap < residual => true,
-            None => match kani_liquidation_recovery_after_close(
-                close_q,
-                leaves_uncovered_open_risk,
-                residual,
-            ) {
-                Some(decision) => decision,
-                None => residual_capacity < residual,
-            },
-        };
-    let expected = uncovered_loss != 0
-        && (active_leg_count > 1
-            || public_chunk_cap < residual
-            || (close_q != 0
-                && (leaves_uncovered_open_risk
-                    || (residual != 0 && residual_capacity < residual))));
-    assert_eq!(requires_recovery, expected);
+    let error = match error_tag {
+        0 => V16Error::InvalidConfig,
+        1 => V16Error::ArithmeticOverflow,
+        2 => V16Error::ProvenanceMismatch,
+        3 => V16Error::HiddenLeg,
+        4 => V16Error::InvalidLeg,
+        5 => V16Error::Stale,
+        6 => V16Error::BStale,
+        7 => V16Error::LockActive,
+        8 => V16Error::NonProgress,
+        9 => V16Error::RecoveryRequired,
+        10 => V16Error::CounterOverflow,
+        _ => V16Error::CounterUnderflow,
+    };
+    let mode = match mode_tag {
+        0 => MarketModeV16::Live,
+        1 => MarketModeV16::Resolved,
+        _ => MarketModeV16::Recovery,
+    };
+    let reason = match reason_tag {
+        0 => Some(PermissionlessRecoveryReasonV16::BelowProgressFloor),
+        1 => Some(PermissionlessRecoveryReasonV16::BlockedSegmentHeadroomOrRepresentability),
+        2 => Some(PermissionlessRecoveryReasonV16::AccountBSettlementCannotProgress),
+        3 => Some(PermissionlessRecoveryReasonV16::BIndexHeadroomExhausted),
+        4 => Some(PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress),
+        5 => Some(PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow),
+        6 => Some(PermissionlessRecoveryReasonV16::OracleOrTargetUnavailableByAuthenticatedPolicy),
+        7 => Some(PermissionlessRecoveryReasonV16::CounterOrEpochOverflowDeclaredRecovery),
+        _ => None,
+    };
 
-    let selected_asset: usize = kani::any();
-    let plan = kani_select_auto_crank_plan(
-        ActionableSummaryV16 {
-            stale: false,
-            b_stale: false,
-            pending_close: false,
-            expired_close: false,
-            liquidatable: true,
-            recovery_eligible: requires_recovery,
-            resolved_winner: false,
-        },
-        0,
-        selected_asset,
-        Some(selected_asset),
-        PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
-    );
-    if requires_recovery {
+    let result = kani_commit_declared_liquidation_recovery(error, mode, reason);
+    let complete_declaration =
+        error == V16Error::RecoveryRequired && mode == MarketModeV16::Recovery && reason.is_some();
+    if complete_declaration {
         assert_eq!(
-            plan,
-            AutoCrankPlanV16::DeclareRecovery {
-                reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
-            }
+            result,
+            Ok(PermissionlessProgressOutcomeV16::RecoveryDeclared(
+                reason.unwrap()
+            ))
         );
     } else {
-        assert_eq!(
-            plan,
-            AutoCrankPlanV16::Liquidate {
-                asset_index: selected_asset
-            }
-        );
+        assert_eq!(result, Err(error));
     }
 
     kani::cover!(
-        uncovered_loss != 0 && active_leg_count > 1,
-        "cross-margin uncovered loss selects recovery"
+        complete_declaration
+            && reason == Some(PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress),
+        "a fully declared liquidation terminal commits successful recovery progress"
     );
     kani::cover!(
-        uncovered_loss != 0 && active_leg_count == 1 && public_chunk_cap < residual,
-        "public residual cap exhaustion selects recovery"
+        error == V16Error::RecoveryRequired && mode == MarketModeV16::Live,
+        "a bare recovery-required error is not swallowed"
     );
     kani::cover!(
-        uncovered_loss != 0
-            && active_leg_count == 1
-            && public_chunk_cap >= residual
-            && close_q != 0
-            && leaves_uncovered_open_risk,
-        "partial close leaving uncovered open risk selects recovery"
+        error == V16Error::RecoveryRequired && mode == MarketModeV16::Recovery && reason.is_none(),
+        "an incomplete Recovery marker fails closed"
     );
     kani::cover!(
-        uncovered_loss != 0
-            && active_leg_count == 1
-            && public_chunk_cap >= residual
-            && close_q != 0
-            && !leaves_uncovered_open_risk
-            && residual != 0
-            && residual_capacity < residual,
-        "insufficient residual capacity selects recovery"
-    );
-    kani::cover!(
-        uncovered_loss != 0
-            && active_leg_count == 1
-            && public_chunk_cap >= residual
-            && close_q != 0
-            && !leaves_uncovered_open_risk
-            && (residual == 0 || residual_capacity >= residual),
-        "ordinary single-leg liquidation remains dispatchable"
+        error != V16Error::RecoveryRequired && mode == MarketModeV16::Recovery && reason.is_some(),
+        "Recovery state cannot mask an unrelated engine error"
     );
 }

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3279,7 +3279,7 @@ fn v16_auto_crank_commits_recovery_for_uncovered_cross_margin_liquidation() {
         .full_account_refresh_not_atomic(&mut account)
         .expect("setup must produce a current cross-margin liquidation cert");
     let summary = market.build_actionable_summary(&account.as_view()).unwrap();
-    assert!(summary.liquidatable && summary.recovery_eligible);
+    assert!(summary.liquidatable && !summary.recovery_eligible);
 
     let bitmap_before = account.header.active_bitmap;
     let pnl_before = account.header.pnl;
@@ -3300,9 +3300,7 @@ fn v16_auto_crank_commits_recovery_for_uncovered_cross_margin_liquidation() {
 
     assert_eq!(
         result.selected,
-        AutoCrankPlanV16::DeclareRecovery {
-            reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
-        }
+        AutoCrankPlanV16::Liquidate { asset_index: 0 }
     );
     assert_eq!(
         result.outcome,

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -13,7 +13,8 @@ use percolator::{
     ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedPayoutLedgerV16,
     ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16, ResolvedPayoutReceiptV16Account,
     SideModeV16, SideV16, SourceCreditStateV16, SourceCreditStateV16Account, TradeRequestV16,
-    V16Config, V16Error, V16PodI128, V16PodU128, V16PodU32, V16PodU64, V16_EMPTY_ACTIVE_BITMAP,
+    V16Config, V16Error, V16OptionalRecoveryReasonAccount, V16PodI128, V16PodU128, V16PodU32,
+    V16PodU64, V16_EMPTY_ACTIVE_BITMAP,
 };
 use percolator::{ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, POS_SCALE};
 
@@ -3230,6 +3231,123 @@ fn v16_auto_crank_liquidates_current_account_without_observation() {
     account.validate_with_market(&market.as_view()).unwrap();
 }
 
+#[test]
+fn v16_auto_crank_commits_recovery_for_uncovered_cross_margin_liquidation() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut account_header = account_fixture(2, 15);
+    header.current_slot = V16PodU64::new(10);
+    header.slot_last = V16PodU64::new(10);
+    header.vault = V16PodU128::new(50);
+    header.insurance = V16PodU128::new(50);
+    header.negative_pnl_account_count = V16PodU64::new(1);
+
+    for (asset_index, market_slot) in markets.iter_mut().enumerate() {
+        let mut asset = market_slot.engine.asset.try_to_runtime().unwrap();
+        asset.slot_last = 10;
+        asset.oi_eff_long_q = 2 * POS_SCALE;
+        asset.oi_eff_short_q = 2 * POS_SCALE;
+        asset.loss_weight_sum_long = 2 * POS_SCALE;
+        asset.loss_weight_sum_short = 2 * POS_SCALE;
+        asset.stored_pos_count_long = 2;
+        asset.stored_pos_count_short = 2;
+        market_slot.engine.asset = AssetStateV16Account::from_runtime(&asset);
+        account_header.legs[asset_index] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+            active: true,
+            asset_index: asset_index as u32,
+            market_id: asset.market_id,
+            side: SideV16::Long,
+            basis_pos_q: POS_SCALE as i128,
+            a_basis: ADL_ONE,
+            k_snap: asset.k_long,
+            f_snap: asset.f_long_num,
+            epoch_snap: asset.epoch_long,
+            loss_weight: POS_SCALE,
+            b_snap: asset.b_long_num,
+            b_rem: 0,
+            b_epoch_snap: asset.epoch_long,
+            b_stale: false,
+            stale: false,
+        });
+    }
+    header.resolved_payout_blocker_count = V16PodU64::new(8);
+    account_header.active_bitmap[0] = V16PodU64::new(0b11);
+    account_header.pnl = V16PodI128::new(-5);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market
+        .full_account_refresh_not_atomic(&mut account)
+        .expect("setup must produce a current cross-margin liquidation cert");
+    let summary = market.build_actionable_summary(&account.as_view()).unwrap();
+    assert!(summary.liquidatable && summary.recovery_eligible);
+
+    let bitmap_before = account.header.active_bitmap;
+    let pnl_before = account.header.pnl;
+    let capital_before = account.header.capital;
+    let vault_before = market.header.vault;
+    let c_tot_before = market.header.c_tot;
+    let insurance_before = market.header.insurance;
+    let result = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &[],
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("recovery-required liquidation must be successful crank progress");
+
+    assert_eq!(
+        result.selected,
+        AutoCrankPlanV16::DeclareRecovery {
+            reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+        }
+    );
+    assert_eq!(
+        result.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::RecoveryDeclared(
+            PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+        ))
+    );
+    assert_eq!(market.header.mode, 2, "market must commit Recovery mode");
+    assert_eq!(account.header.active_bitmap, bitmap_before);
+    assert_eq!(account.header.pnl, pnl_before);
+    assert_eq!(account.header.capital, capital_before);
+    assert_eq!(market.header.vault, vault_before);
+    assert_eq!(market.header.c_tot, c_tot_before);
+    assert_eq!(market.header.insurance, insurance_before);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+
+    let recovery_reason_before = market.header.recovery_reason;
+    let finalized = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &[],
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the next public crank must finalize Recovery into Resolved");
+    assert_eq!(finalized.selected, AutoCrankPlanV16::FinalizeRecovery);
+    assert_eq!(finalized.outcome, AutoCrankOutcomeV16::RecoveryResolved);
+    assert_eq!(
+        market.header.mode, 1,
+        "terminal close must become reachable"
+    );
+    assert_eq!(market.header.recovery_reason, recovery_reason_before);
+    assert_eq!(account.header.active_bitmap, bitmap_before);
+    assert_eq!(account.header.pnl, pnl_before);
+    assert_eq!(account.header.capital, capital_before);
+    assert_eq!(market.header.vault, vault_before);
+    assert_eq!(market.header.c_tot, c_tot_before);
+    assert_eq!(market.header.insurance, insurance_before);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
 // ROADMAP 3C step 4 — terminal no-DoS route via the self-classifying crank: a
 // Live account whose outstanding bankruptcy close ledger has EXPIRED (current
 // slot past max_close_slot) is classified expired_close, and the auto-crank
@@ -3725,6 +3843,25 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
         AutoCrankPlanV16::DeclareRecovery {
             reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
         },
+        false,
+    );
+
+    // --- A6 terminal Recovery: the next step is a value-neutral transition to
+    // Resolved and needs no oracle observation.
+    assert_observation_independent(
+        "finalize_recovery",
+        || {
+            let (mut header, markets) = market_fixture(1, 100);
+            let account_header = account_fixture(1, 205);
+            header.mode = 2;
+            header.recovery_reason = V16OptionalRecoveryReasonAccount::from_runtime(Some(
+                PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+            ));
+            (header, markets, account_header)
+        },
+        0,
+        10,
+        AutoCrankPlanV16::FinalizeRecovery,
         false,
     );
 


### PR DESCRIPTION
## What changed

- Convert a liquidation `RecoveryRequired` into successful crank progress only when that same call left a complete Recovery mode + reason marker.
- Preserve every other engine error unchanged, including bare `RecoveryRequired`, incomplete Recovery state, and unrelated errors while Recovery is set.
- Let the next auto-crank perform the value-neutral Recovery-to-Resolved transition.
- Avoid duplicate liquidation sizing, leg scans, and residual-capacity work on the hot path.

## Root cause

A liquidation could declare Recovery and then return `RecoveryRequired`. The wrapper propagated the error, so SVM rollback erased the declaration and permissionless keepers could repeat the same failing transaction forever.

## PDD evidence

- Red, engine parent `143e68c`: the public LiteSVM crank fails `Custom(23)` after 95,157 CU and Recovery rolls back.
- Kani `proof_v16_liquidation_error_commits_only_fully_declared_recovery`: exhaustive over all 12 engine errors, all 3 market modes, all 8 reasons plus missing reason; 296 checks, 4/4 covers, 0.126s.
- Engine integration drives a real two-leg uncovered-loss liquidation through the reactive Recovery path, checks value/account neutrality, then reaches Resolved on the next crank.
- Wrapper PR #190 runs the same behavior through the public instruction and SVM rollback boundary.

## Validation

- `cargo test --all-targets`: 130 passed
- `cargo kani --tests --features fuzz --harness proof_v16_liquidation_error_commits_only_fully_declared_recovery`: passed
- Wrapper exact recovery regression: passed
- Wrapper issue-103 partial-liquidation CU guard (325k): passed
- Wrapper full suite: 5 unit + 564 LiteSVM tests passed
- `cargo fmt --all -- --check`
- `git diff --check`
