### PR TITLE
[REAL DoS] Prevent zero-delta oracle crank pinning

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1312,10 +1312,6 @@ If full B settlement is too large, partial settlement is allowed. While `B_remai
 
 `accrue_asset_to(asset, now_slot, effective_price, funding_rate)` requires Active/DrainOnly live mode, authenticated time, valid price, and bounded funding rate. Domain locks do not block K/F/price/time accrual. Accrual MUST NOT mutate B, A, OI, weights, staged residuals, staged insurance, ADL, pending barriers, pending obligations, or exposure-clear state for a locked domain unless held by the close/recovery path.
 
-For an exposed asset with `raw_oracle_target_price != effective_price`, a positive accrual segment MUST NOT successfully consume elapsed time when the submitted effective price is unchanged. If cap quantization admits no representable price atom, accrual MUST return `NonProgress` before mutation so transaction rollback preserves the elapsed segment for a later target-directed move. Repeated permissionless calls MUST NOT reset `slot_last` while leaving the lagged effective price unchanged.
-
-If the wrapper authenticates and applies the bounded market-accrual stage before calling `permissionless_auto_crank_not_atomic`, it MUST set `observations_preaccrued`. In that mode the engine dispatches the selected current-state account action without applying a second accrual segment. The wrapper MUST set the flag only after successful pre-accrual in the same transaction and MUST propagate every engine error so SVM rollback covers all not-atomic mutations.
-
 Before any accrual/effective-price/K/F write is usable by a favorable action:
 1. affected source-domain claim-bound buckets MUST be recomputed conservatively;
 2. affected backing freshness buckets MUST be applied;
@@ -1654,7 +1650,6 @@ Wrappers MUST expose full refresh, hinted crank, bounded catchup, active close c
 100. `stock_reconciliation_includes_settlement_rounding_residue_total`.
 101. `drift_consumed_partition_category_is_reserved_and_zero` *(v16.9.0)*.
 102. `per_class_stock_reconciliation_matches_o1_ledgers_where_available`.
-103. `lagged_oracle_target_zero_delta_cannot_consume_accrual_segment`.
 -------------------------------------------------------------------------------
 15. Audit summary and intended tradeoff
 -------------------------------------------------------------------------------

--- a/spec.md
+++ b/spec.md
@@ -1314,6 +1314,8 @@ If full B settlement is too large, partial settlement is allowed. While `B_remai
 
 For an exposed asset with `raw_oracle_target_price != effective_price`, a positive accrual segment MUST NOT successfully consume elapsed time when the submitted effective price is unchanged. If cap quantization admits no representable price atom, accrual MUST return `NonProgress` before mutation so transaction rollback preserves the elapsed segment for a later target-directed move. Repeated permissionless calls MUST NOT reset `slot_last` while leaving the lagged effective price unchanged.
 
+If the wrapper authenticates and applies the bounded market-accrual stage before calling `permissionless_auto_crank_not_atomic`, it MUST set `observations_preaccrued`. In that mode the engine dispatches the selected current-state account action without applying a second accrual segment. The wrapper MUST set the flag only after successful pre-accrual in the same transaction and MUST propagate every engine error so SVM rollback covers all not-atomic mutations.
+
 Before any accrual/effective-price/K/F write is usable by a favorable action:
 1. affected source-domain claim-bound buckets MUST be recomputed conservatively;
 2. affected backing freshness buckets MUST be applied;

