### PR TITLE
[REAL DoS] Keep social-loss dust from blocking owner exit

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1928,11 +1928,48 @@ impl V16Core {
         Ok(leg)
     }
 
+    /// Fold one exiting leg's fractional social-loss remainder into the
+    /// side-level dust bucket. Both inputs are canonical fractions, so the sum
+    /// carries at most one whole quote atom.
+    #[cfg_attr(all(kani, feature = "contracts"), kani::requires(
+        current_dust < SOCIAL_LOSS_DEN && leg_remainder < SOCIAL_LOSS_DEN
+    ))]
+    #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &V16Result<(u128, u128)>| match result {
+        Ok((dust, carry)) => {
+            *dust < SOCIAL_LOSS_DEN
+                && *carry <= 1
+                && current_dust.checked_add(leg_remainder)
+                    == carry.checked_mul(SOCIAL_LOSS_DEN).and_then(|v| v.checked_add(*dust))
+        }
+        Err(_) => true,
+    }))]
+    pub(crate) fn kernel_fold_social_loss_dust(
+        current_dust: u128,
+        leg_remainder: u128,
+    ) -> V16Result<(u128, u128)> {
+        if current_dust >= SOCIAL_LOSS_DEN || leg_remainder >= SOCIAL_LOSS_DEN {
+            return Err(V16Error::InvalidConfig);
+        }
+        let total = current_dust
+            .checked_add(leg_remainder)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        if total >= SOCIAL_LOSS_DEN {
+            Ok((total - SOCIAL_LOSS_DEN, 1))
+        } else {
+            Ok((total, 0))
+        }
+    }
+
     /// PRODUCTION KERNEL: the clear-leg asset transform — decrement the
     /// side's stored-position count (and pending-obligation count for a
     /// zero-basis obligation leg), and unless the leg predates a side reset,
     /// fold its social-loss dust and remove its OI and loss weight. Pure on
     /// (PortfolioLegV16, AssetStateV16); the clear-leg glue calls exactly this.
+    #[cfg_attr(all(kani, feature = "contracts"), kani::requires(
+        leg.b_rem < SOCIAL_LOSS_DEN
+            && asset.social_loss_dust_long_num < SOCIAL_LOSS_DEN
+            && asset.social_loss_dust_short_num < SOCIAL_LOSS_DEN
+    ))]
     #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &V16Result<AssetStateV16>| match result {
         Ok(a) => {
             let prior_reset = match leg.side {
@@ -1955,8 +1992,13 @@ impl V16Core {
                     } else {
                         a.oi_eff_long_q == asset.oi_eff_long_q.wrapping_sub(leg.basis_pos_q.unsigned_abs())
                             && a.loss_weight_sum_long == asset.loss_weight_sum_long.wrapping_sub(leg.loss_weight)
-                            && a.social_loss_dust_long_num == asset.social_loss_dust_long_num.wrapping_add(leg.b_rem)
-                            && (leg.b_rem == 0 || a.social_loss_dust_long_num < SOCIAL_LOSS_DEN)
+                            && a.social_loss_dust_long_num == if asset.social_loss_dust_long_num
+                                .wrapping_add(leg.b_rem) >= SOCIAL_LOSS_DEN {
+                                    asset.social_loss_dust_long_num.wrapping_add(leg.b_rem)
+                                        .wrapping_sub(SOCIAL_LOSS_DEN)
+                                } else {
+                                    asset.social_loss_dust_long_num.wrapping_add(leg.b_rem)
+                                }
                     })
                     && a.oi_eff_short_q == asset.oi_eff_short_q
                     && a.loss_weight_sum_short == asset.loss_weight_sum_short
@@ -1973,8 +2015,13 @@ impl V16Core {
                     } else {
                         a.oi_eff_short_q == asset.oi_eff_short_q.wrapping_sub(leg.basis_pos_q.unsigned_abs())
                             && a.loss_weight_sum_short == asset.loss_weight_sum_short.wrapping_sub(leg.loss_weight)
-                            && a.social_loss_dust_short_num == asset.social_loss_dust_short_num.wrapping_add(leg.b_rem)
-                            && (leg.b_rem == 0 || a.social_loss_dust_short_num < SOCIAL_LOSS_DEN)
+                            && a.social_loss_dust_short_num == if asset.social_loss_dust_short_num
+                                .wrapping_add(leg.b_rem) >= SOCIAL_LOSS_DEN {
+                                    asset.social_loss_dust_short_num.wrapping_add(leg.b_rem)
+                                        .wrapping_sub(SOCIAL_LOSS_DEN)
+                                } else {
+                                    asset.social_loss_dust_short_num.wrapping_add(leg.b_rem)
+                                }
                     })
                     && a.oi_eff_long_q == asset.oi_eff_long_q
                     && a.loss_weight_sum_long == asset.loss_weight_sum_long
