### PR TITLE
Skip Recovery legs in auto-crank selection

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1532,6 +1532,25 @@ impl V16Core {
         None
     }
 
+    /// Ordinary refresh accrual and liquidation may target only a live or
+    /// draining asset. Recovery legs remain exit obligations, but selecting one
+    /// for an ordinary action would deterministically fail.
+    fn kernel_auto_crank_lifecycle_dispatchable(lifecycle: AssetLifecycleV16) -> bool {
+        matches!(
+            lifecycle,
+            AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
+        )
+    }
+
+    fn kernel_auto_crank_liquidatable(
+        live: bool,
+        cert_current: bool,
+        certified_liq_deficit: u128,
+        dispatchable_asset: Option<usize>,
+    ) -> bool {
+        live && cert_current && certified_liq_deficit != 0 && dispatchable_asset.is_some()
+    }
+
     /// PRODUCTION KERNEL (engine.md selection semantics): from the actionable
     /// summary and the ENGINE-selected assets, choose the single highest-priority
     /// bounded plan, carrying the engine-chosen asset (the caller chooses neither
@@ -11607,8 +11626,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         );
         let ledger = account.header.close_progress.try_to_runtime()?;
 
-        let has_open_risk =
-            !active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get));
+        let (_, dispatchable_active_asset) = self.auto_crank_selected_assets(account)?;
         // A close ledger with residual_remaining==0 is already fully booked/covered
         // (e.g. insurance absorbed the loss); only OUTSTANDING residual is real,
         // actionable close work. The `active` flag can linger past that.
@@ -11632,7 +11650,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // a stale cert can still report a deficit after the position was already
         // closed, but with no active leg there is nothing to liquidate (the real
         // liquidate entrypoint requires an active leg), so the flag must be false.
-        let liquidatable = live && cert_current && cert.certified_liq_deficit != 0 && has_open_risk;
+        let liquidatable = V16Core::kernel_auto_crank_liquidatable(
+            live,
+            cert_current,
+            cert.certified_liq_deficit,
+            dispatchable_active_asset,
+        );
         // Permissionless recovery (declare_permissionless_recovery) is a LIVE-mode
         // action — it rejects Resolved mode with LockActive. The proactive Live
         // recovery condition the auto-crank declares is an EXPIRED outstanding
@@ -11695,10 +11718,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             let active = active_bitmap_get(bitmap, slot) && leg.active;
             if active {
                 let lifecycle = self.asset_state(leg.asset_index as usize)?.lifecycle;
-                reducible_flags[slot] = matches!(
-                    lifecycle,
-                    AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
-                );
+                reducible_flags[slot] =
+                    V16Core::kernel_auto_crank_lifecycle_dispatchable(lifecycle);
             }
             b_stale_flags[slot] = active && leg.b_stale;
             slot += 1;

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -11676,20 +11676,30 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     /// ENGINE asset self-selection (engine.md): scan the account's bounded legs and
     /// return, for each asset-scoped continuation, the engine-chosen asset_index —
     /// the FIRST active b-stale leg's asset (SettleBChunk), and the FIRST active
-    /// leg's asset (used for both Liquidate and the refresh accrual target). The
-    /// selection is proven in-range / actionable / first-match / complete by the
-    /// first_actionable_slot contract; the slot->asset_index read is by inspection.
+    /// reducible leg's asset (used for both Liquidate and the refresh accrual target).
+    /// Recovery legs stay available to the separate frozen-mark exit/force-close
+    /// route, but cannot be selected for a continuation that always accrues or
+    /// liquidates its asset. The selection is proven in-range / actionable /
+    /// first-match / complete by the first_actionable_slot contract; the
+    /// slot->asset_index and lifecycle reads are by inspection.
     fn auto_crank_selected_assets(
+        &self,
         account: &PortfolioV16View<'_>,
     ) -> V16Result<(Option<usize>, Option<usize>)> {
         let bitmap = account.header.active_bitmap.map(V16PodU64::get);
-        let mut active_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+        let mut reducible_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut b_stale_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
             let active = active_bitmap_get(bitmap, slot) && leg.active;
-            active_flags[slot] = active;
+            if active {
+                let lifecycle = self.asset_state(leg.asset_index as usize)?.lifecycle;
+                reducible_flags[slot] = matches!(
+                    lifecycle,
+                    AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
+                );
+            }
             b_stale_flags[slot] = active && leg.b_stale;
             slot += 1;
         }
