### PR TITLE
[REAL DoS] Quarantine reset carry without blocking progress

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1960,6 +1960,36 @@ impl V16Core {
         }
     }
 
+    /// Move a side-wide B-division remainder into the durable dust/audit
+    /// buckets before the side's weight basis is reset. The two canonical
+    /// fractions can produce at most one whole quote atom; that atom is an
+    /// explicit unallocated loss, not account health or payout capacity.
+    #[cfg_attr(all(kani, feature = "contracts"), kani::requires(
+        current_dust < SOCIAL_LOSS_DEN && social_remainder < SOCIAL_LOSS_DEN
+    ))]
+    #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &V16Result<(u128, u128)>| match result {
+        Ok((dust, explicit)) => {
+            *dust < SOCIAL_LOSS_DEN
+                && explicit.checked_sub(explicit_before).is_some_and(|carry| carry <= 1)
+                && current_dust.checked_add(social_remainder)
+                    == explicit.checked_sub(explicit_before)
+                        .and_then(|carry| carry.checked_mul(SOCIAL_LOSS_DEN))
+                        .and_then(|whole| whole.checked_add(*dust))
+        }
+        Err(_) => true,
+    }))]
+    pub(crate) fn kernel_quarantine_social_loss_remainder(
+        social_remainder: u128,
+        current_dust: u128,
+        explicit_before: u128,
+    ) -> V16Result<(u128, u128)> {
+        let (dust, carry) = Self::kernel_fold_social_loss_dust(current_dust, social_remainder)?;
+        let explicit = explicit_before
+            .checked_add(carry)
+            .ok_or(V16Error::CounterOverflow)?;
+        Ok((dust, explicit))
+    }
+
     /// PRODUCTION KERNEL: the clear-leg asset transform — decrement the
     /// side's stored-position count (and pending-obligation count for a
     /// zero-basis obligation leg), and unless the leg predates a side reset,
@@ -11283,10 +11313,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             || asset.loss_weight_sum_short != 0
             || asset.social_loss_remainder_long_num != 0
             || asset.social_loss_remainder_short_num != 0
-            || asset.social_loss_dust_long_num != 0
-            || asset.social_loss_dust_short_num != 0
-            || asset.explicit_unallocated_loss_long != 0
-            || asset.explicit_unallocated_loss_short != 0
+            // Canonical dust and explicit unallocated loss are durable audit
+            // state, not positions, liabilities, or oracle-reset blockers.
             || asset.mode_long != SideModeV16::Normal
             || asset.mode_short != SideModeV16::Normal
             || slot.pending_domain_loss_barrier_long.get() != 0
@@ -12197,10 +12225,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             || asset.loss_weight_sum_short != 0
             || asset.social_loss_remainder_long_num != 0
             || asset.social_loss_remainder_short_num != 0
-            || asset.social_loss_dust_long_num != 0
-            || asset.social_loss_dust_short_num != 0
-            || asset.explicit_unallocated_loss_long != 0
-            || asset.explicit_unallocated_loss_short != 0
+            // Retirement canonicalizes audit-only residue after every real
+            // position, loss index, barrier, and funded stock is empty.
             || spent_blocks_empty
             || !long_source.is_empty_amount_shape()
             || !short_source.is_empty_amount_shape()
@@ -13489,10 +13515,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 if asset.oi_eff_long_q != 0 || asset.pending_obligation_count_long != 0 {
                     return Err(V16Error::LockActive);
                 }