@@ -2028,17 +2075,12 @@ impl V16Core {
                     && leg.epoch_snap.checked_add(1) == Some(asset.epoch_short)
             }
         };
-        let dust_after_clear = if !prior_reset_epoch && leg.b_rem != 0 {
+        let dust_after_clear = if !prior_reset_epoch {
             let current_dust = match leg.side {
                 SideV16::Long => asset.social_loss_dust_long_num,
                 SideV16::Short => asset.social_loss_dust_short_num,
             };
-            let new_dust = current_dust
-                .checked_add(leg.b_rem)
-                .ok_or(V16Error::ArithmeticOverflow)?;
-            if new_dust >= SOCIAL_LOSS_DEN {
-                return Err(V16Error::RecoveryRequired);
-            }
+            let (new_dust, _) = Self::kernel_fold_social_loss_dust(current_dust, leg.b_rem)?;
             Some(new_dust)
         } else {
             None
@@ -7040,6 +7082,10 @@ impl<'a, T> MarketGroupV16View<'a, T> {
             || (mode == MarketModeV16::Live && asset.oi_eff_long_q != asset.oi_eff_short_q)
             || asset.loss_weight_sum_long > SOCIAL_LOSS_DEN
             || asset.loss_weight_sum_short > SOCIAL_LOSS_DEN
+            || asset.social_loss_remainder_long_num >= SOCIAL_LOSS_DEN
+            || asset.social_loss_remainder_short_num >= SOCIAL_LOSS_DEN
+            || asset.social_loss_dust_long_num >= SOCIAL_LOSS_DEN
+            || asset.social_loss_dust_short_num >= SOCIAL_LOSS_DEN
             || (asset.oi_eff_long_q != 0 && asset.loss_weight_sum_long == 0)
             || (asset.oi_eff_short_q != 0 && asset.loss_weight_sum_short == 0)
             || (asset.loss_weight_sum_long != 0 && asset.stored_pos_count_long == 0)
@@ -12789,7 +12835,62 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Err(V16Error::Stale);
         }
         let asset = self.asset_state(asset_index)?;
-        let asset = V16Core::kernel_clear_leg(leg, asset)?;
+        let prior_reset_epoch = match leg.side {
+            SideV16::Long => {
+                asset.mode_long == SideModeV16::ResetPending
+                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_long)
+            }
+            SideV16::Short => {
+                asset.mode_short == SideModeV16::ResetPending
+                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_short)
+            }
+        };
+        let current_dust = match leg.side {
+            SideV16::Long => asset.social_loss_dust_long_num,
+            SideV16::Short => asset.social_loss_dust_short_num,
+        };
+        let dust_carry = if prior_reset_epoch {
+            0
+        } else {
+            V16Core::kernel_fold_social_loss_dust(current_dust, leg.b_rem)?.1
+        };
+        let mut asset = V16Core::kernel_clear_leg(leg, asset)?;
+
+        // A whole atom assembled from fractional remainders is still part of
+        // the already-booked social loss. Rebook it over the remaining side;
+        // if this was the last weight (or B has no headroom), assign it to the
+        // exiting account instead. Never reject a risk-reducing clear merely
+        // because the fractional bucket crossed its denominator.
+        let exit_loss_charge = if dust_carry == 0 {
+            0
+        } else if V16Core::apply_bankruptcy_residual_chunk_to_loss_side(
+            &mut asset, leg.side, dust_carry, dust_carry,
+        )?
+        .is_some()
+        {
+            self.header.bankruptcy_hlock_active = 1;
+            self.header.risk_epoch = V16PodU64::new(
+                self.header
+                    .risk_epoch
+                    .get()
+                    .checked_add(1)
+                    .ok_or(V16Error::CounterOverflow)?,
+            );
+            0
+        } else {
+            dust_carry
+        };
+        if exit_loss_charge != 0 {
+            let charge =
+                i128::try_from(exit_loss_charge).map_err(|_| V16Error::ArithmeticOverflow)?;
+            let new_pnl = account
+                .header
+                .pnl
+                .get()
+                .checked_sub(charge)
+                .ok_or(V16Error::ArithmeticOverflow)?;
+            self.set_account_pnl(account, new_pnl)?;
+        }
         account.header.legs[leg_slot] =
             PortfolioLegV16Account::from_runtime(&PortfolioLegV16::EMPTY);
         let mut bitmap = account.header.active_bitmap.map(V16PodU64::get);

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1941,7 +1941,7 @@ impl V16Core {
                 && current_dust.checked_add(leg_remainder)
                     == carry.checked_mul(SOCIAL_LOSS_DEN).and_then(|v| v.checked_add(*dust))
         }
