### PR TITLE
[HARDENING] Keep fragmented risk reductions live below IM

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 244 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 245 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/spec.md
+++ b/spec.md
@@ -1465,6 +1465,7 @@ Trades require:
 - current B/K/F settlement for touched legs;
 - side-mode gating;
 - OI/position bounds;
+- post-trade initial margin for risk-increasing fills; a matched fill that strictly reduces both counterparties' absolute positions MUST remain admissible below initial margin so fragmented exits can make bounded progress;
 - candidate-slippage neutralization;
 - lien creation for positive credit used beyond no-positive-credit equity;
 - matched-side loss recognition before gain extractability;

--- a/spec.md
+++ b/spec.md
@@ -1465,7 +1465,7 @@ Trades require:
 - current B/K/F settlement for touched legs;
 - side-mode gating;
 - OI/position bounds;
-- post-trade initial margin for risk-increasing fills; a matched fill that strictly reduces both counterparties' absolute positions MUST remain admissible below initial margin so fragmented exits can make bounded progress;
+- post-trade initial margin for risk-increasing fills and any liquidatable counterparty; a matched fill that strictly reduces both counterparties' absolute positions while both remain maintenance-healthy MUST remain admissible below initial margin so fragmented exits can make bounded progress without bypassing bankruptcy attribution;
 - candidate-slippage neutralization;
 - lien creation for positive credit used beyond no-positive-credit equity;
 - matched-side loss recognition before gain extractability;

--- a/spec.md
+++ b/spec.md
@@ -1465,7 +1465,6 @@ Trades require:
 - current B/K/F settlement for touched legs;
 - side-mode gating;
 - OI/position bounds;
-- post-trade initial margin for risk-increasing fills and any liquidatable counterparty; a matched fill that strictly reduces both counterparties' absolute positions while both remain maintenance-healthy MUST remain admissible below initial margin so fragmented exits can make bounded progress without bypassing bankruptcy attribution;
 - candidate-slippage neutralization;
 - lien creation for positive credit used beyond no-positive-credit equity;
 - matched-side loss recognition before gain extractability;

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -13993,11 +13993,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 self.create_initial_margin_source_lien_if_needed(short_account)?;
             }
         }
-        Self::ensure_initial_margin(&long_account.as_view())?;
-        Self::ensure_initial_margin(&short_account.as_view())?;
-        if locked {
-            Self::ensure_no_positive_credit_initial_margin(&long_account.as_view())?;
-            Self::ensure_no_positive_credit_initial_margin(&short_account.as_view())?;
+        // Initial margin is an admission gate for new risk, not an exit gate. A matched
+        // two-sided reduction has already proved that neither account's absolute position grows.
+        // Requiring both accounts to regain IM in the same fill can deadlock fragmented recovery:
+        // every available counterparty may be smaller than the reduction needed to cross the IM
+        // boundary. Keep the locked-lane no-positive-credit gate scoped to risk admission too.
+        if risk_increasing {
+            Self::ensure_initial_margin(&long_account.as_view())?;
+            Self::ensure_initial_margin(&short_account.as_view())?;
+            if locked {
+                Self::ensure_no_positive_credit_initial_margin(&long_account.as_view())?;
+                Self::ensure_no_positive_credit_initial_margin(&short_account.as_view())?;
+            }
         }
         self.validate_shape_audit_scan()?;
         self.validate_account_audit_scan(&long_account.as_view())?;

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -13771,6 +13771,27 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         )
     }
 