-                quarantine_remainder(
-                    &mut asset.social_loss_remainder_long_num,
-                    &mut asset.social_loss_dust_long_num,
+                let (dust, explicit) = V16Core::kernel_quarantine_social_loss_remainder(
+                    asset.social_loss_remainder_long_num,
+                    asset.social_loss_dust_long_num,
+                    asset.explicit_unallocated_loss_long,
                 )?;
+                asset.social_loss_remainder_long_num = 0;
+                asset.social_loss_dust_long_num = dust;
+                asset.explicit_unallocated_loss_long = explicit;
                 asset.k_epoch_start_long = asset.k_long;
                 asset.f_epoch_start_long_num = asset.f_long_num;
                 asset.b_epoch_start_long_num = asset.b_long_num;
@@ -13514,10 +13544,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 if asset.oi_eff_short_q != 0 || asset.pending_obligation_count_short != 0 {
                     return Err(V16Error::LockActive);
                 }
-                quarantine_remainder(
-                    &mut asset.social_loss_remainder_short_num,
-                    &mut asset.social_loss_dust_short_num,
+                let (dust, explicit) = V16Core::kernel_quarantine_social_loss_remainder(
+                    asset.social_loss_remainder_short_num,
+                    asset.social_loss_dust_short_num,
+                    asset.explicit_unallocated_loss_short,
                 )?;
+                asset.social_loss_remainder_short_num = 0;
+                asset.social_loss_dust_short_num = dust;
+                asset.explicit_unallocated_loss_short = explicit;
                 asset.k_epoch_start_short = asset.k_short;
                 asset.f_epoch_start_short_num = asset.f_short_num;
                 asset.b_epoch_start_short_num = asset.b_short_num;
@@ -16749,21 +16783,6 @@ fn fraction_ge(lhs_num: u128, lhs_den: u128, rhs_num: u128, rhs_den: u128) -> V1
         .checked_mul(U256::from_u128(lhs_den))
         .ok_or(V16Error::ArithmeticOverflow)?;
     Ok(lhs >= rhs)
-}
-
-fn quarantine_remainder(remainder: &mut u128, dust: &mut u128) -> V16Result<()> {
-    if *remainder == 0 {
-        return Ok(());
-    }
-    let new_dust = dust
-        .checked_add(*remainder)
-        .ok_or(V16Error::ArithmeticOverflow)?;
-    if new_dust >= SOCIAL_LOSS_DEN {
-        return Err(V16Error::RecoveryRequired);
-    }
-    *dust = new_dust;
-    *remainder = 0;
-    Ok(())
 }
 
 fn validate_non_min_i128(v: i128) -> V16Result<()> {

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1965,7 +1965,9 @@ impl V16Core {
     /// fractions can produce at most one whole quote atom; that atom is an
     /// explicit unallocated loss, not account health or payout capacity.
     #[cfg_attr(all(kani, feature = "contracts"), kani::requires(
-        current_dust < SOCIAL_LOSS_DEN && social_remainder < SOCIAL_LOSS_DEN
+        current_dust < SOCIAL_LOSS_DEN
+            && social_remainder < SOCIAL_LOSS_DEN
+            && explicit_before < u128::MAX
     ))]
     #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &V16Result<(u128, u128)>| match result {
         Ok((dust, explicit)) => {
@@ -1976,7 +1978,7 @@ impl V16Core {
                         .and_then(|carry| carry.checked_mul(SOCIAL_LOSS_DEN))
                         .and_then(|whole| whole.checked_add(*dust))
         }
-        Err(_) => true,
+        Err(_) => false,
     }))]
     pub(crate) fn kernel_quarantine_social_loss_remainder(
         social_remainder: u128,

--- a/src/v16_proofs.rs
+++ b/src/v16_proofs.rs
@@ -1579,10 +1579,25 @@ fn contract_check_kernel_quarantine_social_loss_remainder() {
     let explicit_before: u128 = kani::any();
     kani::assume(social_remainder < SOCIAL_LOSS_DEN);
     kani::assume(current_dust < SOCIAL_LOSS_DEN);
-    let _ = V16Core::kernel_quarantine_social_loss_remainder(
+    kani::assume(explicit_before < u128::MAX);
+    let result = V16Core::kernel_quarantine_social_loss_remainder(
         social_remainder,
         current_dust,
         explicit_before,
+    );
+    kani::cover!(
+        current_dust + social_remainder < SOCIAL_LOSS_DEN
+            && result == Ok((current_dust + social_remainder, explicit_before)),
+        "canonical reset remainder can fold without a carry"
+    );
+    kani::cover!(
+        current_dust + social_remainder >= SOCIAL_LOSS_DEN
+            && result
+                == Ok((
+                    current_dust + social_remainder - SOCIAL_LOSS_DEN,
+                    explicit_before + 1,
+                )),
+        "canonical reset remainder can quarantine one explicit loss atom"
     );
 }
 

--- a/src/v16_proofs.rs
+++ b/src/v16_proofs.rs
@@ -1570,6 +1570,23 @@ fn contract_check_kernel_fold_social_loss_dust() {
 }
 
 #[cfg(all(kani, feature = "contracts"))]
+#[kani::proof_for_contract(V16Core::kernel_quarantine_social_loss_remainder)]
+#[kani::unwind(4)]
+#[kani::solver(cadical)]
+fn contract_check_kernel_quarantine_social_loss_remainder() {
+    let social_remainder: u128 = kani::any();
+    let current_dust: u128 = kani::any();
+    let explicit_before: u128 = kani::any();
+    kani::assume(social_remainder < SOCIAL_LOSS_DEN);
+    kani::assume(current_dust < SOCIAL_LOSS_DEN);
+    let _ = V16Core::kernel_quarantine_social_loss_remainder(
+        social_remainder,
+        current_dust,
+        explicit_before,
+    );
+}
+
+#[cfg(all(kani, feature = "contracts"))]
 #[kani::proof_for_contract(V16Core::kernel_clear_leg)]
 #[kani::unwind(8)]
 #[kani::solver(cadical)]


### PR DESCRIPTION
## Summary

- Fold a canonical side-wide B remainder into side dust during full-drain reset.
- Record a whole carry as durable `explicit_unallocated_loss` instead of returning `RecoveryRequired` forever.
- Treat canonical dust and explicit loss as audit-only once positions, B index, funded stock, and barriers are empty.

## PDD

Wrapper PR: https://github.com/aeyakovenko/percolator-prog/pull/218

The public regression creates two normal bankruptcy cycles. At the second zero-OI reset, canonical B remainder plus canonical side dust crosses one atom. Before the fix, each liquidation returned `Custom(23)` at about 188k CU and SVM rollback restored the same underwater account.

The production-kernel contract now requires `kernel_quarantine_social_loss_remainder` to succeed for every canonical dust/remainder pair with representable explicit-loss headroom. It proves exact modulo dust and exact carry attribution, with separate carry and no-carry cover properties.

Mutation check: restoring the old reject-on-carry implementation makes the contract fail and removes the carry cover. The prior `Err(_) => true` proof weakness is removed.

## Validation

- `cargo test --all-targets`: 130 passed
- Kani `contract_check_kernel_quarantine_social_loss_remainder`: 355 checks, 2/2 covers, passed in about 1.1s
- wrapper stack: 5 unit + 565 LiteSVM/SBF tests passed
- `cargo fmt --all -- --check`
- `git diff --check`

## Stack

Base: engine PR #116
Engine commit: `552e9ac76a2288fb5a91c40e1cce7e952a6ab4a5`
