### PR TITLE
[REAL DoS] Reset both zero-OI sides after unilateral close

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1992,6 +1992,28 @@ impl V16Core {
         Ok((dust, explicit))
     }
 
+    /// A unilateral close mutates both effective-OI sides. If the liquidated
+    /// side itself reaches zero while other stored legs remain, those legs
+    /// need the same old-epoch reset route as the matching side; otherwise
+    /// they remain live-looking but cannot reduce or use the dead-leg route.
+    #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &bool| {
+        *result == (effective_oi == 0
+            && stored_position_count != 0
+            && pending_obligation_count == 0
+            && mode != SideModeV16::ResetPending)
+    }))]
+    pub(crate) fn kernel_side_needs_full_drain_reset(
+        effective_oi: u128,
+        stored_position_count: u64,
+        pending_obligation_count: u64,
+        mode: SideModeV16,
+    ) -> bool {
+        effective_oi == 0
+            && stored_position_count != 0
+            && pending_obligation_count == 0
+            && mode != SideModeV16::ResetPending
+    }
+
     /// PRODUCTION KERNEL: the clear-leg asset transform — decrement the
     /// side's stored-position count (and pending-obligation count for a
     /// zero-basis obligation leg), and unless the leg predates a side reset,
@@ -13630,6 +13652,29 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.set_asset_state(asset_index, asset)?;
         if opp_oi_after == 0 {
             self.begin_full_drain_reset_inner(asset_index, opp)?;
+        }
+        let asset = self.asset_state(asset_index)?;
+        let (closed_oi, closed_stored, closed_pending, closed_mode) = match closed_side {
+            SideV16::Long => (
+                asset.oi_eff_long_q,
+                asset.stored_pos_count_long,
+                asset.pending_obligation_count_long,
+                asset.mode_long,
+            ),
+            SideV16::Short => (
+                asset.oi_eff_short_q,
+                asset.stored_pos_count_short,
+                asset.pending_obligation_count_short,
+                asset.mode_short,
+            ),
+        };
+        if V16Core::kernel_side_needs_full_drain_reset(
+            closed_oi,
+            closed_stored,
+            closed_pending,
+            closed_mode,
+        ) {
+            self.begin_full_drain_reset_inner(asset_index, closed_side)?;
         }
         Ok(())
     }

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -454,6 +454,15 @@ impl MarketGroupV16HeaderAccount {
 }
 
 impl<'a, T> MarketGroupV16ViewMut<'a, T> {
+    pub fn kani_reduce_matching_open_interest_for_unilateral_close(
+        &mut self,
+        asset_index: usize,
+        closed_side: SideV16,
+        close_q: u128,
+    ) -> V16Result<()> {
+        self.reduce_matching_open_interest_for_unilateral_close(asset_index, closed_side, close_q)
+    }
+
     pub fn kani_clear_leg(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,

--- a/src/v16_proofs.rs
+++ b/src/v16_proofs.rs
@@ -1614,11 +1614,75 @@ fn contract_check_kernel_side_needs_full_drain_reset() {
         1 => SideModeV16::DrainOnly,
         _ => SideModeV16::ResetPending,
     };
-    let _ = V16Core::kernel_side_needs_full_drain_reset(
+    let reset = V16Core::kernel_side_needs_full_drain_reset(
         effective_oi,
         stored_position_count,
         pending_obligation_count,
         mode,
+    );
+    kani::cover!(reset, "zero OI with stored positions requires reset");
+    kani::cover!(!reset, "a non-reset state remains unchanged");
+}
+
+// Composition proof for the production unilateral-close route. The scalar
+// predicate above is insufficient on its own: this theorem also proves that
+// the mutable view applies the decision to both possible closed-side
+// orientations after the matching side reaches zero OI.
+#[cfg(all(kani, feature = "contracts"))]
+#[kani::proof]
+#[kani::unwind(20)]
+#[kani::solver(cadical)]
+fn composition_unilateral_close_resets_both_zero_oi_sides() {
+    let cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic([1u8; 32], cfg, 1, 0).unwrap();
+    let mut markets = [Market::new(0u64, EngineAssetSlotV16Account::default())];
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        market.activate_empty_market_not_atomic(0, 100, 1).unwrap();
+    }
+
+    let closed_side = if kani::any() {
+        SideV16::Long
+    } else {
+        SideV16::Short
+    };
+    let stored_position_count = u64::from(kani::any::<u8>()).saturating_add(1);
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    match closed_side {
+        SideV16::Long => {
+            asset.oi_eff_long_q = 0;
+            asset.stored_pos_count_long = stored_position_count;
+            asset.oi_eff_short_q = 1;
+            asset.stored_pos_count_short = 1;
+        }
+        SideV16::Short => {
+            asset.oi_eff_short_q = 0;
+            asset.stored_pos_count_short = stored_position_count;
+            asset.oi_eff_long_q = 1;
+            asset.stored_pos_count_long = 1;
+        }
+    }
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        market
+            .kani_reduce_matching_open_interest_for_unilateral_close(0, closed_side, 1)
+            .unwrap();
+    }
+
+    let after = markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(after.oi_eff_long_q, 0);
+    assert_eq!(after.oi_eff_short_q, 0);
+    assert_eq!(after.mode_long, SideModeV16::ResetPending);
+    assert_eq!(after.mode_short, SideModeV16::ResetPending);
+    kani::cover!(
+        closed_side == SideV16::Long,
+        "long closed side enters reset"
+    );
+    kani::cover!(
+        closed_side == SideV16::Short,
+        "short closed side enters reset"
     );
 }
 