+    fn ensure_trade_final_margin_policy(
+        long_account: &PortfolioV16View<'_>,
+        short_account: &PortfolioV16View<'_>,
+        locked: bool,
+        risk_increasing: bool,
+    ) -> V16Result<()> {
+        let long_cert = long_account.header.health_cert.try_to_runtime()?;
+        let short_cert = short_account.header.health_cert.try_to_runtime()?;
+        let maintenance_healthy =
+            long_cert.certified_liq_deficit == 0 && short_cert.certified_liq_deficit == 0;
+        if risk_increasing || !maintenance_healthy {
+            Self::ensure_initial_margin(long_account)?;
+            Self::ensure_initial_margin(short_account)?;
+            if locked {
+                Self::ensure_no_positive_credit_initial_margin(long_account)?;
+                Self::ensure_no_positive_credit_initial_margin(short_account)?;
+            }
+        }
+        Ok(())
+    }
+
     fn recertify_account_after_source_lien_change(
         &self,
         account: &mut PortfolioV16ViewMut<'_>,
@@ -13993,24 +14014,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 self.create_initial_margin_source_lien_if_needed(short_account)?;
             }
         }
-        let long_cert = long_account.header.health_cert.try_to_runtime()?;
-        let short_cert = short_account.header.health_cert.try_to_runtime()?;
-        let maintenance_healthy =
-            long_cert.certified_liq_deficit == 0 && short_cert.certified_liq_deficit == 0;
         // Initial margin is an admission gate for new risk and remains a bankruptcy-path gate for
         // liquidatable accounts. A maintenance-healthy matched reduction has already proved that
         // neither account's absolute position grows. Requiring those accounts to regain IM in the
         // same fill can deadlock fragmented recovery when every counterparty is smaller than the
         // reduction needed to cross the IM boundary. Keep the locked-lane no-positive-credit gate
         // scoped to the same admission/bankruptcy boundary.
-        if risk_increasing || !maintenance_healthy {
-            Self::ensure_initial_margin(&long_account.as_view())?;
-            Self::ensure_initial_margin(&short_account.as_view())?;
-            if locked {
-                Self::ensure_no_positive_credit_initial_margin(&long_account.as_view())?;
-                Self::ensure_no_positive_credit_initial_margin(&short_account.as_view())?;
-            }
-        }
+        Self::ensure_trade_final_margin_policy(
+            &long_account.as_view(),
+            &short_account.as_view(),
+            locked,
+            risk_increasing,
+        )?;
         self.validate_shape_audit_scan()?;
         self.validate_account_audit_scan(&long_account.as_view())?;
         self.validate_account_audit_scan(&short_account.as_view())?;

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -13993,12 +13993,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 self.create_initial_margin_source_lien_if_needed(short_account)?;
             }
         }
