### PR TITLE
[REAL DoS] Allow resolved close after ADL scaling

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1495,6 +1495,8 @@ For every recovered account, the engine MUST compute `recovery_value_transfer_bo
 
 Recovery preserves and reconciles `SourceCreditState`, insurance-credit reservations, lien buckets including impaired buckets, liens, close ledgers, pending obligations, B/ADL/support progress, and payout ledgers. It cannot erase ledgered progress and recompute gross loss. Recovery direct positive payout must use resolved receipts or pay no positive junior value.
 
+Resolved terminal leg detachment is ADL-aware. For a current-epoch leg it removes `min(abs(stored_basis_q), remaining_OI_eff_side)` from effective OI while removing the leg's full stored-position count and loss weight; for a leg whose side aggregates were already cleared by a prior reset, it removes only the stored record. Thus quantity ADL cannot leave a basis record that underflows effective OI and permanently blocks resolved close. This terminal metadata step does not move quote value.
+
 Resolved payout is progressive and source-domain based:
 1. initialize a `ResolvedPayoutLedger` after terminal losses, insurance, source-credit liens, barriers, and obligations are settled/reserved;
 2. disable ordinary positive-PnL withdrawals/releases;

--- a/spec.md
+++ b/spec.md
@@ -1495,8 +1495,6 @@ For every recovered account, the engine MUST compute `recovery_value_transfer_bo
 
 Recovery preserves and reconciles `SourceCreditState`, insurance-credit reservations, lien buckets including impaired buckets, liens, close ledgers, pending obligations, B/ADL/support progress, and payout ledgers. It cannot erase ledgered progress and recompute gross loss. Recovery direct positive payout must use resolved receipts or pay no positive junior value.
 
-Resolved terminal leg detachment is ADL-aware. For a current-epoch leg it removes `min(abs(stored_basis_q), remaining_OI_eff_side)` from effective OI while removing the leg's full stored-position count and loss weight; for a leg whose side aggregates were already cleared by a prior reset, it removes only the stored record. Thus quantity ADL cannot leave a basis record that underflows effective OI and permanently blocks resolved close. This terminal metadata step does not move quote value.
-
 Resolved payout is progressive and source-domain based:
 1. initialize a `ResolvedPayoutLedger` after terminal losses, insurance, source-credit liens, barriers, and obligations are settled/reserved;
 2. disable ordinary positive-PnL withdrawals/releases;

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -2098,6 +2098,160 @@ impl V16Core {
         Ok(asset)
     }
 