--- a/src/v16_proofs.rs
+++ b/src/v16_proofs.rs
@@ -1602,6 +1602,27 @@ fn contract_check_kernel_quarantine_social_loss_remainder() {
 }
 
 #[cfg(all(kani, feature = "contracts"))]
+#[kani::proof_for_contract(V16Core::kernel_side_needs_full_drain_reset)]
+#[kani::unwind(2)]
+#[kani::solver(cadical)]
+fn contract_check_kernel_side_needs_full_drain_reset() {
+    let effective_oi: u128 = kani::any();
+    let stored_position_count: u64 = kani::any();
+    let pending_obligation_count: u64 = kani::any();
+    let mode = match kani::any::<u8>() % 3 {
+        0 => SideModeV16::Normal,
+        1 => SideModeV16::DrainOnly,
+        _ => SideModeV16::ResetPending,
+    };
+    let _ = V16Core::kernel_side_needs_full_drain_reset(
+        effective_oi,
+        stored_position_count,
+        pending_obligation_count,
+        mode,
+    );
+}
+
+#[cfg(all(kani, feature = "contracts"))]
 #[kani::proof_for_contract(V16Core::kernel_clear_leg)]
 #[kani::unwind(8)]
 #[kani::solver(cadical)]


### PR DESCRIPTION
## Summary

- Detect when the liquidated side itself reaches zero effective OI while stored legs remain.
- Enter the same bounded `ResetPending` old-epoch route already used for the matching side.
- Prove both orientations through the production zero-copy mutable view, not only through the scalar predicate.

## Public red case

Wrapper PDD: https://github.com/aeyakovenko/percolator-prog/pull/219

After the two-bankruptcy lifecycle from PR #218, both effective-OI sides are zero but one short account remains stored. On the parent engine, only the matching long side enters `ResetPending`; owner `ForfeitRecoveryLeg` returns `Custom(21)` / `LockActive`, ordinary rebalance has no matching OI, and the user cannot become flat or withdraw.

With this PR, the liquidated side also enters `ResetPending`; the owner dead-leg exit, reset finalization, and complete SPL withdrawal all succeed within the custody CU limit.

## PDD strength

The original 105-check contract only proved a Boolean helper and could not catch deletion of its production call. The added composition theorem constructs a one-slot market, chooses long or short symbolically, invokes the actual `reduce_matching_open_interest_for_unilateral_close` view path, and proves both OI values are zero and both modes are `ResetPending`.

Mutation check: disabling only the closed-side production transition makes the composition proof fail one assertion and leaves both orientation covers unreachable.

## Validation

- composition theorem: 4,794 checks, 2/2 orientation covers, passed in 143s
- scalar contract: 105 checks, 2/2 reset/non-reset covers, passed
- mutation run: failed as expected
- `cargo test --all-targets`: 130 passed
- wrapper stack: 5 unit + 565 LiteSVM/SBF tests passed
- `cargo fmt --all -- --check`
- `git diff --check`

## Stack

Base: engine PR #117
Engine commit: `f97194677901e38bc8b2b87a67ac878c74dbfa99`