@@ -11702,8 +11712,32 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
         };
         let b_stale_asset = asset_of(V16Core::first_actionable_slot(b_stale_flags))?;
-        let active_asset = asset_of(V16Core::first_actionable_slot(active_flags))?;
+        let active_asset = asset_of(V16Core::first_actionable_slot(reducible_flags))?;
         Ok((b_stale_asset, active_asset))
+    }
+
+    /// Pure production plan query for wrappers that must authenticate the oracle
+    /// observation required by the exact continuation the engine will dispatch.
+    /// Keeping this query beside execution prevents wrappers from duplicating
+    /// lifecycle-sensitive asset selection.
+    pub fn build_auto_crank_plan(
+        &self,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<AutoCrankPlanV16> {
+        let summary = self.build_actionable_summary(account)?;
+        let (b_stale_asset, active_asset) = self.auto_crank_selected_assets(account)?;
+        let recovery_reason = if summary.expired_close {
+            PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
+        } else {
+            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow
+        };
+        Ok(V16Core::select_auto_crank_plan(
+            summary,
+            b_stale_asset.unwrap_or(0),
+            active_asset.unwrap_or(0),
+            active_asset,
+            recovery_reason,
+        ))
     }
 
     /// THE SINGLE PUBLIC PERMISSIONLESS CRANK (engine.md): the only crank the
@@ -11736,22 +11770,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
         work: AutoCrankWorkV16<'_>,
     ) -> V16Result<AutoCrankResultV16> {
-        let summary = self.build_actionable_summary(&account.as_view())?;
-        let (b_stale_asset, active_asset) = Self::auto_crank_selected_assets(&account.as_view())?;
-        let recovery_reason = if summary.expired_close {
-            PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
-        } else {
-            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow
-        };
         // PRODUCTION KERNEL: the proven plan selector (priority + totality +
-        // engine-selected asset). refresh accrues the first active leg's asset.
-        let plan = V16Core::select_auto_crank_plan(
-            summary,
-            b_stale_asset.unwrap_or(0),
-            active_asset.unwrap_or(0),
-            active_asset,
-            recovery_reason,
-        );
+        // engine-selected asset), exposed through the same pure query wrappers
+        // use to authenticate its selected observation.
+        let plan = self.build_auto_crank_plan(&account.as_view())?;
 
         let obs_or_current_asset = |me: &Self, i: usize| -> V16Result<AutoCrankObservationV16> {
             match work

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -9,6 +9,44 @@
 use super::*;
 use crate::wide_math::U256;
 
+pub fn kani_auto_crank_lifecycle_dispatchable(lifecycle: AssetLifecycleV16) -> bool {
+    V16Core::kernel_auto_crank_lifecycle_dispatchable(lifecycle)
+}
+
+pub fn kani_auto_crank_liquidatable(
+    live: bool,
+    cert_current: bool,
+    certified_liq_deficit: u128,
+    dispatchable_asset: Option<usize>,
+) -> bool {
+    V16Core::kernel_auto_crank_liquidatable(
+        live,
+        cert_current,
+        certified_liq_deficit,
+        dispatchable_asset,
+    )
+}
+
+pub fn kani_first_actionable_slot(flags: [bool; V16_MAX_PORTFOLIO_ASSETS_N]) -> Option<usize> {
+    V16Core::first_actionable_slot(flags)
+}
+
+pub fn kani_select_auto_crank_plan(
+    summary: ActionableSummaryV16,
+    b_stale_slot: usize,
+    liq_slot: usize,
+    refresh_asset: Option<usize>,
+    recovery_reason: PermissionlessRecoveryReasonV16,
+) -> AutoCrankPlanV16 {
+    V16Core::select_auto_crank_plan(
+        summary,
+        b_stale_slot,
+        liq_slot,
+        refresh_asset,
+        recovery_reason,
+    )
+}
+
 pub fn kani_apply_backing_utilization_fee_charge(
     account_capital: u128,
     group_c_tot: u128,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -5,20 +5,22 @@ use percolator::v16::{
     backing_domain_fee_split_for_lien_delta_num, kani_active_bitmap_set as active_bitmap_set,
     kani_add_open_interest_for_new_position, kani_apply_backing_provider_earnings_withdraw,
     kani_apply_backing_utilization_fee_charge, kani_apply_resolved_payout_receipt_payment,
+    kani_auto_crank_lifecycle_dispatchable, kani_auto_crank_liquidatable,
     kani_available_backing_num_for_source_credit_state,
     kani_backing_utilization_fee_quote_atoms_for_lien,
     kani_backing_utilization_rate_e9_for_source_state, kani_cert_is_current,
-    kani_expected_source_credit_rate_num_for_state, kani_health_cert_after_capital_debit,
-    kani_health_requirements_from_base_and_target_lag,
+    kani_expected_source_credit_rate_num_for_state, kani_first_actionable_slot,
+    kani_health_cert_after_capital_debit, kani_health_requirements_from_base_and_target_lag,
     kani_liquidation_close_would_leave_uncovered_loss_with_open_risk,
     kani_liquidation_engine_close_request_q, kani_liquidation_fee_from_raw_fee,
     kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
     kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
-    kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
-    kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
-    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
-    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
+    kani_prepare_asset_recovery_transition, kani_select_auto_crank_plan,
+    kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
+    kani_trade_preexisting_oi_reduction_gate, kani_trade_preflight_risk_gate,
+    kani_validate_positive_pnl_source_attribution, ActionableSummaryV16, AssetLifecycleV16,
+    AssetStateV16, AssetStateV16Account, AutoCrankPlanV16, BackingBucketStatusV16,
     BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
     CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
     HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
@@ -15401,4 +15403,146 @@ fn proof_v16_backing_utilization_zero_fee_carries_accrual_forward() {
     assert_eq!(market.header.c_tot.get(), c_tot_before);
     assert_eq!(market.header.vault.get(), vault_before);
     assert_eq!(market.header.insurance.get(), insurance_before);
+}
+
+// Mixed-lifecycle liveness over every ordering and multiplicity in the full
+// 16-leg shape. Recovery obligations cannot become ordinary refresh/liquidation
+// targets or starve later Active/DrainOnly work.
+#[kani::proof]
+#[kani::unwind(18)]
+#[kani::solver(cadical)]
+fn proof_v16_recovery_legs_cannot_starve_dispatchable_auto_crank_work() {
+    let recovery_mask: u16 = kani::any();
+    let active_mask: u16 = kani::any();
+    let drain_only_mask: u16 = kani::any();
+    kani::assume(recovery_mask != 0);
+    kani::assume(recovery_mask & active_mask == 0);
+    kani::assume(recovery_mask & drain_only_mask == 0);
+    kani::assume(active_mask & drain_only_mask == 0);
+
+    let dispatchable_mask = active_mask | drain_only_mask;
+    let mut dispatchable_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+    let mut slot = 0usize;
+    while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+        let bit = 1u16 << slot;
+        let lifecycle = if recovery_mask & bit != 0 {
+            AssetLifecycleV16::Recovery
+        } else if active_mask & bit != 0 {
+            AssetLifecycleV16::Active
+        } else if drain_only_mask & bit != 0 {
+            AssetLifecycleV16::DrainOnly
+        } else {
+            AssetLifecycleV16::Retired
+        };
+        let dispatchable = kani_auto_crank_lifecycle_dispatchable(lifecycle);
+        assert_eq!(dispatchable, dispatchable_mask & bit != 0);
+        dispatchable_flags[slot] = dispatchable;
+        slot += 1;
+    }
+
+    let selected = kani_first_actionable_slot(dispatchable_flags);
+    let liquidatable = kani_auto_crank_liquidatable(true, true, 1, selected);
+    assert_eq!(liquidatable, dispatchable_mask != 0);
+    let mut recovery_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+    slot = 0;
+    while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+        recovery_flags[slot] = recovery_mask & (1u16 << slot) != 0;
+        slot += 1;
+    }
+    let first_recovery = kani_first_actionable_slot(recovery_flags).unwrap();
+
+    if dispatchable_mask == 0 {
+        assert!(selected.is_none());
+        let plan = kani_select_auto_crank_plan(
+            ActionableSummaryV16 {
+                stale: false,
+                b_stale: false,
+                pending_close: false,
+                expired_close: false,
+                liquidatable,
+                recovery_eligible: false,
+                resolved_winner: false,
+            },
+            0,
+            0,
+            None,
+            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+        );
+        assert_eq!(plan, AutoCrankPlanV16::NoAction);
+    } else {
+        let selected = selected.unwrap();
+        let selected_bit = 1u16 << selected;
+        assert!(dispatchable_mask & selected_bit != 0);
+        assert!(recovery_mask & selected_bit == 0);
+        slot = 0;
+        while slot < selected {
+            assert!(dispatchable_mask & (1u16 << slot) == 0);
+            slot += 1;
+        }
+
+        let refresh = kani_select_auto_crank_plan(
+            ActionableSummaryV16 {
+                stale: true,
+                b_stale: false,
+                pending_close: false,
+                expired_close: false,
+                liquidatable: false,
+                recovery_eligible: false,
+                resolved_winner: false,
+            },
+            0,
+            selected,
+            Some(selected),
+            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+        );
+        assert_eq!(
+            refresh,
+            AutoCrankPlanV16::RefreshAccount {
+                asset_index: Some(selected)
+            }
+        );
+        let liquidate = kani_select_auto_crank_plan(
+            ActionableSummaryV16 {
+                stale: false,
+                b_stale: false,
+                pending_close: false,
+                expired_close: false,
+                liquidatable,
+                recovery_eligible: false,
+                resolved_winner: false,
+            },
+            0,
+            selected,
+            Some(selected),
+            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+        );
+        assert_eq!(
+            liquidate,
+            AutoCrankPlanV16::Liquidate {
+                asset_index: selected
+            }
+        );
+
+        kani::cover!(
+            first_recovery < selected,
+            "Recovery obligation can precede dispatchable work"
+        );
+        kani::cover!(
+            selected < first_recovery,
+            "dispatchable work can precede Recovery obligation"
+        );
+        kani::cover!(
+            active_mask & selected_bit != 0,
+            "Active candidate is selected"
+        );
+        kani::cover!(
+            drain_only_mask & selected_bit != 0,
+            "DrainOnly candidate is selected"
+        );
+    }
+
+    kani::cover!(
+        dispatchable_mask == 0,
+        "Recovery-only account has no fake liquidation target"
+    );
 }

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3153,6 +3153,80 @@ fn v16_auto_crank_drives_stale_underwater_account_to_derisked_fixed_point() {
 }
 
 #[test]
+fn v16_auto_crank_skips_recovery_first_leg_for_live_refresh() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut long_header = account_fixture(2, 14);
+    let mut short_header = account_fixture(2, 15);
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+
+    market.deposit_not_atomic(&mut long, 1_000_000).unwrap();
+    market.deposit_not_atomic(&mut short, 1_000_000).unwrap();
+    for asset_index in [1, 0] {
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index,
+                    size_q: POS_SCALE as i128,
+                    exec_price: 100,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+    }
+    assert_eq!(
+        long.header.legs[0].try_to_runtime().unwrap().asset_index,
+        1,
+        "the Recovery asset must occupy the first active leg"
+    );
+
+    market.force_asset_recovery_not_atomic(1, 3).unwrap();
+    let summary = market.build_actionable_summary(&long.as_view()).unwrap();
+    assert!(
+        summary.stale,
+        "the lifecycle epoch bump must stale the account"
+    );
+
+    let result = market
+        .permissionless_auto_crank_not_atomic(
+            &mut long,
+            AutoCrankWorkV16 {
+                now_slot: 3,
+                observations: &[],
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the auto-crank must select the later live leg");
+    assert_eq!(
+        result.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    );
+    assert!(
+        !market
+            .build_actionable_summary(&long.as_view())
+            .unwrap()
+            .stale,
+        "the selected live refresh must certify the mixed-lifecycle account"
+    );
+    assert_eq!(
+        market.markets[1]
+            .engine
+            .asset
+            .try_to_runtime()
+            .unwrap()
+            .lifecycle,
+        AssetLifecycleV16::Recovery
+    );
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_auto_crank_liquidates_current_account_without_observation() {
     let (mut header, mut markets) = market_fixture(1, 100);
     let mut account_header = account_fixture(1, 14);


### PR DESCRIPTION
## What changed

- Select the first `Active` or `DrainOnly` leg for auto-crank refresh/liquidation instead of the first active portfolio leg regardless of asset lifecycle.
- Require a dispatchable leg before classifying an account liquidatable, so Recovery-only accounts cannot advertise a fake asset-0 continuation.
- Expose `build_auto_crank_plan` so wrappers authenticate the observation for the exact engine-selected continuation without duplicating lifecycle logic.
- Route lifecycle dispatchability and liquidation eligibility through the same small production kernels used by the broad Kani theorem.

## Root cause and impact

`build_actionable_summary` correctly marked a mixed-lifecycle portfolio stale, but the auto-crank selected its first portfolio leg even when that asset was in `Recovery`. Refresh then called `accrue_asset_to_not_atomic`, which rejects Recovery assets with `LockActive`, so the sole permissionless crank could not make the available progress on a later live leg.

A Recovery-only active bitmap could also make the old classifier advertise liquidation and default to asset 0 even though no leg was dispatchable.

This is a public-state partial DoS and a contradiction of the engine's dispatch-reachability claim. It is not classified as total DoS/LoF because the Recovery asset retains its frozen-mark exit and delayed force-close routes.

## Proof-driven validation

The broad theorem `proof_v16_recovery_legs_cannot_starve_dispatchable_auto_crank_work` symbolically covers every ordering and multiplicity of disjoint Recovery, Active, and DrainOnly masks across all 16 portfolio slots. It proves:

- Recovery legs are never ordinary refresh/liquidation targets.
- The first dispatchable Active/DrainOnly leg is selected regardless of Recovery-leg placement.
- Refresh and liquidation plans carry exactly that engine-selected leg.
- Recovery-only portfolios produce no fake liquidation target.
- All five important state classes are reachable.

Result: 200 checks, 5/5 covers, 0.66s.

Mutation sensitivity:

- Treating `Recovery` as dispatchable fails the lifecycle-equivalence assertion.
- Ignoring the dispatchable-leg requirement for liquidation fails the Recovery-only assertion while 4/5 covers remain reachable.

Additional validation:

- `cargo test --all-targets`: 130 passed (50 + 9 + 2 + 69).
- `cargo fmt --all`
- `git diff --check`
- Frozen `spec.md` unchanged.
- Public wrapper LiteSVM TDD: failed with `EngineLockActive` before the fix and passes after it, refreshing the later live leg under the crank CU limit.