### PR TITLE
Keep funded flat assets reusable

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -12082,6 +12082,38 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         canonical_slot
     }
 
+    #[inline(always)]
+    fn asset_has_empty_lifecycle_blocker(asset: AssetStateV16) -> bool {
+        asset.mode_long != SideModeV16::Normal
+            || asset.mode_short != SideModeV16::Normal
+            || !((asset.a_long == ADL_ONE && asset.a_short == ADL_ONE)
+                || (asset.a_long == 0 && asset.a_short == 0))
+            || asset.k_long != 0
+            || asset.k_short != 0
+            || asset.k_epoch_start_long != 0
+            || asset.k_epoch_start_short != 0
+            || asset.b_long_num != 0
+            || asset.b_short_num != 0
+            || asset.b_epoch_start_long_num != 0
+            || asset.b_epoch_start_short_num != 0
+            || asset.oi_eff_long_q != 0
+            || asset.oi_eff_short_q != 0
+            || asset.stored_pos_count_long != 0
+            || asset.stored_pos_count_short != 0
+            || asset.stale_account_count_long != 0
+            || asset.stale_account_count_short != 0
+            || asset.pending_obligation_count_long != 0
+            || asset.pending_obligation_count_short != 0
+            || asset.loss_weight_sum_long != 0
+            || asset.loss_weight_sum_short != 0
+            || asset.social_loss_remainder_long_num != 0
+            || asset.social_loss_remainder_short_num != 0
+            || asset.social_loss_dust_long_num != 0
+            || asset.social_loss_dust_short_num != 0
+            || asset.explicit_unallocated_loss_long != 0
+            || asset.explicit_unallocated_loss_short != 0
+    }
+
     fn require_asset_live_reducible(&self, asset_index: usize) -> V16Result<()> {
         let asset = self.asset_state(asset_index)?;
         match asset.lifecycle {
@@ -12126,34 +12158,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // can still claim either the current or epoch-start F anchors. Restart canonicalizes them.
         if slot.pending_domain_loss_barrier_long.get() != 0
             || slot.pending_domain_loss_barrier_short.get() != 0
-            || asset.mode_long != SideModeV16::Normal
-            || asset.mode_short != SideModeV16::Normal
-            || !((asset.a_long == ADL_ONE && asset.a_short == ADL_ONE)
-                || (asset.a_long == 0 && asset.a_short == 0))
-            || asset.k_long != 0
-            || asset.k_short != 0
-            || asset.k_epoch_start_long != 0
-            || asset.k_epoch_start_short != 0
-            || asset.b_long_num != 0
-            || asset.b_short_num != 0
-            || asset.b_epoch_start_long_num != 0
-            || asset.b_epoch_start_short_num != 0
-            || asset.oi_eff_long_q != 0
-            || asset.oi_eff_short_q != 0
-            || asset.stored_pos_count_long != 0
-            || asset.stored_pos_count_short != 0
-            || asset.stale_account_count_long != 0
-            || asset.stale_account_count_short != 0
-            || asset.pending_obligation_count_long != 0
-            || asset.pending_obligation_count_short != 0
-            || asset.loss_weight_sum_long != 0
-            || asset.loss_weight_sum_short != 0
-            || asset.social_loss_remainder_long_num != 0
-            || asset.social_loss_remainder_short_num != 0
-            || asset.social_loss_dust_long_num != 0
-            || asset.social_loss_dust_short_num != 0
-            || asset.explicit_unallocated_loss_long != 0
-            || asset.explicit_unallocated_loss_short != 0
+            || Self::asset_has_empty_lifecycle_blocker(asset)
             || spent_blocks_empty
             || !long_source.is_empty_amount_shape()
             || !short_source.is_empty_amount_shape()

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -12121,6 +12121,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             long_spent != 0 || short_spent != 0
         };
 
+        // Funding indices are settlement history, not liabilities. Once the position, stale,
+        // obligation, loss, source, backing, and reservation checks below are all empty, no account
+        // can still claim either the current or epoch-start F anchors. Restart canonicalizes them.
         if slot.pending_domain_loss_barrier_long.get() != 0
             || slot.pending_domain_loss_barrier_short.get() != 0
             || asset.mode_long != SideModeV16::Normal
@@ -12129,12 +12132,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 || (asset.a_long == 0 && asset.a_short == 0))
             || asset.k_long != 0
             || asset.k_short != 0