+    /// Terminal resolved clear for an ADL-scaled leg. ADL can reduce side OI
+    /// below the sum of stored basis positions while those positions remain as
+    /// settlement records. In Resolved mode the record must still be removable:
+    /// consume at most the effective OI that remains, but remove the full stored
+    /// position count and current-epoch loss weight. A prior-reset leg leaves
+    /// already-reset side aggregates untouched. Fractional B residue is
+    /// terminally discarded against the claimant, as in the existing
+    /// resolved-close path.
+    #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &V16Result<AssetStateV16>| match result {
+        Ok(a) => {
+            let prior_reset = match leg.side {
+                SideV16::Long => asset.mode_long == SideModeV16::ResetPending
+                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_long),
+                SideV16::Short => asset.mode_short == SideModeV16::ResetPending
+                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_short),
+            };
+            let obligation = leg.basis_pos_q == 0 && leg.loss_weight != 0;
+            (match leg.side {
+                SideV16::Long => {
+                    a.oi_eff_long_q == if prior_reset { asset.oi_eff_long_q } else {
+                        asset.oi_eff_long_q.saturating_sub(leg.basis_pos_q.unsigned_abs())
+                    }
+                    && a.oi_eff_short_q == asset.oi_eff_short_q
+                    && a.stored_pos_count_long == asset.stored_pos_count_long.wrapping_sub(1)
+                    && a.stored_pos_count_short == asset.stored_pos_count_short
+                    && a.pending_obligation_count_long == if obligation {
+                        asset.pending_obligation_count_long.wrapping_sub(1)
+                    } else {
+                        asset.pending_obligation_count_long
+                    }
+                    && a.pending_obligation_count_short == asset.pending_obligation_count_short
+                    && a.loss_weight_sum_long == if prior_reset { asset.loss_weight_sum_long } else {
+                        asset.loss_weight_sum_long.wrapping_sub(leg.loss_weight)
+                    }
+                    && a.loss_weight_sum_short == asset.loss_weight_sum_short
+                    && a.social_loss_dust_long_num == asset.social_loss_dust_long_num
+                    && a.social_loss_dust_short_num == asset.social_loss_dust_short_num
+                }
+                SideV16::Short => {
+                    a.oi_eff_short_q == if prior_reset { asset.oi_eff_short_q } else {
+                        asset.oi_eff_short_q.saturating_sub(leg.basis_pos_q.unsigned_abs())
+                    }
+                    && a.oi_eff_long_q == asset.oi_eff_long_q
+                    && a.stored_pos_count_short == asset.stored_pos_count_short.wrapping_sub(1)
+                    && a.stored_pos_count_long == asset.stored_pos_count_long
+                    && a.pending_obligation_count_short == if obligation {
+                        asset.pending_obligation_count_short.wrapping_sub(1)
+                    } else {
+                        asset.pending_obligation_count_short
+                    }
+                    && a.pending_obligation_count_long == asset.pending_obligation_count_long
+                    && a.loss_weight_sum_short == if prior_reset { asset.loss_weight_sum_short } else {
+                        asset.loss_weight_sum_short.wrapping_sub(leg.loss_weight)
+                    }
+                    && a.loss_weight_sum_long == asset.loss_weight_sum_long
+                    && a.social_loss_dust_short_num == asset.social_loss_dust_short_num
+                    && a.social_loss_dust_long_num == asset.social_loss_dust_long_num
+                }
+            })
+                && a.market_id == asset.market_id
+                && a.retired_slot == asset.retired_slot
+                && a.lifecycle == asset.lifecycle
+                && a.raw_oracle_target_price == asset.raw_oracle_target_price
+                && a.effective_price == asset.effective_price
+                && a.fund_px_last == asset.fund_px_last
+                && a.slot_last == asset.slot_last
+                && a.a_long == asset.a_long
+                && a.a_short == asset.a_short
+                && a.k_long == asset.k_long
+                && a.k_short == asset.k_short
+                && a.f_long_num == asset.f_long_num
+                && a.f_short_num == asset.f_short_num
+                && a.k_epoch_start_long == asset.k_epoch_start_long
+                && a.k_epoch_start_short == asset.k_epoch_start_short
+                && a.f_epoch_start_long_num == asset.f_epoch_start_long_num
+                && a.f_epoch_start_short_num == asset.f_epoch_start_short_num
+                && a.b_long_num == asset.b_long_num
+                && a.b_short_num == asset.b_short_num
+                && a.b_epoch_start_long_num == asset.b_epoch_start_long_num
+                && a.b_epoch_start_short_num == asset.b_epoch_start_short_num
+                && a.stale_account_count_long == asset.stale_account_count_long
+                && a.stale_account_count_short == asset.stale_account_count_short
+                && a.social_loss_remainder_long_num == asset.social_loss_remainder_long_num
+                && a.social_loss_remainder_short_num == asset.social_loss_remainder_short_num
+                && a.explicit_unallocated_loss_long == asset.explicit_unallocated_loss_long
+                && a.explicit_unallocated_loss_short == asset.explicit_unallocated_loss_short
+                && a.epoch_long == asset.epoch_long
+                && a.epoch_short == asset.epoch_short
+                && a.mode_long == asset.mode_long
+                && a.mode_short == asset.mode_short
+        }
+        Err(_) => true,
+    }))]
+    pub(crate) fn kernel_clear_resolved_leg(
+        leg: PortfolioLegV16,
+        mut asset: AssetStateV16,
+    ) -> V16Result<AssetStateV16> {
+        let prior_reset_epoch = match leg.side {
+            SideV16::Long => {
+                asset.mode_long == SideModeV16::ResetPending
+                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_long)
+            }
+            SideV16::Short => {
+                asset.mode_short == SideModeV16::ResetPending
+                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_short)
+            }
+        };
+        match leg.side {
+            SideV16::Long => {
+                asset.stored_pos_count_long = asset
+                    .stored_pos_count_long
+                    .checked_sub(1)
+                    .ok_or(V16Error::CounterUnderflow)?;
+                if leg.basis_pos_q == 0 && leg.loss_weight != 0 {
+                    asset.pending_obligation_count_long = asset
+                        .pending_obligation_count_long
+                        .checked_sub(1)
+                        .ok_or(V16Error::CounterUnderflow)?;
+                }
+                if !prior_reset_epoch {
+                    asset.oi_eff_long_q = asset
+                        .oi_eff_long_q
+                        .saturating_sub(leg.basis_pos_q.unsigned_abs());
+                    asset.loss_weight_sum_long = asset
+                        .loss_weight_sum_long
+                        .checked_sub(leg.loss_weight)
+                        .ok_or(V16Error::CounterUnderflow)?;
+                }
+            }
+            SideV16::Short => {
+                asset.stored_pos_count_short = asset
+                    .stored_pos_count_short
+                    .checked_sub(1)
+                    .ok_or(V16Error::CounterUnderflow)?;
+                if leg.basis_pos_q == 0 && leg.loss_weight != 0 {
+                    asset.pending_obligation_count_short = asset
+                        .pending_obligation_count_short
+                        .checked_sub(1)
+                        .ok_or(V16Error::CounterUnderflow)?;
+                }
+                if !prior_reset_epoch {
+                    asset.oi_eff_short_q = asset
+                        .oi_eff_short_q
+                        .saturating_sub(leg.basis_pos_q.unsigned_abs());
+                    asset.loss_weight_sum_short = asset
+                        .loss_weight_sum_short
+                        .checked_sub(leg.loss_weight)
+                        .ok_or(V16Error::CounterUnderflow)?;
+                }
+            }
+        }
+        Ok(asset)
+    }
+
     /// PRODUCTION KERNEL: the attach-leg core — snapshot the side's basis
     /// anchors, gate the a-basis range, add open interest, and construct the
     /// new leg. Pure on (AssetStateV16, scalars); the attach glue calls