--- a/spec.md
+++ b/spec.md
@@ -1312,6 +1312,8 @@ If full B settlement is too large, partial settlement is allowed. While `B_remai
 
 `accrue_asset_to(asset, now_slot, effective_price, funding_rate)` requires Active/DrainOnly live mode, authenticated time, valid price, and bounded funding rate. Domain locks do not block K/F/price/time accrual. Accrual MUST NOT mutate B, A, OI, weights, staged residuals, staged insurance, ADL, pending barriers, pending obligations, or exposure-clear state for a locked domain unless held by the close/recovery path.
 
+For an exposed asset with `raw_oracle_target_price != effective_price`, a positive accrual segment MUST NOT successfully consume elapsed time when the submitted effective price is unchanged. If cap quantization admits no representable price atom, accrual MUST return `NonProgress` before mutation so transaction rollback preserves the elapsed segment for a later target-directed move. Repeated permissionless calls MUST NOT reset `slot_last` while leaving the lagged effective price unchanged.
+
 Before any accrual/effective-price/K/F write is usable by a favorable action:
 1. affected source-domain claim-bound buckets MUST be recomputed conservatively;
 2. affected backing freshness buckets MUST be applied;
@@ -1650,6 +1652,7 @@ Wrappers MUST expose full refresh, hinted crank, bounded catchup, active close c
 100. `stock_reconciliation_includes_settlement_rounding_residue_total`.
 101. `drift_consumed_partition_category_is_reserved_and_zero` *(v16.9.0)*.
 102. `per_class_stock_reconciliation_matches_o1_ledgers_where_available`.
+103. `lagged_oracle_target_zero_delta_cannot_consume_accrual_segment`.
 -------------------------------------------------------------------------------
 15. Audit summary and intended tradeoff
 -------------------------------------------------------------------------------

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -11395,6 +11395,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         } else {
             dt_total
         };
+        let exposed = old.oi_eff_long_q != 0 || old.oi_eff_short_q != 0;
+        if segment_dt != 0
+            && exposed
+            && old.raw_oracle_target_price != old.effective_price
+            && effective_price == old.effective_price
+        {
+            // A percentage cap can round below one price atom. Consuming the segment anyway lets
+            // a permissionless caller reset dt every slot and pin a live market away from its
+            // committed oracle target forever. Preserve the elapsed segment until the caller can
+            // submit a representable target-directed price move.
+            return Err(V16Error::NonProgress);
+        }
         let activity = V16Core::accrual_activity_for_asset_segment(
             old,
             segment_dt,

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -4824,6 +4824,9 @@ pub struct AutoCrankObservationV16 {
 pub struct AutoCrankWorkV16<'a> {
     pub now_slot: u64,
     pub observations: &'a [AutoCrankObservationV16],
+    /// The trusted wrapper already authenticated and applied its bounded market-accrual stage in
+    /// this transaction. The selected account action must not accrue a second segment.
+    pub observations_preaccrued: bool,
     pub resolved_close_fee_rate_per_slot: u128,
 }
 
@@ -11528,6 +11531,15 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
         request: PermissionlessCrankRequestV16,
     ) -> V16Result<PermissionlessProgressOutcomeV16> {
+        self.permissionless_crank_impl_not_atomic(account, request, false)
+    }
+
+    fn permissionless_crank_impl_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        request: PermissionlessCrankRequestV16,
+        skip_post_action_accrual: bool,
+    ) -> V16Result<PermissionlessProgressOutcomeV16> {
         self.validate_unconfigured_market_tail()?;
         if decode_market_mode(self.header.mode)? != MarketModeV16::Live
             && !matches!(request.action, PermissionlessCrankActionV16::Recover(_))
@@ -11575,6 +11587,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 return self.declare_permissionless_recovery(reason);
             }
         };
+        if skip_post_action_accrual {
+            self.validate_shape_audit_scan()?;
+            return Ok(PermissionlessProgressOutcomeV16::AccountCurrent);
+        }
         self.accrue_asset_to_not_atomic(
             request.asset_index,
             request.now_slot,
@@ -11730,12 +11746,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     ///    keeper has fresh data for — plus the `resolved_close_fee_rate_per_slot`.
     /// 2. Authenticate clock/slot + each observation against the oracle.
     /// 3. Build `AutoCrankWorkV16 { now_slot, observations,
-    ///    resolved_close_fee_rate_per_slot }` and call this ONCE (one ix = one
-    ///    step; never loop to a fixed point — CU).
+    ///    observations_preaccrued, resolved_close_fee_rate_per_slot }` and call
+    ///    this ONCE (one ix = one step; never loop to a fixed point — CU). Set
+    ///    `observations_preaccrued` only when the wrapper already applied the
+    ///    authenticated bounded market-accrual stage in the same transaction.
     /// 4. The engine classifies the account, selects the highest-priority step AND
     ///    its asset (self-selected — the caller never chooses action or asset),
     ///    matches the observation that step needs, derives the liquidation fee from
-    ///    CONFIG (never the caller), and dispatches one bounded primitive.
+    ///    CONFIG (never the caller), and dispatches one bounded primitive. A
+    ///    pre-accrued call dispatches the account primitive without accruing a
+    ///    second market segment.
     /// 5. On `Ok(result)`, mirror any wrapper-owned token/custody movement keyed off
     ///    `result.selected` (the `AutoCrankPlanV16`): refresh / settle-B move no
     ///    custody; liquidate / close-resolved may. `NoAction` => nothing was needed.
@@ -11789,7 +11809,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                           obs: AutoCrankObservationV16,
                           action: PermissionlessCrankActionV16|
          -> V16Result<PermissionlessProgressOutcomeV16> {
-            me.permissionless_crank_not_atomic(
+            me.permissionless_crank_impl_not_atomic(
                 account,
                 PermissionlessCrankRequestV16 {
                     now_slot: work.now_slot,
@@ -11798,6 +11818,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     funding_rate_e9: obs.funding_rate_e9,
                     action,
                 },
+                work.observations_preaccrued,
             )
         };
 

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -9186,6 +9186,42 @@ fn proof_v16_equity_active_accrual_requires_protective_progress_before_mutation(
 #[kani::proof]
 #[kani::unwind(48)]
 #[kani::solver(cadical)]
+fn proof_v16_lagged_target_zero_delta_cannot_consume_accrual_segment() {
+    let target_delta_raw: u8 = kani::any();
+    kani::assume(target_delta_raw > 0);
+    let (mut header, mut markets, _) = one_market_view_fixture();
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.oi_eff_long_q = POS_SCALE;
+    asset.stored_pos_count_long = 1;
+    asset.raw_oracle_target_price = asset
+        .effective_price
+        .checked_add(target_delta_raw as u64)
+        .unwrap();
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    let header_before = header;
+    let market_before = markets[0];
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let result = market.accrue_asset_to_not_atomic(0, 2, asset.effective_price, 0, true);
+
+    kani::cover!(
+        target_delta_raw > 1,
+        "lagged-target proof covers a nontrivial target distance"
+    );
+    assert_eq!(result, Err(V16Error::NonProgress));
+    assert_eq!(market.header.current_slot, header_before.current_slot);
+    assert_eq!(market.header.slot_last, header_before.slot_last);
+    assert_eq!(market.header.oracle_epoch, header_before.oracle_epoch);
+    assert_eq!(market.header.funding_epoch, header_before.funding_epoch);
+    assert_eq!(market.header.vault, header_before.vault);
+    assert_eq!(market.header.c_tot, header_before.c_tot);
+    assert_eq!(market.header.insurance, header_before.insurance);
+    assert_eq!(market.markets[0].engine.asset, market_before.engine.asset);
+}
+
+#[kani::proof]
+#[kani::unwind(48)]
+#[kani::solver(cadical)]
 fn proof_v16_equity_active_accrual_with_progress_commits_one_bounded_segment() {
     let now_slot_raw: u8 = kani::any();
     let price_delta_raw: u8 = kani::any();

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1318,6 +1318,51 @@ fn v16_public_raw_oracle_target_update_is_value_neutral_and_lifecycle_gated() {
 }
 
 #[test]
+fn v16_lagged_oracle_target_rejects_zero_delta_slot_consumption() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut long_header = account_fixture(1, 221);
+    let mut short_header = account_fixture(1, 222);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market.deposit_not_atomic(&mut long, 1_000).unwrap();
+        market.deposit_not_atomic(&mut short, 1_000).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: signed_q(POS_SCALE),
+                    exec_price: 100,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+        market
+            .set_asset_raw_oracle_target_not_atomic(0, 200)
+            .unwrap();
+    }
+
+    let header_before = header;
+    let slot_before = markets[0];
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let result = market.accrue_asset_to_not_atomic(0, 2, 100, 0, true);
+
+    assert_eq!(result, Err(V16Error::NonProgress));
+    assert_eq!(market.header, &header_before);
+    assert_eq!(market.markets[0], slot_before);
+
+    let progressed = market
+        .accrue_asset_to_not_atomic(0, 2, 101, 0, true)
+        .unwrap();
+    assert_eq!(progressed.dt, 1);
+    assert!(progressed.price_move_active);
+    assert_eq!(market.markets[0].engine.asset.effective_price.get(), 101);
+}
+
+#[test]
 fn v16_public_empty_asset_oracle_anchor_reset_rejects_any_group_position_state() {
     let (mut header, mut markets) = market_fixture(2, 100);
     let mut other_asset = markets[1].engine.asset.try_to_runtime().unwrap();

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3042,6 +3042,7 @@ fn v16_auto_crank_classifies_fresh_account_stale_then_refreshes_to_clean() {
     let work = AutoCrankWorkV16 {
         now_slot: 5,
         observations: &obs,
+        observations_preaccrued: false,
         resolved_close_fee_rate_per_slot: 0,
     };
 
@@ -3073,6 +3074,80 @@ fn v16_auto_crank_classifies_fresh_account_stale_then_refreshes_to_clean() {
 
     market.validate_shape().unwrap();
     account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_auto_crank_preaccrued_observation_does_not_apply_a_second_segment() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut long_header = account_fixture(1, 22);
+    let mut short_header = account_fixture(1, 23);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market.deposit_not_atomic(&mut long, 1_000).unwrap();
+        market.deposit_not_atomic(&mut short, 1_000).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: signed_q(POS_SCALE),
+                    exec_price: 100,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+        market
+            .set_asset_raw_oracle_target_not_atomic(0, 300)
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(0, 2, 200, 0, true)
+            .unwrap();
+    }
+
+    let asset_before = markets[0].engine.asset;
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let obs = [AutoCrankObservationV16 {
+        asset_index: 0,
+        effective_price: 200,
+        funding_rate_e9: 0,
+    }];
+    let result = market
+        .permissionless_auto_crank_not_atomic(
+            &mut long,
+            AutoCrankWorkV16 {
+                now_slot: 2,
+                observations: &obs,
+                observations_preaccrued: true,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .unwrap();
+
+    assert!(matches!(
+        result.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    ));
+    assert_eq!(
+        result.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+    );
+    assert_eq!(
+        market.markets[0].engine.asset, asset_before,
+        "pre-accrued auto-crank dispatches the account action without consuming another segment"
+    );
+    assert!(
+        !market
+            .build_actionable_summary(&long.as_view())
+            .unwrap()
+            .stale,
+        "the selected refresh still makes the account certificate current"
+    );
 }
 
 // ROADMAP 3C step 4 / NB2 finite-multi-step liveness via the self-classifying
@@ -3142,6 +3217,7 @@ fn v16_auto_crank_drives_stale_underwater_account_to_derisked_fixed_point() {
     let work = AutoCrankWorkV16 {
         now_slot: 10,
         observations: &obs,
+        observations_preaccrued: false,
         resolved_close_fee_rate_per_slot: 0,
     };
 
@@ -3252,6 +3328,7 @@ fn v16_auto_crank_liquidates_current_account_without_observation() {
     let work = AutoCrankWorkV16 {
         now_slot: 10,
         observations: &[],
+        observations_preaccrued: false,
         resolved_close_fee_rate_per_slot: 0,
     };
     let result = market
@@ -3326,6 +3403,7 @@ fn v16_auto_crank_declares_recovery_for_expired_live_close() {
     let work = AutoCrankWorkV16 {
         now_slot: 10,
         observations: &[],
+        observations_preaccrued: false,
         resolved_close_fee_rate_per_slot: 0,
     };
     let vault_before = market.header.vault;
@@ -3439,6 +3517,7 @@ fn v16_auto_crank_settles_b_stale_leg() {
     let work = AutoCrankWorkV16 {
         now_slot: 10,
         observations: &[],
+        observations_preaccrued: false,
         resolved_close_fee_rate_per_slot: 0,
     };
     let r = market
@@ -3483,6 +3562,7 @@ fn v16_auto_crank_missing_observation_is_clean_nonprogress_no_mutation() {
     let work = AutoCrankWorkV16 {
         now_slot: 5,
         observations: &[],
+        observations_preaccrued: false,
         resolved_close_fee_rate_per_slot: 0,
     };
     let r = market.permissionless_auto_crank_not_atomic(&mut account, work);
@@ -3533,6 +3613,7 @@ fn assert_observation_independent(
             AutoCrankWorkV16 {
                 now_slot,
                 observations,
+                observations_preaccrued: false,
                 resolved_close_fee_rate_per_slot: 0,
             },
         )


### PR DESCRIPTION
## Impact

A permissionless caller can indefinitely pin an exposed market away from its committed oracle target when the per-slot percentage cap rounds below one price atom.

For example, at price 100 with a 24 bps/slot cap, the public caller cranks every slot. Each call previously succeeded and advanced `slot_last`, but integer truncation left `effective_price` at 100. Repeating the call erased elapsed time forever, preventing the honest five-slot interval needed to move one atom toward target 200. This can freeze price-dependent PnL, liquidation, and funding progress on a live initialized market.

## Fix

When an asset is exposed, has a lagged raw oracle target, and a positive accrual segment proposes no effective-price change, return `NonProgress` before any mutation. SVM rollback then preserves `slot_last`, so elapsed time accumulates until the target-directed clamp admits a representable move.

The wrapper already applies its authenticated bounded market-accrual stage before invoking auto-crank. `AutoCrankWorkV16::observations_preaccrued` now records that trusted same-transaction fact, allowing auto-crank to dispatch the selected account refresh/liquidation without applying a second market segment. This preserves one-call account progress while ensuring each observation consumes at most one accrual segment.

The frozen `spec.md` remains unchanged. The engine accepts the pre-accrual flag only as an explicit wrapper contract: the wrapper must set it after successful authenticated pre-accrual in the same transaction and propagate every later engine error to the instruction boundary so SVM rollback covers all not-atomic mutations.

## Coverage

- Engine regression builds real OI through deposit and trade, then proves a zero-delta segment rejects byte-stably and a representable move succeeds.
- Auto-crank regression proves a pre-accrued observation refreshes the selected account while leaving the engine asset byte-identical, including when target lag remains.
- Kani proves the zero-delta lagged-target path returns `NonProgress` while preserving all relevant market and asset state.
- Public-interface LiteSVM TDD coverage and wrapper integration are in [percolator-prog#246](https://github.com/aeyakovenko/percolator-prog/pull/246), pinned to `a8b8877e784e34fbef7bfd16ce7228130219904b`.

The previous liveness model treated `slot_last` advancement as progress. It did not include target-distance progress or the integer-quantization branch, so the successful zero-delta transition satisfied the modeled rank while making the real oracle route permanently attacker-resettable.

## Verification

- `cargo test --all-targets`
- `cargo test --test v16_spec_tests v16_lagged_oracle_target_rejects_zero_delta_slot_consumption`
- `cargo kani --tests --features fuzz --harness proof_v16_lagged_target_zero_delta_cannot_consume_accrual_segment`
- `cargo fmt --all`
- `git diff --check`