-        Err(_) => true,
+        Err(_) => false,
     }))]
     pub(crate) fn kernel_fold_social_loss_dust(
         current_dust: u128,

--- a/src/v16_proofs.rs
+++ b/src/v16_proofs.rs
@@ -1548,6 +1548,18 @@ fn contract_check_kernel_attach_leg() {
 }
 
 #[cfg(all(kani, feature = "contracts"))]
+#[kani::proof_for_contract(V16Core::kernel_fold_social_loss_dust)]
+#[kani::unwind(4)]
+#[kani::solver(cadical)]
+fn contract_check_kernel_fold_social_loss_dust() {
+    let current_dust: u128 = kani::any();
+    let leg_remainder: u128 = kani::any();
+    kani::assume(current_dust < SOCIAL_LOSS_DEN);
+    kani::assume(leg_remainder < SOCIAL_LOSS_DEN);
+    let _ = V16Core::kernel_fold_social_loss_dust(current_dust, leg_remainder);
+}
+
+#[cfg(all(kani, feature = "contracts"))]
 #[kani::proof_for_contract(V16Core::kernel_clear_leg)]
 #[kani::unwind(8)]
 #[kani::solver(cadical)]
@@ -1625,6 +1637,9 @@ fn contract_check_kernel_clear_leg() {
         },
     };
     kani::assume(leg.basis_pos_q > i128::MIN);
+    kani::assume(leg.b_rem < SOCIAL_LOSS_DEN);
+    kani::assume(asset.social_loss_dust_long_num < SOCIAL_LOSS_DEN);
+    kani::assume(asset.social_loss_dust_short_num < SOCIAL_LOSS_DEN);
     let _ = V16Core::kernel_clear_leg(leg, asset);
 }
 

--- a/src/v16_proofs.rs
+++ b/src/v16_proofs.rs
@@ -1556,7 +1556,17 @@ fn contract_check_kernel_fold_social_loss_dust() {
     let leg_remainder: u128 = kani::any();
     kani::assume(current_dust < SOCIAL_LOSS_DEN);
     kani::assume(leg_remainder < SOCIAL_LOSS_DEN);
-    let _ = V16Core::kernel_fold_social_loss_dust(current_dust, leg_remainder);
+    let result = V16Core::kernel_fold_social_loss_dust(current_dust, leg_remainder);
+    kani::cover!(
+        current_dust + leg_remainder < SOCIAL_LOSS_DEN
+            && result == Ok((current_dust + leg_remainder, 0)),
+        "canonical fractions can fold without a carry"
+    );
+    kani::cover!(
+        current_dust + leg_remainder >= SOCIAL_LOSS_DEN
+            && result == Ok((current_dust + leg_remainder - SOCIAL_LOSS_DEN, 1)),
+        "canonical fractions can fold one whole-atom carry"
+    );
 }
 
 #[cfg(all(kani, feature = "contracts"))]