@@ -12809,7 +12963,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Err(V16Error::LockActive);
         }
         let leg_slot = Self::require_active_leg_slot_for_asset(&account.as_view(), asset_index)?;
-        let mut leg = account.header.legs[leg_slot].try_to_runtime()?;
+        let leg = account.header.legs[leg_slot].try_to_runtime()?;
         if !leg.active || leg.b_stale || leg.stale {
             return Err(V16Error::InvalidLeg);
         }
@@ -12831,9 +12985,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if self.b_target_for_leg(asset_index, leg)? != leg.b_snap {
             return Err(V16Error::Stale);
         }
-        leg.b_rem = 0;
         let asset = self.asset_state(asset_index)?;
-        let asset = V16Core::kernel_clear_leg(leg, asset)?;
+        let asset = V16Core::kernel_clear_resolved_leg(leg, asset)?;
         account.header.legs[leg_slot] =
             PortfolioLegV16Account::from_runtime(&PortfolioLegV16::EMPTY);
         let mut bitmap = account.header.active_bitmap.map(V16PodU64::get);

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -9,6 +9,13 @@
 use super::*;
 use crate::wide_math::U256;
 
+pub fn kani_clear_resolved_leg(
+    leg: PortfolioLegV16,
+    asset: AssetStateV16,
+) -> V16Result<AssetStateV16> {
+    V16Core::kernel_clear_resolved_leg(leg, asset)
+}
+
 pub fn kani_apply_backing_utilization_fee_charge(
     account_capital: u128,
     group_c_tot: u128,

--- a/src/v16_proofs.rs
+++ b/src/v16_proofs.rs
@@ -1629,6 +1629,53 @@ fn contract_check_kernel_clear_leg() {
 }
 
 #[cfg(all(kani, feature = "contracts"))]
+#[kani::proof_for_contract(V16Core::kernel_clear_resolved_leg)]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn contract_check_kernel_clear_resolved_leg() {
+    let side = if kani::any() {
+        SideV16::Long
+    } else {
+        SideV16::Short
+    };
+    let basis_pos_q: i128 = kani::any();
+    kani::assume(basis_pos_q > i128::MIN);
+    let leg = PortfolioLegV16 {
+        active: true,
+        side,
+        basis_pos_q,
+        epoch_snap: kani::any(),
+        loss_weight: kani::any(),
+        b_rem: kani::any(),
+        ..PortfolioLegV16::EMPTY
+    };
+    let mut asset = AssetStateV16::default();
+    asset.oi_eff_long_q = kani::any();
+    asset.oi_eff_short_q = kani::any();
+    asset.stored_pos_count_long = kani::any();
+    asset.stored_pos_count_short = kani::any();
+    asset.pending_obligation_count_long = kani::any();
+    asset.pending_obligation_count_short = kani::any();
+    asset.loss_weight_sum_long = kani::any();
+    asset.loss_weight_sum_short = kani::any();
+    asset.social_loss_dust_long_num = kani::any();
+    asset.social_loss_dust_short_num = kani::any();
+    asset.epoch_long = kani::any();
+    asset.epoch_short = kani::any();
+    asset.mode_long = if kani::any() {
+        SideModeV16::Normal
+    } else {
+        SideModeV16::ResetPending
+    };
+    asset.mode_short = if kani::any() {
+        SideModeV16::Normal
+    } else {
+        SideModeV16::ResetPending
+    };
+    let _ = V16Core::kernel_clear_resolved_leg(leg, asset);
+}
+
+#[cfg(all(kani, feature = "contracts"))]
 #[kani::proof_for_contract(V16Core::kernel_advance_leg_b_snap)]
 #[kani::unwind(8)]
 #[kani::solver(cadical)]

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -8,8 +8,8 @@ use percolator::v16::{
     kani_available_backing_num_for_source_credit_state,
     kani_backing_utilization_fee_quote_atoms_for_lien,
     kani_backing_utilization_rate_e9_for_source_state, kani_cert_is_current,
-    kani_expected_source_credit_rate_num_for_state, kani_health_cert_after_capital_debit,
-    kani_health_requirements_from_base_and_target_lag,
+    kani_clear_resolved_leg, kani_expected_source_credit_rate_num_for_state,
+    kani_health_cert_after_capital_debit, kani_health_requirements_from_base_and_target_lag,
     kani_liquidation_close_would_leave_uncovered_loss_with_open_risk,
     kani_liquidation_engine_close_request_q, kani_liquidation_fee_from_raw_fee,
     kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
@@ -15401,4 +15401,143 @@ fn proof_v16_backing_utilization_zero_fee_carries_accrual_forward() {
     assert_eq!(market.header.c_tot.get(), c_tot_before);
     assert_eq!(market.header.vault.get(), vault_before);
     assert_eq!(market.header.insurance.get(), insurance_before);
+}
+
+// Terminal ADL liveness theorem over the production clear kernel. A stored
+// settlement basis may exceed effective OI after quantity ADL; every such record
+// still detaches on either side, while prior-reset records cannot debit the reset
+// side a second time and neither path mutates opposite-side aggregates.
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_resolved_leg_clear_closes_every_adl_gap_without_cross_side_mutation() {
+    let side = if kani::any() {
+        SideV16::Long
+    } else {
+        SideV16::Short
+    };
+    let prior_reset: bool = kani::any();
+    let stored_raw: u16 = kani::any();
+    let effective_raw: u16 = kani::any();
+    let trailing_weight_raw: u16 = kani::any();
+    let count_raw: u8 = kani::any();
+    let epoch_raw: u8 = kani::any();
+    let b_rem_raw: u16 = kani::any();
+    kani::assume((1..=1024).contains(&stored_raw));
+    kani::assume(effective_raw < stored_raw);
+    kani::assume(count_raw > 0);
+    kani::assume(epoch_raw < u8::MAX);
+
+    let stored_q = stored_raw as u128 * POS_SCALE;
+    let effective_q = effective_raw as u128 * POS_SCALE;
+    let trailing_weight = trailing_weight_raw as u128 * POS_SCALE;
+    let basis = i128::try_from(stored_q).unwrap();
+    let leg = PortfolioLegV16 {
+        active: true,
+        side,
+        basis_pos_q: if side == SideV16::Long { basis } else { -basis },
+        epoch_snap: epoch_raw as u64,
+        loss_weight: stored_q,
+        b_rem: b_rem_raw as u128,
+        ..PortfolioLegV16::EMPTY
+    };
+    let mut asset = AssetStateV16::default();
+    asset.oi_eff_long_q = if side == SideV16::Long {
+        effective_q
+    } else {
+        7 * POS_SCALE
+    };
+    asset.oi_eff_short_q = if side == SideV16::Short {
+        effective_q
+    } else {
+        11 * POS_SCALE
+    };
+    asset.stored_pos_count_long = if side == SideV16::Long {
+        count_raw as u64
+    } else {
+        5
+    };
+    asset.stored_pos_count_short = if side == SideV16::Short {
+        count_raw as u64
+    } else {
+        3
+    };
+    asset.loss_weight_sum_long = if side == SideV16::Long {
+        stored_q + trailing_weight
+    } else {
+        13 * POS_SCALE
+    };
+    asset.loss_weight_sum_short = if side == SideV16::Short {
+        stored_q + trailing_weight
+    } else {
+        17 * POS_SCALE
+    };
+    if side == SideV16::Long {
+        asset.epoch_long = epoch_raw as u64 + u64::from(prior_reset);
+        asset.mode_long = if prior_reset {
+            SideModeV16::ResetPending
+        } else {
+            SideModeV16::Normal
+        };
+    } else {
+        asset.epoch_short = epoch_raw as u64 + u64::from(prior_reset);
+        asset.mode_short = if prior_reset {
+            SideModeV16::ResetPending
+        } else {
+            SideModeV16::Normal
+        };
+    }
+    let before = asset;
+
+    let after = kani_clear_resolved_leg(leg, asset).unwrap();
+
+    kani::cover!(
+        side == SideV16::Long && !prior_reset && effective_raw > 0 && b_rem_raw > 0,
+        "current-epoch long closes a strict ADL gap and discards terminal B residue"
+    );
+    kani::cover!(
+        side == SideV16::Short && !prior_reset && effective_raw > 0,
+        "current-epoch short closes a strict ADL gap"
+    );
+    kani::cover!(
+        prior_reset && effective_raw > 0,
+        "prior-reset record detaches without debiting reset side aggregates"
+    );
+
+    match side {
+        SideV16::Long => {
+            assert_eq!(after.stored_pos_count_long, count_raw as u64 - 1);
+            assert_eq!(after.stored_pos_count_short, before.stored_pos_count_short);
+            assert_eq!(after.oi_eff_short_q, before.oi_eff_short_q);
+            assert_eq!(after.loss_weight_sum_short, before.loss_weight_sum_short);
+            if prior_reset {
+                assert_eq!(after.oi_eff_long_q, before.oi_eff_long_q);
+                assert_eq!(after.loss_weight_sum_long, before.loss_weight_sum_long);
+            } else {
+                assert_eq!(after.oi_eff_long_q, 0);
+                assert_eq!(after.loss_weight_sum_long, trailing_weight);
+            }
+        }
+        SideV16::Short => {
+            assert_eq!(after.stored_pos_count_short, count_raw as u64 - 1);
+            assert_eq!(after.stored_pos_count_long, before.stored_pos_count_long);
+            assert_eq!(after.oi_eff_long_q, before.oi_eff_long_q);
+            assert_eq!(after.loss_weight_sum_long, before.loss_weight_sum_long);
+            if prior_reset {
+                assert_eq!(after.oi_eff_short_q, before.oi_eff_short_q);
+                assert_eq!(after.loss_weight_sum_short, before.loss_weight_sum_short);
+            } else {
+                assert_eq!(after.oi_eff_short_q, 0);
+                assert_eq!(after.loss_weight_sum_short, trailing_weight);
+            }
+        }
+    }
+    assert_eq!(
+        after.social_loss_dust_long_num,
+        before.social_loss_dust_long_num
+    );
+    assert_eq!(
+        after.social_loss_dust_short_num,
+        before.social_loss_dust_short_num
+    );
 }

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1,6 +1,6 @@
 use percolator::{
-    auto_crank_plan_requires_caller_observation, AutoCrankObservationV16, AutoCrankOutcomeV16,
-    AutoCrankPlanV16, AutoCrankWorkV16,
+    active_bitmap_is_empty, auto_crank_plan_requires_caller_observation, AutoCrankObservationV16,
+    AutoCrankOutcomeV16, AutoCrankPlanV16, AutoCrankWorkV16,
 };
 use percolator::{
     v16_domain_count_for_market_slots, AssetLifecycleV16, AssetStateV16Account,
@@ -10,10 +10,11 @@ use percolator::{
     PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
-    ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedPayoutLedgerV16,
-    ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16, ResolvedPayoutReceiptV16Account,
-    SideModeV16, SideV16, SourceCreditStateV16, SourceCreditStateV16Account, TradeRequestV16,
-    V16Config, V16Error, V16PodI128, V16PodU128, V16PodU32, V16PodU64, V16_EMPTY_ACTIVE_BITMAP,
+    ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedCloseOutcomeV16,
+    ResolvedPayoutLedgerV16, ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16,
+    ResolvedPayoutReceiptV16Account, SideModeV16, SideV16, SourceCreditStateV16,
+    SourceCreditStateV16Account, TradeRequestV16, V16Config, V16Error, V16PodI128, V16PodU128,
+    V16PodU32, V16PodU64, V16_EMPTY_ACTIVE_BITMAP,
 };
 use percolator::{ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, POS_SCALE};
 
@@ -800,6 +801,72 @@ fn v16_crossed_trade_cannot_spend_same_call_addition_as_preexisting_oi() {
         ),
         value_before
     );
+}
+
+#[test]
+fn v16_resolved_close_detaches_adl_basis_above_effective_oi() {
+    const STORED_Q: u128 = 13 * POS_SCALE;
+    const EFFECTIVE_Q: u128 = 10 * POS_SCALE;
+
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 22);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut account_header);
+        market.deposit_not_atomic(&mut account, 100).unwrap();
+        market.resolve_market_not_atomic(1).unwrap();
+    }
+
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.a_long = ADL_ONE * EFFECTIVE_Q / STORED_Q;
+    asset.oi_eff_long_q = EFFECTIVE_Q;
+    asset.oi_eff_short_q = 0;
+    asset.stored_pos_count_long = 1;
+    asset.loss_weight_sum_long = STORED_Q;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(1);
+
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Long,
+        basis_pos_q: signed_q(STORED_Q),
+        a_basis: ADL_ONE,
+        k_snap: asset.k_long,
+        f_snap: asset.f_long_num,
+        epoch_snap: asset.epoch_long,
+        loss_weight: STORED_Q,
+        b_snap: asset.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(1);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+
+    let outcome = market
+        .close_resolved_account_not_atomic(&mut account, 0)
+        .expect("terminal close must saturate ADL-reduced effective OI");
+
+    assert_eq!(outcome, ResolvedCloseOutcomeV16::Closed { payout: 100 });
+    assert!(active_bitmap_is_empty(
+        account.header.active_bitmap.map(V16PodU64::get)
+    ));
+    assert_eq!(account.header.capital.get(), 0);
+    let asset_after = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(asset_after.oi_eff_long_q, 0);
+    assert_eq!(asset_after.stored_pos_count_long, 0);
+    assert_eq!(asset_after.loss_weight_sum_long, 0);
+    assert_eq!(market.header.vault.get(), 0);
+    assert_eq!(market.header.c_tot.get(), 0);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- Add an ADL-aware terminal clear kernel for resolved positions.
- Remove `min(abs(stored_basis_q), remaining_oi_eff_side)` from current-epoch effective OI while removing the full stored-position count and loss weight.
- Detach prior-reset records without debiting already-reset side aggregates again.
- Keep `spec.md` frozen.