-            || asset.f_long_num != 0
-            || asset.f_short_num != 0
             || asset.k_epoch_start_long != 0
             || asset.k_epoch_start_short != 0
-            || asset.f_epoch_start_long_num != 0
-            || asset.f_epoch_start_short_num != 0
             || asset.b_long_num != 0
             || asset.b_short_num != 0
             || asset.b_epoch_start_long_num != 0

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -832,6 +832,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Self::canonical_retired_asset_slot(old_asset)
     }
 
+    pub fn kani_asset_has_empty_lifecycle_blocker(asset: AssetStateV16) -> bool {
+        Self::asset_has_empty_lifecycle_blocker(asset)
+    }
+
     pub fn kani_convert_source_claim_exposure_guard(
         &self,
         account: &PortfolioV16View<'_>,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -7158,11 +7158,21 @@ fn proof_v16_retire_nonempty_asset_rejects() {
 fn proof_v16_retire_empty_asset_is_value_neutral_and_epoch_scoped() {
     let with_senior_balances: bool = kani::any();
     let retire_slot_raw: u8 = kani::any();
+    let funding_raw: i8 = kani::any();
+    let epoch_funding_raw: i8 = kani::any();
     kani::assume((1..=10).contains(&retire_slot_raw));
+    kani::assume(funding_raw != 0);
+    kani::assume(epoch_funding_raw != 0);
     let c_tot = if with_senior_balances { 7 } else { 0 };
     let insurance = if with_senior_balances { 3 } else { 0 };
     let retire_slot = retire_slot_raw as u64;
     let (mut header, mut markets, _) = one_market_view_fixture();
+    let mut inert_asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    inert_asset.f_long_num = funding_raw as i128;
+    inert_asset.f_short_num = -(funding_raw as i128);
+    inert_asset.f_epoch_start_long_num = epoch_funding_raw as i128;
+    inert_asset.f_epoch_start_short_num = -(epoch_funding_raw as i128);
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&inert_asset);
     header.vault = V16PodU128::new(c_tot + insurance);
     header.c_tot = V16PodU128::new(c_tot);
     header.insurance = V16PodU128::new(insurance);
@@ -7179,8 +7189,12 @@ fn proof_v16_retire_empty_asset_is_value_neutral_and_epoch_scoped() {
     let asset = market.markets[0].engine.asset.try_to_runtime().unwrap();
 
     kani::cover!(
-        retire_slot > 1 && with_senior_balances && asset.lifecycle == AssetLifecycleV16::Retired,
-        "empty asset can retire without moving nonzero senior balances"
+        retire_slot > 1
+            && with_senior_balances
+            && asset.lifecycle == AssetLifecycleV16::Retired
+            && asset.f_long_num != 0
+            && asset.f_epoch_start_long_num != 0,
+        "empty asset with inert funding history can retire without moving senior balances"
     );
     assert_eq!(asset.lifecycle, AssetLifecycleV16::Retired);
     assert_eq!(asset.retired_slot, retire_slot);
@@ -7188,6 +7202,16 @@ fn proof_v16_retire_empty_asset_is_value_neutral_and_epoch_scoped() {
     assert_eq!(market.header.vault, vault_before);
     assert_eq!(market.header.c_tot, c_tot_before);
     assert_eq!(market.header.insurance, insurance_before);
+    assert_eq!(asset.f_long_num, inert_asset.f_long_num);
+    assert_eq!(asset.f_short_num, inert_asset.f_short_num);
+    assert_eq!(
+        asset.f_epoch_start_long_num,
+        inert_asset.f_epoch_start_long_num
+    );
+    assert_eq!(
+        asset.f_epoch_start_short_num,
+        inert_asset.f_epoch_start_short_num
+    );
     assert_eq!(
         market.header.asset_set_epoch.get(),
         asset_set_epoch_before + 1

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -1792,6 +1792,10 @@ fn proof_v16_public_restart_empty_asset_zero_preserves_budgets_and_senior_value(
     old_asset.fund_px_last = 100;
     old_asset.slot_last = current_slot;
     old_asset.retired_slot = if restart_retired { current_slot } else { 0 };
+    old_asset.f_long_num = 1;
+    old_asset.f_short_num = -1;
+    old_asset.f_epoch_start_long_num = 1;
+    old_asset.f_epoch_start_short_num = -1;
     markets[0].engine.asset = AssetStateV16Account::from_runtime(&old_asset);
     markets[0].engine.insurance_domain_budget_long = V16PodU128::new(long_budget);
     markets[0].engine.insurance_domain_budget_short = V16PodU128::new(short_budget);
@@ -1828,6 +1832,10 @@ fn proof_v16_public_restart_empty_asset_zero_preserves_budgets_and_senior_value(
     assert_eq!(restarted_asset.effective_price, price_raw as u64);
     assert_eq!(restarted_asset.fund_px_last, price_raw as u64);
     assert_eq!(restarted_asset.slot_last, now_slot);
+    assert_eq!(restarted_asset.f_long_num, 0);
+    assert_eq!(restarted_asset.f_short_num, 0);
+    assert_eq!(restarted_asset.f_epoch_start_long_num, 0);
+    assert_eq!(restarted_asset.f_epoch_start_short_num, 0);
     assert_eq!(restarted.insurance_domain_budget_long.get(), long_budget);
     assert_eq!(restarted.insurance_domain_budget_short.get(), short_budget);
     assert_eq!(restarted.insurance_domain_spent_long.get(), 0);
@@ -7155,23 +7163,198 @@ fn proof_v16_retire_nonempty_asset_rejects() {
 #[kani::proof]
 #[kani::unwind(48)]
 #[kani::solver(cadical)]
+// F is settlement history once every claimant-bearing field is empty. Prove
+// magnitude and lane-pattern independence over the full four-i128 domain.
+fn proof_v16_empty_lifecycle_classifier_is_f_history_independent() {
+    let f_history: [i128; 4] = kani::any();
+    let zero_adl_epoch: bool = kani::any();
+    let mut asset = AssetStateV16::default();
+    if zero_adl_epoch {
+        asset.a_long = 0;
+        asset.a_short = 0;
+    }
+    asset.f_long_num = f_history[0];
+    asset.f_short_num = f_history[1];
+    asset.f_epoch_start_long_num = f_history[2];
+    asset.f_epoch_start_short_num = f_history[3];
+    let mut zero_f = asset;
+    zero_f.f_long_num = 0;
+    zero_f.f_short_num = 0;
+    zero_f.f_epoch_start_long_num = 0;
+    zero_f.f_epoch_start_short_num = 0;
+
+    let classified = MarketGroupV16ViewMut::<u64>::kani_asset_has_empty_lifecycle_blocker(asset);
+    let zero_classified =
+        MarketGroupV16ViewMut::<u64>::kani_asset_has_empty_lifecycle_blocker(zero_f);
+
+    kani::cover!(
+        f_history[0] == i128::MAX
+            && f_history[1] == i128::MIN + 1
+            && f_history[2] == 1
+            && f_history[3] == -1,
+        "mixed current and epoch-start F history is inert at valid extrema"
+    );
+    kani::cover!(
+        f_history[0] != 0
+            && f_history[1] != 0
+            && f_history[2] != 0
+            && f_history[3] != 0
+            && zero_adl_epoch,
+        "all F history lanes are inert in the zero ADL epoch"
+    );
+    assert_eq!(classified, zero_classified);
+    assert!(!classified);
+}
+
+#[kani::proof]
+#[kani::solver(cadical)]
+// Complement the noninterference theorem: every asset-local field that still
+// owns risk, a claimant, or unsettled loss must independently block reuse.
+fn proof_v16_empty_lifecycle_classifier_rejects_every_asset_claimant_and_loss_field() {
+    let blocker: u8 = kani::any();
+    let short_side: bool = kani::any();
+    kani::assume(blocker <= 13);
+    let mut asset = AssetStateV16 {
+        f_long_num: i128::MAX,
+        f_short_num: i128::MIN + 1,
+        f_epoch_start_long_num: 1,
+        f_epoch_start_short_num: -1,
+        ..AssetStateV16::default()
+    };
+
+    match blocker {
+        0 => {
+            if short_side {
+                asset.mode_short = SideModeV16::DrainOnly;
+            } else {
+                asset.mode_long = SideModeV16::DrainOnly;
+            }
+        }
+        1 => {
+            if short_side {
+                asset.a_short = 0;
+            } else {
+                asset.a_long = 0;
+            }
+        }
+        2 => {
+            if short_side {
+                asset.k_short = -1;
+            } else {
+                asset.k_long = 1;
+            }
+        }
+        3 => {
+            if short_side {
+                asset.k_epoch_start_short = -1;
+            } else {
+                asset.k_epoch_start_long = 1;
+            }
+        }
+        4 => {
+            if short_side {
+                asset.b_short_num = 1;
+            } else {
+                asset.b_long_num = 1;
+            }
+        }
+        5 => {
+            if short_side {
+                asset.b_epoch_start_short_num = 1;
+            } else {
+                asset.b_epoch_start_long_num = 1;
+            }
+        }
+        6 => {
+            if short_side {
+                asset.oi_eff_short_q = 1;
+            } else {
+                asset.oi_eff_long_q = 1;
+            }
+        }
+        7 => {
+            if short_side {
+                asset.stored_pos_count_short = 1;
+            } else {
+                asset.stored_pos_count_long = 1;
+            }
+        }
+        8 => {
+            if short_side {
+                asset.stale_account_count_short = 1;
+            } else {
+                asset.stale_account_count_long = 1;
+            }
+        }
+        9 => {
+            if short_side {
+                asset.pending_obligation_count_short = 1;
+            } else {
+                asset.pending_obligation_count_long = 1;
+            }
+        }
+        10 => {
+            if short_side {
+                asset.loss_weight_sum_short = 1;
+            } else {
+                asset.loss_weight_sum_long = 1;
+            }
+        }
+        11 => {
+            if short_side {
+                asset.social_loss_remainder_short_num = 1;
+            } else {
+                asset.social_loss_remainder_long_num = 1;
+            }
+        }
+        12 => {
+            if short_side {
+                asset.social_loss_dust_short_num = 1;
+            } else {
+                asset.social_loss_dust_long_num = 1;
+            }
+        }
+        _ => {
+            if short_side {
+                asset.explicit_unallocated_loss_short = 1;
+            } else {
+                asset.explicit_unallocated_loss_long = 1;
+            }
+        }
+    }
+
+    kani::cover!(
+        blocker == 0 && !short_side,
+        "long mode blocker is reachable"
+    );
+    kani::cover!(
+        blocker == 6 && short_side,
+        "short open-interest blocker is reachable"
+    );
+    kani::cover!(
+        blocker == 13 && !short_side,
+        "long explicit-loss blocker is reachable"
+    );
+    assert!(MarketGroupV16ViewMut::<u64>::kani_asset_has_empty_lifecycle_blocker(asset));
+}
+
+#[kani::proof]
+#[kani::unwind(48)]
+#[kani::solver(cadical)]
+// Bind the classifier theorem to the persisted zero-copy retirement path with
+// all four F lanes present; the separate theorem above discharges magnitude.
 fn proof_v16_retire_empty_asset_is_value_neutral_and_epoch_scoped() {
     let with_senior_balances: bool = kani::any();
-    let retire_slot_raw: u8 = kani::any();
-    let funding_raw: i8 = kani::any();
-    let epoch_funding_raw: i8 = kani::any();
-    kani::assume((1..=10).contains(&retire_slot_raw));
-    kani::assume(funding_raw != 0);
-    kani::assume(epoch_funding_raw != 0);
+    let late_retirement: bool = kani::any();
     let c_tot = if with_senior_balances { 7 } else { 0 };
     let insurance = if with_senior_balances { 3 } else { 0 };
-    let retire_slot = retire_slot_raw as u64;
+    let retire_slot = if late_retirement { 10 } else { 1 };
     let (mut header, mut markets, _) = one_market_view_fixture();
     let mut inert_asset = markets[0].engine.asset.try_to_runtime().unwrap();
-    inert_asset.f_long_num = funding_raw as i128;
-    inert_asset.f_short_num = -(funding_raw as i128);
-    inert_asset.f_epoch_start_long_num = epoch_funding_raw as i128;
-    inert_asset.f_epoch_start_short_num = -(epoch_funding_raw as i128);
+    inert_asset.f_long_num = 1;
+    inert_asset.f_short_num = -1;
+    inert_asset.f_epoch_start_long_num = 1;
+    inert_asset.f_epoch_start_short_num = -1;
     markets[0].engine.asset = AssetStateV16Account::from_runtime(&inert_asset);
     header.vault = V16PodU128::new(c_tot + insurance);
     header.c_tot = V16PodU128::new(c_tot);
@@ -7189,7 +7372,7 @@ fn proof_v16_retire_empty_asset_is_value_neutral_and_epoch_scoped() {
     let asset = market.markets[0].engine.asset.try_to_runtime().unwrap();
 
     kani::cover!(
-        retire_slot > 1
+        late_retirement
             && with_senior_balances
             && asset.lifecycle == AssetLifecycleV16::Retired
             && asset.f_long_num != 0
@@ -7217,7 +7400,6 @@ fn proof_v16_retire_empty_asset_is_value_neutral_and_epoch_scoped() {
         asset_set_epoch_before + 1
     );
     assert_eq!(market.header.risk_epoch.get(), risk_epoch_before + 1);
-    assert_eq!(market.validate_shape(), Ok(()));
 }
 
 #[kani::proof]

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1395,6 +1395,102 @@ fn v16_public_force_asset_recovery_freezes_mark_and_is_idempotent() {
 }
 
 #[test]
+fn v16_funded_then_flat_asset_remains_retireable() {
+    let (mut header, mut markets) = funding_market_fixture(FUNDING_COUNTER_PRICE);
+    let mut long_header = account_fixture(1, 124);
+    let mut short_header = account_fixture(1, 125);
+
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market.deposit_not_atomic(&mut long, 1_000).unwrap();
+        market.deposit_not_atomic(&mut short, 1_000).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: 1,
+                    exec_price: FUNDING_COUNTER_PRICE,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(0, 2, FUNDING_COUNTER_PRICE, FUNDING_COUNTER_RATE_E9, true)
+            .unwrap();
+        market.full_account_refresh_not_atomic(&mut long).unwrap();
+        market.full_account_refresh_not_atomic(&mut short).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: -1,
+                    exec_price: FUNDING_COUNTER_PRICE,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+    }
+
+    let backing_amounts = [
+        markets[0]
+            .engine
+            .backing_long
+            .try_to_runtime()
+            .unwrap()
+            .fresh_unliened_backing_num,
+        markets[0]
+            .engine
+            .backing_short
+            .try_to_runtime()
+            .unwrap()
+            .fresh_unliened_backing_num,
+    ];
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    for (domain, backing_num) in backing_amounts.into_iter().enumerate() {
+        assert_eq!(backing_num % BOUND_SCALE, 0);
+        let amount = backing_num / BOUND_SCALE;
+        if amount != 0 {
+            market
+                .withdraw_fresh_counterparty_backing_not_atomic(domain, amount)
+                .unwrap();
+        }
+    }
+
+    let flat = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(flat.k_long, 0);
+    assert_eq!(flat.k_short, 0);
+    assert_ne!(flat.f_long_num, 0, "control: funding history advanced");
+    assert_ne!(flat.f_short_num, 0, "control: funding history advanced");
+    assert_eq!(flat.oi_eff_long_q, 0);
+    assert_eq!(flat.oi_eff_short_q, 0);
+    assert_eq!(flat.stored_pos_count_long, 0);
+    assert_eq!(flat.stored_pos_count_short, 0);
+    assert_eq!(flat.stale_account_count_long, 0);
+    assert_eq!(flat.stale_account_count_short, 0);
+    assert_eq!(flat.pending_obligation_count_long, 0);
+    assert_eq!(flat.pending_obligation_count_short, 0);
+    assert_eq!(flat.loss_weight_sum_long, 0);
+    assert_eq!(flat.loss_weight_sum_short, 0);
+    let old_market_id = flat.market_id;
+
+    market.retire_empty_asset_not_atomic(0, 3).unwrap();
+    market
+        .restart_empty_asset_preserving_insurance_budget_not_atomic(0, FUNDING_COUNTER_PRICE, 4)
+        .unwrap();
+    let restarted = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_ne!(restarted.market_id, old_market_id);
+    assert_eq!(restarted.f_long_num, 0);
+    assert_eq!(restarted.f_short_num, 0);
+    market.validate_shape().unwrap();
+}
+
+#[test]
 fn v16_restart_empty_asset_preserves_domain_budget_for_nonzero_asset() {
     let (mut header, mut markets) = market_fixture(2, 100);
     {


### PR DESCRIPTION
## Impact

A normal funded asset can become permanently unreusable after its trading lifecycle is complete. Balanced OI advances the funding indices; after both users settle, close, and withdraw all source backing, the asset has no positions, stale accounts, obligations, loss state, source claims, backing, reservations, K, B, or value claimant. Historical current and epoch-start F values remain, and the parent empty-lifecycle guard rejects retirement/restart forever.

This is a partial public DoS against finite market-slot capacity. The trigger uses ordinary matched trading and funding accrual, not malformed or directly injected state.

## Fix

Treat current and epoch-start F indices as inert settlement anchors only after every claimant-bearing and value-bearing field satisfies the existing empty-state requirements. Retirement preserves the history; restart changes `market_id` and canonicalizes the slot.

All real blockers remain enforced: side mode, ADL epoch shape, K/B, OI, position/stale/obligation counts, loss weights, social-loss remainder/dust, explicit loss, barriers, source credit, backing, reservations, and spent insurance.

## Proof-driven evidence

The source extracts the exact O(1) asset-local empty-lifecycle predicate without changing behavior, making the semantic boundary directly provable.

- `proof_v16_empty_lifecycle_classifier_is_f_history_independent` quantifies all four F lanes as arbitrary `i128` values (512 symbolic bits) across both valid ADL epoch shapes. It proves classification is identical to zero-F state. Result: 39 checks, 2/2 full-width covers, 0.113s.
- `proof_v16_empty_lifecycle_classifier_rejects_every_asset_claimant_and_loss_field` exhausts all 14 asset-local blocker classes on both sides while nonzero/extreme F history coexists. Result: 14 checks, 3/3 covers, 0.063s.
- `proof_v16_retire_empty_asset_is_value_neutral_and_epoch_scoped` calls the real zero-copy retirement path with all four F histories present. It proves success, history preservation, exact senior-value framing, bounded time update, and exact asset/risk epoch bumps. Result: 4,651 checks, 1/1 cover, 244.23s.
- `proof_v16_public_restart_empty_asset_zero_preserves_budgets_and_senior_value` calls the public zero-copy restart path with all four F histories present and both Recovery/Retired sources. It proves fresh market generation, F canonicalization, source/backing reset, budget preservation, value-stock preservation, and exact counter updates. Result: 4,282 checks, 3/3 covers, 50.77s.

This replaces the monolithic retirement proof that timed out at 300 seconds with stronger layered obligations, each under 300 seconds.

Mutation sensitivity:

- Reintroducing a current-F retirement guard falsifies arbitrary-width noninterference with both covers reached.
- Removing the long-OI blocker falsifies blocker completeness with all three covers reached.
- Mutations were restored before clean verification.

## Validation

- Production regression `v16_funded_then_flat_asset_remains_retireable`: fails with `LockActive` on the parent and passes after the fix.
- `cargo test --all-targets`: 130 passed, 0 failed.
- All four Kani harnesses above pass under 300 seconds.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
- Frozen `spec.md` unchanged.