@@ -1641,6 +1651,87 @@ fn contract_check_kernel_clear_leg() {
     kani::assume(asset.social_loss_dust_long_num < SOCIAL_LOSS_DEN);
     kani::assume(asset.social_loss_dust_short_num < SOCIAL_LOSS_DEN);
     let _ = V16Core::kernel_clear_leg(leg, asset);
+}
+
+#[cfg(all(kani, feature = "closure"))]
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_clear_leg_canonical_dust_never_blocks_exit() {
+    let side = if kani::any() {
+        SideV16::Long
+    } else {
+        SideV16::Short
+    };
+    let current_dust: u128 = kani::any();
+    let leg_remainder: u128 = kani::any();
+    kani::assume(current_dust < SOCIAL_LOSS_DEN);
+    kani::assume(leg_remainder < SOCIAL_LOSS_DEN);
+
+    let basis_abs = POS_SCALE;
+    let basis_pos_q = match side {
+        SideV16::Long => basis_abs as i128,
+        SideV16::Short => -(basis_abs as i128),
+    };
+    let leg = PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: 1,
+        side,
+        basis_pos_q,
+        a_basis: POS_SCALE,
+        k_snap: 0,
+        f_snap: 0,
+        epoch_snap: 0,
+        loss_weight: 1,
+        b_snap: 0,
+        b_rem: leg_remainder,
+        b_epoch_snap: 0,
+        b_stale: false,
+        stale: false,
+    };
+    let mut asset = AssetStateV16::default();
+    asset.market_id = 1;
+    asset.lifecycle = AssetLifecycleV16::Active;
+    match side {
+        SideV16::Long => {
+            asset.oi_eff_long_q = basis_abs;
+            asset.stored_pos_count_long = 1;
+            asset.loss_weight_sum_long = 1;
+            asset.social_loss_dust_long_num = current_dust;
+        }
+        SideV16::Short => {
+            asset.oi_eff_short_q = basis_abs;
+            asset.stored_pos_count_short = 1;
+            asset.loss_weight_sum_short = 1;
+            asset.social_loss_dust_short_num = current_dust;
+        }
+    }
+
+    let cleared = V16Core::kernel_clear_leg(leg, asset).unwrap();
+    let expected_dust = (current_dust + leg_remainder) % SOCIAL_LOSS_DEN;
+    match side {
+        SideV16::Long => {
+            assert_eq!(cleared.oi_eff_long_q, 0);
+            assert_eq!(cleared.stored_pos_count_long, 0);
+            assert_eq!(cleared.loss_weight_sum_long, 0);
+            assert_eq!(cleared.social_loss_dust_long_num, expected_dust);
+        }
+        SideV16::Short => {
+            assert_eq!(cleared.oi_eff_short_q, 0);
+            assert_eq!(cleared.stored_pos_count_short, 0);
+            assert_eq!(cleared.loss_weight_sum_short, 0);
+            assert_eq!(cleared.social_loss_dust_short_num, expected_dust);
+        }
+    }
+    kani::cover!(
+        current_dust + leg_remainder < SOCIAL_LOSS_DEN,
+        "a no-carry exit clears"
+    );
+    kani::cover!(
+        current_dust + leg_remainder >= SOCIAL_LOSS_DEN,
+        "a whole-atom carry exit clears"
+    );
 }
 
 #[cfg(all(kani, feature = "contracts"))]


### PR DESCRIPTION
## What changed

- Fold canonical per-leg social-loss remainders modulo `SOCIAL_LOSS_DEN` instead of rejecting when side dust carries one atom.
- Rebook a carried atom into the remaining side B-index, advancing `risk_epoch`, or conservatively charge the exiting account when no recipient weight exists.
- Enforce canonical social-loss remainder and dust bounds in the production audit.

## PDD

Wrapper PR: https://github.com/aeyakovenko/percolator-prog/pull/217

The public LiteSVM regression creates four matched positions, realizes a two-atom bankruptcy, and gives two exiting winners exactly half an atom of B remainder each. Before the fix, the second ordinary owner exit permanently returned `Custom(23)` at about 114k CU because SVM rollback restored the same carry state.

The engine proof now executes the production `kernel_clear_leg` over symbolic side, canonical leg remainder, and canonical current dust. It requires successful closure, zero OI/count/weight, and exact modulo dust, with explicit carry and no-carry cover properties.

Mutation check: restoring the old `RecoveryRequired` carry branch makes the closure proof fail at the production call and loses the carry cover. This prevents the former weak `Err(_) => true` behavior from proving the vulnerable implementation.

## Validation

- `cargo test --all-targets`: 130 passed
- Kani `proof_clear_leg_canonical_dust_never_blocks_exit`: 177 checks, 2/2 covers, passed in about 1.5s
- Kani `contract_check_kernel_fold_social_loss_dust`: 227 checks, 2/2 covers, passed
- Kani `contract_check_kernel_clear_leg`: 1,634 checks, passed
- wrapper stack: 5 unit + 564 LiteSVM/SBF tests passed
- `cargo fmt --all -- --check`
- `git diff --check`

Engine commit: `4beb6ce141bb28656e7cc38b82a3d5c54e1884e4`