## Root cause and impact

Quantity ADL scales aggregate effective OI while preserving each winner stored basis as a settlement record. Resolved close reused the live clear kernel, which required effective OI to cover the full stored basis. After a normal partial liquidation, `CloseResolved` could therefore return `CounterUnderflow` forever and permanently strand a winner leg and payout.

Wrapper PR #216 reproduces this using only deposits, trade, authenticated mark movement, permissionless liquidation, resolution, and public close. The parent returns `Custom(25)` at about 128k CU; the fixed lifecycle fully reconciles both users and custody.

## PDD evidence

- `proof_v16_resolved_leg_clear_closes_every_adl_gap_without_cross_side_mutation`: symbolic strict ADL gaps on both sides plus prior-reset records; 157 checks, 3/3 covers, 2.33s.
- `contract_check_kernel_clear_resolved_leg`: arbitrary-input success-frame contract; 1,290 checks, 9.9s.
- Engine integration closes an ADL-scaled resolved account with stored basis above effective OI and reconciles OI, count, loss weight, vault, and `c_tot`.
- Public LiteSVM red/green and custody theorem in wrapper PR #216.

## Validation

- `cargo test --all-targets`: 130 passed
- Both Kani harnesses above: passed under 300s
- Wrapper exact lifecycle regression: passed
- Wrapper full suite: 5 unit + 564 LiteSVM tests passed
- `cargo fmt --all -- --check`
- `git diff --check`
