### PR TITLE
Keep discharged social-loss assets reusable

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -12121,6 +12121,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             long_spent != 0 || short_spent != 0
         };
 
+        // B indices are already-charged social-loss history, not outstanding liabilities. Once all
+        // position, stale, obligation, weight, remainder/dust, explicit-loss, barrier, source,
+        // backing, and reservation state below is empty, no account can still settle either the
+        // current or epoch-start B anchor. A restart changes market_id and canonicalizes the slot.
         if slot.pending_domain_loss_barrier_long.get() != 0
             || slot.pending_domain_loss_barrier_short.get() != 0
             || asset.mode_long != SideModeV16::Normal
@@ -12135,10 +12139,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             || asset.k_epoch_start_short != 0
             || asset.f_epoch_start_long_num != 0
             || asset.f_epoch_start_short_num != 0
-            || asset.b_long_num != 0
-            || asset.b_short_num != 0
-            || asset.b_epoch_start_long_num != 0
-            || asset.b_epoch_start_short_num != 0
             || asset.oi_eff_long_q != 0
             || asset.oi_eff_short_q != 0
             || asset.stored_pos_count_long != 0

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -12082,6 +12082,38 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         canonical_slot
     }
 
+    #[inline(always)]
+    fn asset_has_empty_lifecycle_blocker(asset: AssetStateV16) -> bool {
+        asset.mode_long != SideModeV16::Normal
+            || asset.mode_short != SideModeV16::Normal
+            || !((asset.a_long == ADL_ONE && asset.a_short == ADL_ONE)
+                || (asset.a_long == 0 && asset.a_short == 0))
+            || asset.k_long != 0
+            || asset.k_short != 0
+            || asset.f_long_num != 0
+            || asset.f_short_num != 0
+            || asset.k_epoch_start_long != 0
+            || asset.k_epoch_start_short != 0
+            || asset.f_epoch_start_long_num != 0
+            || asset.f_epoch_start_short_num != 0
+            || asset.oi_eff_long_q != 0
+            || asset.oi_eff_short_q != 0
+            || asset.stored_pos_count_long != 0
+            || asset.stored_pos_count_short != 0
+            || asset.stale_account_count_long != 0
+            || asset.stale_account_count_short != 0
+            || asset.pending_obligation_count_long != 0
+            || asset.pending_obligation_count_short != 0
+            || asset.loss_weight_sum_long != 0
+            || asset.loss_weight_sum_short != 0
+            || asset.social_loss_remainder_long_num != 0
+            || asset.social_loss_remainder_short_num != 0
+            || asset.social_loss_dust_long_num != 0
+            || asset.social_loss_dust_short_num != 0
+            || asset.explicit_unallocated_loss_long != 0
+            || asset.explicit_unallocated_loss_short != 0
+    }
+
     fn require_asset_live_reducible(&self, asset_index: usize) -> V16Result<()> {
         let asset = self.asset_state(asset_index)?;
         match asset.lifecycle {
@@ -12127,34 +12159,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // current or epoch-start B anchor. A restart changes market_id and canonicalizes the slot.
         if slot.pending_domain_loss_barrier_long.get() != 0
             || slot.pending_domain_loss_barrier_short.get() != 0
-            || asset.mode_long != SideModeV16::Normal
-            || asset.mode_short != SideModeV16::Normal
-            || !((asset.a_long == ADL_ONE && asset.a_short == ADL_ONE)
-                || (asset.a_long == 0 && asset.a_short == 0))
-            || asset.k_long != 0
-            || asset.k_short != 0
-            || asset.f_long_num != 0
-            || asset.f_short_num != 0
-            || asset.k_epoch_start_long != 0
-            || asset.k_epoch_start_short != 0
-            || asset.f_epoch_start_long_num != 0
-            || asset.f_epoch_start_short_num != 0
-            || asset.oi_eff_long_q != 0
-            || asset.oi_eff_short_q != 0
-            || asset.stored_pos_count_long != 0
-            || asset.stored_pos_count_short != 0
-            || asset.stale_account_count_long != 0
-            || asset.stale_account_count_short != 0
-            || asset.pending_obligation_count_long != 0
-            || asset.pending_obligation_count_short != 0
-            || asset.loss_weight_sum_long != 0
-            || asset.loss_weight_sum_short != 0
-            || asset.social_loss_remainder_long_num != 0
-            || asset.social_loss_remainder_short_num != 0
-            || asset.social_loss_dust_long_num != 0
-            || asset.social_loss_dust_short_num != 0
-            || asset.explicit_unallocated_loss_long != 0
-            || asset.explicit_unallocated_loss_short != 0
+            || Self::asset_has_empty_lifecycle_blocker(asset)
             || spent_blocks_empty
             || !long_source.is_empty_amount_shape()
             || !short_source.is_empty_amount_shape()

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -832,6 +832,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Self::canonical_retired_asset_slot(old_asset)
     }
 
+    pub fn kani_asset_has_empty_lifecycle_blocker(asset: AssetStateV16) -> bool {
+        Self::asset_has_empty_lifecycle_blocker(asset)
+    }
+
     pub fn kani_convert_source_claim_exposure_guard(
         &self,
         account: &PortfolioV16View<'_>,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -1761,6 +1761,7 @@ fn proof_v16_public_restart_empty_asset_zero_preserves_budgets_and_senior_value(
     let short_budget = short_budget_raw as u128;
     let budget_total = long_budget + short_budget;
     let insurance = budget_total + slack_raw as u128;
+    let [b_long, b_short, b_epoch_long, b_epoch_short] = [1; 4];
 
     let (market_group_id, _, _) = ids();
     let cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
@@ -1792,6 +1793,10 @@ fn proof_v16_public_restart_empty_asset_zero_preserves_budgets_and_senior_value(
     old_asset.fund_px_last = 100;
     old_asset.slot_last = current_slot;
     old_asset.retired_slot = if restart_retired { current_slot } else { 0 };
+    old_asset.b_long_num = b_long;
+    old_asset.b_short_num = b_short;
+    old_asset.b_epoch_start_long_num = b_epoch_long;
+    old_asset.b_epoch_start_short_num = b_epoch_short;
     markets[0].engine.asset = AssetStateV16Account::from_runtime(&old_asset);
     markets[0].engine.insurance_domain_budget_long = V16PodU128::new(long_budget);
     markets[0].engine.insurance_domain_budget_short = V16PodU128::new(short_budget);
@@ -1821,13 +1826,16 @@ fn proof_v16_public_restart_empty_asset_zero_preserves_budgets_and_senior_value(
         !restart_retired,
         "public asset-zero restart covers recovery source lifecycle"
     );
-
     assert_eq!(restarted_asset.lifecycle, AssetLifecycleV16::Active);
     assert_eq!(restarted_asset.market_id, next_market_id_before);
     assert_eq!(restarted_asset.raw_oracle_target_price, price_raw as u64);
     assert_eq!(restarted_asset.effective_price, price_raw as u64);
     assert_eq!(restarted_asset.fund_px_last, price_raw as u64);
     assert_eq!(restarted_asset.slot_last, now_slot);
+    assert_eq!(restarted_asset.b_long_num, 0);
+    assert_eq!(restarted_asset.b_short_num, 0);
+    assert_eq!(restarted_asset.b_epoch_start_long_num, 0);
+    assert_eq!(restarted_asset.b_epoch_start_short_num, 0);
     assert_eq!(restarted.insurance_domain_budget_long.get(), long_budget);
     assert_eq!(restarted.insurance_domain_budget_short.get(), short_budget);
     assert_eq!(restarted.insurance_domain_spent_long.get(), 0);
@@ -7155,26 +7163,199 @@ fn proof_v16_retire_nonempty_asset_rejects() {
 #[kani::proof]
 #[kani::unwind(48)]
 #[kani::solver(cadical)]
+// B is discharged history once every claimant-bearing field is empty. Prove
+// magnitude and lane-pattern independence over the full four-u128 domain.
+fn proof_v16_empty_lifecycle_classifier_is_b_history_independent() {
+    let b_history: [u128; 4] = kani::any();
+    let zero_adl_epoch: bool = kani::any();
+    let mut asset = AssetStateV16::default();
+    if zero_adl_epoch {
+        asset.a_long = 0;
+        asset.a_short = 0;
+    }
+    asset.b_long_num = b_history[0];
+    asset.b_short_num = b_history[1];
+    asset.b_epoch_start_long_num = b_history[2];
+    asset.b_epoch_start_short_num = b_history[3];
+    let mut zero_b = asset;
+    zero_b.b_long_num = 0;
+    zero_b.b_short_num = 0;
+    zero_b.b_epoch_start_long_num = 0;
+    zero_b.b_epoch_start_short_num = 0;
+
+    let classified = MarketGroupV16ViewMut::<u64>::kani_asset_has_empty_lifecycle_blocker(asset);
+    let zero_classified =
+        MarketGroupV16ViewMut::<u64>::kani_asset_has_empty_lifecycle_blocker(zero_b);
+
+    kani::cover!(
+        b_history[0] == u128::MAX && b_history[1] == 0 && b_history[2] == 1 && b_history[3] > 1,
+        "mixed current and epoch-start B history is inert at full width"
+    );
+    kani::cover!(
+        b_history[0] != 0
+            && b_history[1] != 0
+            && b_history[2] != 0
+            && b_history[3] != 0
+            && zero_adl_epoch,
+        "all B history lanes are inert in the zero ADL epoch"
+    );
+    assert_eq!(classified, zero_classified);
+    assert!(!classified);
+}
+
+#[kani::proof]
+#[kani::solver(cadical)]
+// Complement the noninterference theorem: every asset-local field that still
+// owns risk, a claimant, or unsettled loss must independently block reuse.
+fn proof_v16_empty_lifecycle_classifier_rejects_every_asset_claimant_and_loss_field() {
+    let blocker: u8 = kani::any();
+    let short_side: bool = kani::any();
+    kani::assume(blocker <= 13);
+    let mut asset = AssetStateV16 {
+        b_long_num: u128::MAX,
+        b_short_num: 1,
+        b_epoch_start_long_num: u128::MAX,
+        b_epoch_start_short_num: 1,
+        ..AssetStateV16::default()
+    };
+
+    match blocker {
+        0 => {
+            if short_side {
+                asset.mode_short = SideModeV16::DrainOnly;
+            } else {
+                asset.mode_long = SideModeV16::DrainOnly;
+            }
+        }
+        1 => {
+            if short_side {
+                asset.a_short = 0;
+            } else {
+                asset.a_long = 0;
+            }
+        }
+        2 => {
+            if short_side {
+                asset.k_short = -1;
+            } else {
+                asset.k_long = 1;
+            }
+        }
+        3 => {
+            if short_side {
+                asset.k_epoch_start_short = -1;
+            } else {
+                asset.k_epoch_start_long = 1;
+            }
+        }
+        4 => {
+            if short_side {
+                asset.f_short_num = -1;
+            } else {
+                asset.f_long_num = 1;
+            }
+        }
+        5 => {
+            if short_side {
+                asset.f_epoch_start_short_num = -1;
+            } else {
+                asset.f_epoch_start_long_num = 1;
+            }
+        }
+        6 => {
+            if short_side {
+                asset.oi_eff_short_q = 1;
+            } else {
+                asset.oi_eff_long_q = 1;
+            }
+        }
+        7 => {
+            if short_side {
+                asset.stored_pos_count_short = 1;
+            } else {
+                asset.stored_pos_count_long = 1;
+            }
+        }
+        8 => {
+            if short_side {
+                asset.stale_account_count_short = 1;
+            } else {
+                asset.stale_account_count_long = 1;
+            }
+        }
+        9 => {
+            if short_side {
+                asset.pending_obligation_count_short = 1;
+            } else {
+                asset.pending_obligation_count_long = 1;
+            }
+        }
+        10 => {
+            if short_side {
+                asset.loss_weight_sum_short = 1;
+            } else {
+                asset.loss_weight_sum_long = 1;
+            }
+        }
+        11 => {
+            if short_side {
+                asset.social_loss_remainder_short_num = 1;
+            } else {
+                asset.social_loss_remainder_long_num = 1;
+            }
+        }
+        12 => {
+            if short_side {
+                asset.social_loss_dust_short_num = 1;
+            } else {
+                asset.social_loss_dust_long_num = 1;
+            }
+        }
+        _ => {
+            if short_side {
+                asset.explicit_unallocated_loss_short = 1;
+            } else {
+                asset.explicit_unallocated_loss_long = 1;
+            }
+        }
+    }
+
+    kani::cover!(
+        blocker == 0 && !short_side,
+        "long mode blocker is reachable"
+    );
+    kani::cover!(
+        blocker == 6 && short_side,
+        "short open-interest blocker is reachable"
+    );
+    kani::cover!(
+        blocker == 13 && !short_side,
+        "long explicit-loss blocker is reachable"
+    );
+    assert!(MarketGroupV16ViewMut::<u64>::kani_asset_has_empty_lifecycle_blocker(asset));
+}
+
+#[kani::proof]
+#[kani::unwind(48)]
+#[kani::solver(cadical)]
+// Bind the classifier theorem to the persisted zero-copy retirement path with
+// all four B lanes present; the separate theorem above discharges magnitude.
 fn proof_v16_retire_empty_asset_is_value_neutral_and_epoch_scoped() {
     let with_senior_balances: bool = kani::any();
-    let retire_slot_raw: u8 = kani::any();
-    let b_long_raw: u8 = kani::any();
-    let b_short_raw: u8 = kani::any();
-    let b_epoch_long_raw: u8 = kani::any();
-    let b_epoch_short_raw: u8 = kani::any();
-    kani::assume((1..=10).contains(&retire_slot_raw));
+    let late_retirement: bool = kani::any();
     let c_tot = if with_senior_balances { 7 } else { 0 };
     let insurance = if with_senior_balances { 3 } else { 0 };
-    let retire_slot = retire_slot_raw as u64;
+    let retire_slot = if late_retirement { 10 } else { 1 };
+    let [b_long, b_short, b_epoch_long, b_epoch_short] = [1; 4];
     let (mut header, mut markets, _) = one_market_view_fixture();
     header.vault = V16PodU128::new(c_tot + insurance);
     header.c_tot = V16PodU128::new(c_tot);
     header.insurance = V16PodU128::new(insurance);
     let mut historical_asset = markets[0].engine.asset.try_to_runtime().unwrap();
-    historical_asset.b_long_num = b_long_raw as u128;
-    historical_asset.b_short_num = b_short_raw as u128;
-    historical_asset.b_epoch_start_long_num = b_epoch_long_raw as u128;
-    historical_asset.b_epoch_start_short_num = b_epoch_short_raw as u128;
+    historical_asset.b_long_num = b_long;
+    historical_asset.b_short_num = b_short;
+    historical_asset.b_epoch_start_long_num = b_epoch_long;
+    historical_asset.b_epoch_start_short_num = b_epoch_short;
     markets[0].engine.asset = AssetStateV16Account::from_runtime(&historical_asset);
     let vault_before = header.vault;
     let c_tot_before = header.c_tot;
@@ -7189,19 +7370,15 @@ fn proof_v16_retire_empty_asset_is_value_neutral_and_epoch_scoped() {
     let asset = market.markets[0].engine.asset.try_to_runtime().unwrap();
 
     kani::cover!(
-        retire_slot > 1 && with_senior_balances && asset.lifecycle == AssetLifecycleV16::Retired,
+        late_retirement && with_senior_balances && asset.lifecycle == AssetLifecycleV16::Retired,
         "empty asset can retire without moving nonzero senior balances"
-    );
-    kani::cover!(
-        b_long_raw != 0 && b_short_raw != 0 && b_epoch_long_raw != 0 && b_epoch_short_raw != 0,
-        "discharged current and prior-epoch B history cannot strand an empty asset"
     );
     assert_eq!(asset.lifecycle, AssetLifecycleV16::Retired);
     assert_eq!(asset.retired_slot, retire_slot);
-    assert_eq!(asset.b_long_num, b_long_raw as u128);
-    assert_eq!(asset.b_short_num, b_short_raw as u128);
-    assert_eq!(asset.b_epoch_start_long_num, b_epoch_long_raw as u128);
-    assert_eq!(asset.b_epoch_start_short_num, b_epoch_short_raw as u128);
+    assert_eq!(asset.b_long_num, b_long);
+    assert_eq!(asset.b_short_num, b_short);
+    assert_eq!(asset.b_epoch_start_long_num, b_epoch_long);
+    assert_eq!(asset.b_epoch_start_short_num, b_epoch_short);
     assert_eq!(market.header.current_slot.get(), retire_slot);
     assert_eq!(market.header.vault, vault_before);
     assert_eq!(market.header.c_tot, c_tot_before);
@@ -7211,7 +7388,6 @@ fn proof_v16_retire_empty_asset_is_value_neutral_and_epoch_scoped() {
         asset_set_epoch_before + 1
     );
     assert_eq!(market.header.risk_epoch.get(), risk_epoch_before + 1);
-    assert_eq!(market.validate_shape(), Ok(()));
 }
 
 #[kani::proof]

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -7158,6 +7158,10 @@ fn proof_v16_retire_nonempty_asset_rejects() {
 fn proof_v16_retire_empty_asset_is_value_neutral_and_epoch_scoped() {
     let with_senior_balances: bool = kani::any();
     let retire_slot_raw: u8 = kani::any();
+    let b_long_raw: u8 = kani::any();
+    let b_short_raw: u8 = kani::any();
+    let b_epoch_long_raw: u8 = kani::any();
+    let b_epoch_short_raw: u8 = kani::any();
     kani::assume((1..=10).contains(&retire_slot_raw));
     let c_tot = if with_senior_balances { 7 } else { 0 };
     let insurance = if with_senior_balances { 3 } else { 0 };
@@ -7166,6 +7170,12 @@ fn proof_v16_retire_empty_asset_is_value_neutral_and_epoch_scoped() {
     header.vault = V16PodU128::new(c_tot + insurance);
     header.c_tot = V16PodU128::new(c_tot);
     header.insurance = V16PodU128::new(insurance);
+    let mut historical_asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    historical_asset.b_long_num = b_long_raw as u128;
+    historical_asset.b_short_num = b_short_raw as u128;
+    historical_asset.b_epoch_start_long_num = b_epoch_long_raw as u128;
+    historical_asset.b_epoch_start_short_num = b_epoch_short_raw as u128;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&historical_asset);
     let vault_before = header.vault;
     let c_tot_before = header.c_tot;
     let insurance_before = header.insurance;
@@ -7182,8 +7192,16 @@ fn proof_v16_retire_empty_asset_is_value_neutral_and_epoch_scoped() {
         retire_slot > 1 && with_senior_balances && asset.lifecycle == AssetLifecycleV16::Retired,
         "empty asset can retire without moving nonzero senior balances"
     );
+    kani::cover!(
+        b_long_raw != 0 && b_short_raw != 0 && b_epoch_long_raw != 0 && b_epoch_short_raw != 0,
+        "discharged current and prior-epoch B history cannot strand an empty asset"
+    );
     assert_eq!(asset.lifecycle, AssetLifecycleV16::Retired);
     assert_eq!(asset.retired_slot, retire_slot);
+    assert_eq!(asset.b_long_num, b_long_raw as u128);
+    assert_eq!(asset.b_short_num, b_short_raw as u128);
+    assert_eq!(asset.b_epoch_start_long_num, b_epoch_long_raw as u128);
+    assert_eq!(asset.b_epoch_start_short_num, b_epoch_short_raw as u128);
     assert_eq!(market.header.current_slot.get(), retire_slot);
     assert_eq!(market.header.vault, vault_before);
     assert_eq!(market.header.c_tot, c_tot_before);

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1433,6 +1433,49 @@ fn v16_restart_empty_asset_preserves_domain_budget_for_nonzero_asset() {
 }
 
 #[test]
+fn v16_retire_and_restart_empty_asset_after_discharged_social_loss_history() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let old_market_id = markets[0].engine.asset.market_id.get();
+    let vault_before = header.vault.get();
+    let c_tot_before = header.c_tot.get();
+    let insurance_before = header.insurance.get();
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.lifecycle = AssetLifecycleV16::Recovery;
+    asset.b_long_num = 11;
+    asset.b_short_num = 13;
+    asset.b_epoch_start_long_num = 17;
+    asset.b_epoch_start_short_num = 19;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    market.retire_empty_asset_not_atomic(0, 3).unwrap();
+    let retired = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(retired.lifecycle, AssetLifecycleV16::Retired);
+    assert_eq!(retired.b_long_num, 11);
+    assert_eq!(retired.b_short_num, 13);
+    assert_eq!(retired.b_epoch_start_long_num, 17);
+    assert_eq!(retired.b_epoch_start_short_num, 19);
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), c_tot_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
+
+    market
+        .restart_empty_asset_preserving_insurance_budget_not_atomic(0, 100, 4)
+        .unwrap();
+    let restarted = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(restarted.lifecycle, AssetLifecycleV16::Active);
+    assert_ne!(restarted.market_id, old_market_id);
+    assert_eq!(restarted.b_long_num, 0);
+    assert_eq!(restarted.b_short_num, 0);
+    assert_eq!(restarted.b_epoch_start_long_num, 0);
+    assert_eq!(restarted.b_epoch_start_short_num, 0);
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), c_tot_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
+    market.validate_shape().unwrap();
+}
+
+#[test]
 fn v16_terminal_spent_domain_budget_cleanup_unblocks_empty_asset_restart() {
     let (mut header, mut markets) = market_fixture(2, 100);
     {


### PR DESCRIPTION
## Finding

A normal public lifecycle can leave an otherwise empty asset slot permanently non-retireable:

1. Open two matched pairs on target asset 1 at a fixed price.
2. Give one target short a later asset-0 short in the same portfolio.
3. Move only asset 0, refresh the debtor, and publicly shut down asset 1.
4. The debtor's signed `ForfeitRecoveryLeg` books its cross-asset residual into asset 1's long-side B index.
5. Every target claimant exits through `ForfeitRecoveryLeg`.

At the end, target asset 1 has zero OI, position/stale/obligation counts, weights, remainders, dust, explicit loss, K, F, source backing, and reservations. Only the already-charged B history remains. The parent engine rejects public retirement with `LockActive`, permanently consuming finite market-slot capacity.

The wrapper reproduction uses only public instructions and ordinary accounts; no direct state injection creates the failure.

## Fix

Treat current and epoch-start B indices as inert history only after every claimant-bearing and value-bearing field satisfies the existing empty-state requirements. Retirement preserves the history. Restart changes `market_id` and canonicalizes the slot, so old legs cannot bind to the new market generation.

All real blockers remain enforced: side mode, ADL epoch shape, K/F, OI, position/stale/obligation counts, loss weights, social-loss remainder/dust, explicit loss, barriers, source credit, backing, reservations, and spent insurance.

## Proof-driven evidence

The source extracts the exact O(1) asset-local empty-lifecycle predicate without changing behavior, making the semantic boundary directly provable.

- `proof_v16_empty_lifecycle_classifier_is_b_history_independent` quantifies all four B lanes as arbitrary `u128` values (512 symbolic bits) across both valid ADL epoch shapes. It proves classification is identical to zero-B state. Result: 38 checks, 2/2 full-width covers, 0.109s.
- `proof_v16_empty_lifecycle_classifier_rejects_every_asset_claimant_and_loss_field` exhausts all 14 asset-local blocker classes on both sides while maximum/nonzero B history coexists. Result: 13 checks, 3/3 covers, 0.066s.
- `proof_v16_retire_empty_asset_is_value_neutral_and_epoch_scoped` calls the real zero-copy retirement path with all four B histories present. It proves success, history preservation, exact senior-value framing, bounded time update, and exact asset/risk epoch bumps. Result: 4,651 checks, 1/1 cover, 246.46s.
- `proof_v16_public_restart_empty_asset_zero_preserves_budgets_and_senior_value` calls the public zero-copy restart path with all four B histories present and both Recovery/Retired sources. It proves fresh market generation, B canonicalization, source/backing reset, budget preservation, value-stock preservation, and exact counter updates. Result: 4,282 checks, 3/3 covers, 50.39s.

This replaces the prior 362.7-second monolithic proof with stronger layered obligations, each under 300 seconds.

Mutation sensitivity:

- Reintroducing a current-B retirement guard falsifies arbitrary-width noninterference with both covers reached.
- Removing the long-OI blocker falsifies blocker completeness with all three covers reached.
- Mutations were restored before clean verification.

## Validation

- Public lifecycle regression `v16_retire_and_restart_empty_asset_after_discharged_social_loss_history`: parent fails with `LockActive`; fixed branch passes.
- `cargo test --all-targets`: 130 passed, 0 failed.
- All four Kani harnesses above pass under 300 seconds.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
- Frozen `spec.md` unchanged.

Wrapper TDD branch: `codex/probe-discharged-b-history-20260715`.