-        // Initial margin is an admission gate for new risk, not an exit gate. A matched
-        // two-sided reduction has already proved that neither account's absolute position grows.
-        // Requiring both accounts to regain IM in the same fill can deadlock fragmented recovery:
-        // every available counterparty may be smaller than the reduction needed to cross the IM
-        // boundary. Keep the locked-lane no-positive-credit gate scoped to risk admission too.
-        if risk_increasing {
+        let long_cert = long_account.header.health_cert.try_to_runtime()?;
+        let short_cert = short_account.header.health_cert.try_to_runtime()?;
+        let maintenance_healthy =
+            long_cert.certified_liq_deficit == 0 && short_cert.certified_liq_deficit == 0;
+        // Initial margin is an admission gate for new risk and remains a bankruptcy-path gate for
+        // liquidatable accounts. A maintenance-healthy matched reduction has already proved that
+        // neither account's absolute position grows. Requiring those accounts to regain IM in the
+        // same fill can deadlock fragmented recovery when every counterparty is smaller than the
+        // reduction needed to cross the IM boundary. Keep the locked-lane no-positive-credit gate
+        // scoped to the same admission/bankruptcy boundary.
+        if risk_increasing || !maintenance_healthy {
             Self::ensure_initial_margin(&long_account.as_view())?;
             Self::ensure_initial_margin(&short_account.as_view())?;
             if locked {

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -938,6 +938,15 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Self::ensure_no_positive_credit_initial_margin(account)
     }
 
+    pub fn kani_ensure_trade_final_margin_policy(
+        long_account: &PortfolioV16View<'_>,
+        short_account: &PortfolioV16View<'_>,
+        locked: bool,
+        risk_increasing: bool,
+    ) -> V16Result<()> {
+        Self::ensure_trade_final_margin_policy(long_account, short_account, locked, risk_increasing)
+    }
+
     pub fn kani_apply_trade_after_refresh_not_atomic(
         &mut self,
         long_account: &mut PortfolioV16ViewMut<'_>,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -4221,6 +4221,142 @@ fn proof_v16_locked_trade_margin_gate_cannot_use_positive_pnl_credit() {
 }
 
 #[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_trade_final_margin_policy_preserves_exit_liveness_and_bankruptcy_gates() {
+    let long_capital_raw: u8 = kani::any();
+    let short_capital_raw: u8 = kani::any();
+    let long_pnl_raw: i8 = kani::any();
+    let short_pnl_raw: i8 = kani::any();
+    let long_fee_debt_raw: u8 = kani::any();
+    let short_fee_debt_raw: u8 = kani::any();
+    let long_equity_raw: i8 = kani::any();
+    let short_equity_raw: i8 = kani::any();
+    let long_req_raw: u8 = kani::any();
+    let short_req_raw: u8 = kani::any();
+    let long_liq_deficit_raw: u8 = kani::any();
+    let short_liq_deficit_raw: u8 = kani::any();
+    let long_cert_valid: bool = kani::any();
+    let short_cert_valid: bool = kani::any();
+    let risk_increasing: bool = kani::any();
+    let locked: bool = kani::any();
+
+    let account = |capital_raw: u8,
+                   pnl_raw: i8,
+                   fee_debt_raw: u8,
+                   equity_raw: i8,
+                   req_raw: u8,
+                   liq_deficit_raw: u8,
+                   valid: bool| {
+        let mut header = PortfolioAccountV16Account::default();
+        header.capital = V16PodU128::new(capital_raw as u128);
+        header.pnl = V16PodI128::new(pnl_raw as i128);
+        header.fee_credits = V16PodI128::new(-(fee_debt_raw as i128));
+        header.health_cert = HealthCertV16Account::from_runtime(&HealthCertV16 {
+            certified_equity: equity_raw as i128,
+            certified_initial_req: req_raw as u128,
+            certified_maintenance_req: req_raw as u128,
+            certified_liq_deficit: liq_deficit_raw as u128,
+            certified_worst_case_loss: req_raw as u128,
+            cert_oracle_epoch: 0,
+            cert_funding_epoch: 0,
+            cert_risk_epoch: 0,
+            cert_asset_set_epoch: 0,
+            active_bitmap_at_cert: V16_EMPTY_ACTIVE_BITMAP,
+            valid,
+        });
+        header
+    };
+    let long_header = account(
+        long_capital_raw,
+        long_pnl_raw,
+        long_fee_debt_raw,
+        long_equity_raw,
+        long_req_raw,
+        long_liq_deficit_raw,
+        long_cert_valid,
+    );
+    let short_header = account(
+        short_capital_raw,
+        short_pnl_raw,
+        short_fee_debt_raw,
+        short_equity_raw,
+        short_req_raw,
+        short_liq_deficit_raw,
+        short_cert_valid,
+    );
+    let long = PortfolioV16View::new(&long_header);
+    let short = PortfolioV16View::new(&short_header);
+
+    let certified_ok =
+        |equity: i8, req: u8, valid: bool| valid && equity >= 0 && (equity as u8) >= req;
+    let principal_only_ok = |capital: u8, pnl: i8, fee_debt: u8, req: u8| {
+        let equity = capital as i128 + (pnl as i128).min(0) - fee_debt as i128;
+        equity >= 0 && (equity as u128) >= req as u128
+    };
+    let long_certified_ok = certified_ok(long_equity_raw, long_req_raw, long_cert_valid);
+    let short_certified_ok = certified_ok(short_equity_raw, short_req_raw, short_cert_valid);
+    let long_principal_only_ok = principal_only_ok(
+        long_capital_raw,
+        long_pnl_raw,
+        long_fee_debt_raw,
+        long_req_raw,
+    );
+    let short_principal_only_ok = principal_only_ok(
+        short_capital_raw,
+        short_pnl_raw,
+        short_fee_debt_raw,
+        short_req_raw,
+    );
+    let margin_required =
+        risk_increasing || long_liq_deficit_raw != 0 || short_liq_deficit_raw != 0;
+    let expected_ok = !margin_required
+        || (long_certified_ok
+            && short_certified_ok
+            && (!locked || (long_principal_only_ok && short_principal_only_ok)));
+
+    let result = MarketGroupV16ViewMut::<u64>::kani_ensure_trade_final_margin_policy(
+        &long,
+        &short,
+        locked,
+        risk_increasing,
+    );
+
+    kani::cover!(
+        !margin_required && !long_certified_ok && !short_certified_ok,
+        "maintenance-healthy bilateral reductions progress below IM"
+    );
+    kani::cover!(
+        risk_increasing && !long_certified_ok && result.is_err(),
+        "risk increases cannot bypass certified initial margin"
+    );
+    kani::cover!(
+        !risk_increasing && long_liq_deficit_raw != 0 && !long_certified_ok && result.is_err(),
+        "liquidatable counterparties cannot use the reduction exemption"
+    );
+    kani::cover!(
+        margin_required
+            && locked
+            && long_certified_ok
+            && short_certified_ok
+            && !long_principal_only_ok
+            && result.is_err(),
+        "locked risk cannot satisfy IM using positive credit"
+    );
+    kani::cover!(
+        margin_required
+            && locked
+            && long_certified_ok
+            && short_certified_ok
+            && long_principal_only_ok
+            && short_principal_only_ok
+            && result.is_ok(),
+        "fully funded locked risk remains admissible"
+    );
+    assert_eq!(result.is_ok(), expected_ok);
+}
+
+#[kani::proof]
 #[kani::unwind(48)]
 #[kani::solver(cadical)]
 fn proof_v16_live_market_shape_rejects_long_short_oi_mismatch() {

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -702,6 +702,9 @@ fn v16_trade_keeps_two_sided_risk_reduction_open_during_side_recovery() {
 #[test]
 fn v16_two_sided_reduction_does_not_require_same_fill_im_recovery() {
     let (mut header, mut markets) = market_fixture(1, 100);
+    header.config.maintenance_margin_bps = V16PodU64::new(5_000);
+    header.config.initial_margin_bps = V16PodU64::new(10_000);
+    header.config.max_price_move_bps_per_slot = V16PodU64::new(1_000);
     let mut long_header = account_fixture(1, 20);
     let mut short_header = account_fixture(1, 21);
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
@@ -735,6 +738,23 @@ fn v16_two_sided_reduction_does_not_require_same_fill_im_recovery() {
             .sync_account_fee_to_slot_not_atomic(&mut short, 1, 150)
             .unwrap(),
         150
+    );
+    assert_eq!(
+        long.header
+            .health_cert
+            .try_to_runtime()
+            .unwrap()
+            .certified_liq_deficit,
+        0
+    );
+    assert_eq!(
+        short
+            .header
+            .health_cert
+            .try_to_runtime()
+            .unwrap()
+            .certified_liq_deficit,
+        0
     );
 
     market

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -700,6 +700,70 @@ fn v16_trade_keeps_two_sided_risk_reduction_open_during_side_recovery() {
 }
 
 #[test]
+fn v16_two_sided_reduction_does_not_require_same_fill_im_recovery() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut long_header = account_fixture(1, 20);
+    let mut short_header = account_fixture(1, 21);
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market.deposit_not_atomic(&mut long, 1_000).unwrap();
+    market.deposit_not_atomic(&mut short, 1_000).unwrap();
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: signed_q(10 * POS_SCALE),
+                exec_price: 100,
+                fee_bps: 0,
+            },
+        )
+        .unwrap();
+
+    // Move both accounts below IM without changing position direction. This models the public
+    // margin-gap/recovery state produced by an adverse mark or an accrued account fee.
+    assert_eq!(
+        market
+            .sync_account_fee_to_slot_not_atomic(&mut long, 1, 150)
+            .unwrap(),
+        150
+    );
+    assert_eq!(
+        market
+            .sync_account_fee_to_slot_not_atomic(&mut short, 1, 150)
+            .unwrap(),
+        150
+    );
+
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: -signed_q(POS_SCALE),
+                exec_price: 100,
+                fee_bps: 0,
+            },
+        )
+        .expect("a matched reduction must make progress even when one fill cannot restore IM");
+
+    let long_leg = long.header.legs[0].try_to_runtime().unwrap();
+    let short_leg = short.header.legs[0].try_to_runtime().unwrap();
+    assert_eq!(long_leg.basis_pos_q, signed_q(9 * POS_SCALE));
+    assert_eq!(short_leg.basis_pos_q, -signed_q(9 * POS_SCALE));
+    let long_cert = long.header.health_cert.try_to_runtime().unwrap();
+    let short_cert = short.header.health_cert.try_to_runtime().unwrap();
+    assert!((long_cert.certified_equity as u128) < long_cert.certified_initial_req);
+    assert!((short_cert.certified_equity as u128) < short_cert.certified_initial_req);
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+    short.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_crossed_trade_cannot_spend_same_call_addition_as_preexisting_oi() {
     const SURVIVOR_Q: u128 = 13 * POS_SCALE;
     const MATCHED_Q: u128 = 10 * POS_SCALE;


### PR DESCRIPTION
## What changed

- Gate post-trade initial margin only when a fill increases risk or either post-trade account is liquidatable.
- Keep the locked-lane no-positive-credit IM gate scoped to that same admission/bankruptcy boundary.
- Leave the frozen `spec.md` unchanged.

## Root cause and impact

The trade preflight already proves that a matched risk-reducing fill does not increase either counterparty's absolute position. The final trade stage nevertheless required both accounts to cover initial margin after every fill.

That creates a permissionless recovery deadlock when one maintenance-healthy account has a large position and aggregate opposite OI is fragmented across smaller portfolios. Each available force-close reduces both sides, but each partial fill reverts until one counterparty is large enough to restore the large account's IM in a single call. No such counterparty has to exist.

Risk-increasing fills and liquidatable accounts retain the existing initial-margin and locked-lane checks, so bilateral trading cannot bypass bankruptcy attribution. Two-sided reductions where both post-trade accounts remain maintenance-healthy can decrease position rank below IM, preserving user and delayed recovery exit liveness.

## Proof-driven verification

`proof_v16_trade_final_margin_policy_preserves_exit_liveness_and_bankruptcy_gates` is a symbolic theorem over the production final-margin policy, not a fixed trade fixture. It quantifies both accounts' capital, positive/negative PnL, fee debt, certified equity, IM requirement, liquidation deficit, certificate validity, risk direction, and locked-lane state. It proves the full policy partition:

- maintenance-healthy bilateral reductions do not require same-fill IM recovery;
- every risk increase still requires both certified IM checks;
- any liquidatable post-state loses the reduction exemption;
- locked risk cannot satisfy IM with positive PnL credit;
- fully principal-funded locked risk remains admissible.

All five policy classes have explicit reachability covers. Restoring the parent unconditional final-IM gate falsifies the reduction-liveness assertion; weakening either bankruptcy gate falsifies the corresponding safety assertion. The persisted production regression and public wrapper LiteSVM scenario bind the theorem to the full trade path.

## Validation

- `cargo fmt --check`
- `cargo test --all-targets`
- `cargo kani --tests --features fuzz --harness proof_v16_trade_final_margin_policy_preserves_exit_liveness_and_bankruptcy_gates`
- Focused regression: `v16_two_sided_reduction_does_not_require_same_fill_im_recovery`
- Existing bankrupt/off-mark recycle regressions remain rejecting
