### PR TITLE
Preserve accrual slots without observations

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1316,8 +1316,6 @@ For an exposed asset with `raw_oracle_target_price != effective_price`, a positi
 
 If the wrapper authenticates and applies the bounded market-accrual stage before calling `permissionless_auto_crank_not_atomic`, it MUST set `observations_preaccrued`. In that mode the engine dispatches the selected current-state account action without applying a second accrual segment. The wrapper MUST set the flag only after successful pre-accrual in the same transaction and MUST propagate every engine error so SVM rollback covers all not-atomic mutations.
 
-When the selected account action is realizable from committed state but its matching observation is absent, auto-crank MAY dispatch that account action but MUST NOT advance the selected asset's accrual segment. A synthesized committed price is sufficient for account refresh or liquidation bookkeeping; it is not an authenticated observation and cannot consume elapsed market time.
-
 Before any accrual/effective-price/K/F write is usable by a favorable action:
 1. affected source-domain claim-bound buckets MUST be recomputed conservatively;
 2. affected backing freshness buckets MUST be applied;

--- a/spec.md
+++ b/spec.md
@@ -1312,10 +1312,6 @@ If full B settlement is too large, partial settlement is allowed. While `B_remai
 
 `accrue_asset_to(asset, now_slot, effective_price, funding_rate)` requires Active/DrainOnly live mode, authenticated time, valid price, and bounded funding rate. Domain locks do not block K/F/price/time accrual. Accrual MUST NOT mutate B, A, OI, weights, staged residuals, staged insurance, ADL, pending barriers, pending obligations, or exposure-clear state for a locked domain unless held by the close/recovery path.
 
-For an exposed asset with `raw_oracle_target_price != effective_price`, a positive accrual segment MUST NOT successfully consume elapsed time when the submitted effective price is unchanged. If cap quantization admits no representable price atom, accrual MUST return `NonProgress` before mutation so transaction rollback preserves the elapsed segment for a later target-directed move. Repeated permissionless calls MUST NOT reset `slot_last` while leaving the lagged effective price unchanged.
-
-If the wrapper authenticates and applies the bounded market-accrual stage before calling `permissionless_auto_crank_not_atomic`, it MUST set `observations_preaccrued`. In that mode the engine dispatches the selected current-state account action without applying a second accrual segment. The wrapper MUST set the flag only after successful pre-accrual in the same transaction and MUST propagate every engine error so SVM rollback covers all not-atomic mutations.
-
 Before any accrual/effective-price/K/F write is usable by a favorable action:
 1. affected source-domain claim-bound buckets MUST be recomputed conservatively;
 2. affected backing freshness buckets MUST be applied;
@@ -1654,7 +1650,6 @@ Wrappers MUST expose full refresh, hinted crank, bounded catchup, active close c
 100. `stock_reconciliation_includes_settlement_rounding_residue_total`.
 101. `drift_consumed_partition_category_is_reserved_and_zero` *(v16.9.0)*.
 102. `per_class_stock_reconciliation_matches_o1_ledgers_where_available`.
-103. `lagged_oracle_target_zero_delta_cannot_consume_accrual_segment`.
 -------------------------------------------------------------------------------
 15. Audit summary and intended tradeoff
 -------------------------------------------------------------------------------

--- a/spec.md
+++ b/spec.md
@@ -1316,6 +1316,8 @@ For an exposed asset with `raw_oracle_target_price != effective_price`, a positi
 
 If the wrapper authenticates and applies the bounded market-accrual stage before calling `permissionless_auto_crank_not_atomic`, it MUST set `observations_preaccrued`. In that mode the engine dispatches the selected current-state account action without applying a second accrual segment. The wrapper MUST set the flag only after successful pre-accrual in the same transaction and MUST propagate every engine error so SVM rollback covers all not-atomic mutations.
 
+When the selected account action is realizable from committed state but its matching observation is absent, auto-crank MAY dispatch that account action but MUST NOT advance the selected asset's accrual segment. A synthesized committed price is sufficient for account refresh or liquidation bookkeeping; it is not an authenticated observation and cannot consume elapsed market time.
+
 Before any accrual/effective-price/K/F write is usable by a favorable action:
 1. affected source-domain claim-bound buckets MUST be recomputed conservatively;
 2. affected backing freshness buckets MUST be applied;

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -11755,7 +11755,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     ///    matches the observation that step needs, derives the liquidation fee from
     ///    CONFIG (never the caller), and dispatches one bounded primitive. A
     ///    pre-accrued call dispatches the account primitive without accruing a
-    ///    second market segment.
+    ///    second market segment. When the matching observation is absent, a step
+    ///    realizable from committed state may still update the account but cannot
+    ///    advance the selected asset's accrual segment.
     /// 5. On `Ok(result)`, mirror any wrapper-owned token/custody movement keyed off
     ///    `result.selected` (the `AutoCrankPlanV16`): refresh / settle-B move no
     ///    custody; liquidate / close-resolved may. `NoAction` => nothing was needed.
@@ -11785,28 +11787,33 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             recovery_reason,
         );
 
-        let obs_or_current_asset = |me: &Self, i: usize| -> V16Result<AutoCrankObservationV16> {
-            match work
-                .observations
-                .iter()
-                .copied()
-                .find(|o| o.asset_index == i)
-            {
-                Some(obs) => Ok(obs),
-                None => {
-                    let asset = me.asset_state(i)?;
-                    Ok(AutoCrankObservationV16 {
-                        asset_index: i,
-                        effective_price: asset.effective_price,
-                        funding_rate_e9: 0,
-                    })
+        let obs_or_current_asset =
+            |me: &Self, i: usize| -> V16Result<(AutoCrankObservationV16, bool)> {
+                match work
+                    .observations
+                    .iter()
+                    .copied()
+                    .find(|o| o.asset_index == i)
+                {
+                    Some(obs) => Ok((obs, true)),
+                    None => {
+                        let asset = me.asset_state(i)?;
+                        Ok((
+                            AutoCrankObservationV16 {
+                                asset_index: i,
+                                effective_price: asset.effective_price,
+                                funding_rate_e9: 0,
+                            },
+                            false,
+                        ))
+                    }
                 }
-            }
-        };
+            };
         let crank_with = |me: &mut Self,
                           account: &mut PortfolioV16ViewMut<'_>,
                           asset_index: usize,
                           obs: AutoCrankObservationV16,
+                          observation_supplied: bool,
                           action: PermissionlessCrankActionV16|
          -> V16Result<PermissionlessProgressOutcomeV16> {
             me.permissionless_crank_impl_not_atomic(
@@ -11818,25 +11825,28 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     funding_rate_e9: obs.funding_rate_e9,
                     action,
                 },
-                work.observations_preaccrued,
+                work.observations_preaccrued || !observation_supplied,
             )
         };
 
         let outcome = match plan {
             AutoCrankPlanV16::NoAction => AutoCrankOutcomeV16::NoAction,
             AutoCrankPlanV16::RefreshAccount { asset_index } => {
-                // Accrue the engine-selected active asset from either a fresh
-                // observation or committed state; if no active asset exists, use
-                // the first supplied observation to give the refresh a price.
-                let (ai, obs) = match asset_index {
-                    Some(i) => (i, obs_or_current_asset(self, i)?),
+                // A committed-state fallback can refresh the account, but only a
+                // supplied observation authorizes advancing the asset's accrual
+                // segment. If no active asset exists, an observation is required.
+                let (ai, obs, observation_supplied) = match asset_index {
+                    Some(i) => {
+                        let (obs, supplied) = obs_or_current_asset(self, i)?;
+                        (i, obs, supplied)
+                    }
                     None => {
                         let o = work
                             .observations
                             .first()
                             .copied()
                             .ok_or(V16Error::NonProgress)?;
-                        (o.asset_index, o)
+                        (o.asset_index, o, true)
                     }
                 };
                 AutoCrankOutcomeV16::Progressed(crank_with(
@@ -11844,26 +11854,29 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     account,
                     ai,
                     obs,
+                    observation_supplied,
                     PermissionlessCrankActionV16::Refresh,
                 )?)
             }
             AutoCrankPlanV16::SettleBChunk { asset_index } => {
-                let obs = obs_or_current_asset(self, asset_index)?;
+                let (obs, observation_supplied) = obs_or_current_asset(self, asset_index)?;
                 AutoCrankOutcomeV16::Progressed(crank_with(
                     self,
                     account,
                     asset_index,
                     obs,
+                    observation_supplied,
                     PermissionlessCrankActionV16::SettleB { asset_index },
                 )?)
             }
             AutoCrankPlanV16::Liquidate { asset_index } => {
-                let obs = obs_or_current_asset(self, asset_index)?;
+                let (obs, observation_supplied) = obs_or_current_asset(self, asset_index)?;
                 AutoCrankOutcomeV16::Progressed(crank_with(
                     self,
                     account,
                     asset_index,
                     obs,
+                    observation_supplied,
                     PermissionlessCrankActionV16::Liquidate(LiquidationRequestV16 { asset_index }),
                 )?)
             }

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -4830,6 +4830,14 @@ pub struct AutoCrankWorkV16<'a> {
     pub resolved_close_fee_rate_per_slot: u128,
 }
 
+#[inline(always)]
+const fn auto_crank_skip_post_action_accrual(
+    observations_preaccrued: bool,
+    selected_observation_supplied: bool,
+) -> bool {
+    observations_preaccrued || !selected_observation_supplied
+}
+
 /// The bounded progress step the engine SELECTED from current state (engine.md).
 /// The asset/leg is chosen by the engine, not the caller. One auto-crank call
 /// dispatches exactly one of these.
@@ -11825,7 +11833,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     funding_rate_e9: obs.funding_rate_e9,
                     action,
                 },
-                work.observations_preaccrued || !observation_supplied,
+                auto_crank_skip_post_action_accrual(
+                    work.observations_preaccrued,
+                    observation_supplied,
+                ),
             )
         };
 

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -9,6 +9,13 @@
 use super::*;
 use crate::wide_math::U256;
 
+pub fn kani_auto_crank_skip_post_action_accrual(
+    observations_preaccrued: bool,
+    selected_observation_supplied: bool,
+) -> bool {
+    auto_crank_skip_post_action_accrual(observations_preaccrued, selected_observation_supplied)
+}
+
 pub fn kani_apply_backing_utilization_fee_charge(
     account_capital: u128,
     group_c_tot: u128,
@@ -1944,5 +1951,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         request: PermissionlessCrankRequestV16,
     ) -> V16Result<PermissionlessProgressOutcomeV16> {
         self.permissionless_crank_not_atomic(account, request)
+    }
+
+    pub fn kani_permissionless_crank_with_skip_post_action_accrual(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        request: PermissionlessCrankRequestV16,
+        skip_post_action_accrual: bool,
+    ) -> V16Result<PermissionlessProgressOutcomeV16> {
+        self.permissionless_crank_impl_not_atomic(account, request, skip_post_action_accrual)
     }
 }

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -5,7 +5,7 @@ use percolator::v16::{
     backing_domain_fee_split_for_lien_delta_num, kani_active_bitmap_set as active_bitmap_set,
     kani_add_open_interest_for_new_position, kani_apply_backing_provider_earnings_withdraw,
     kani_apply_backing_utilization_fee_charge, kani_apply_resolved_payout_receipt_payment,
-    kani_available_backing_num_for_source_credit_state,
+    kani_auto_crank_skip_post_action_accrual, kani_available_backing_num_for_source_credit_state,
     kani_backing_utilization_fee_quote_atoms_for_lien,
     kani_backing_utilization_rate_e9_for_source_state, kani_cert_is_current,
     kani_expected_source_credit_rate_num_for_state, kani_health_cert_after_capital_debit,
@@ -15318,6 +15318,138 @@ fn proof_v16_auto_crank_refresh_is_unique_observation_requiring_plan() {
     }));
 }
 
+#[kani::proof]
+fn proof_v16_auto_crank_accrual_requires_selected_observation_and_no_preaccrual() {
+    let observations_preaccrued: bool = kani::any();
+    let selected_observation_supplied: bool = kani::any();
+    let skip = kani_auto_crank_skip_post_action_accrual(
+        observations_preaccrued,
+        selected_observation_supplied,
+    );
+
+    kani::cover!(
+        !observations_preaccrued && !selected_observation_supplied && skip,
+        "committed-price fallback cannot authorize accrual"
+    );
+    kani::cover!(
+        !observations_preaccrued && selected_observation_supplied && !skip,
+        "fresh selected observation authorizes one accrual segment"
+    );
+    kani::cover!(
+        observations_preaccrued && selected_observation_supplied && skip,
+        "pre-accrued selected observation cannot apply a second segment"
+    );
+    kani::cover!(
+        observations_preaccrued && !selected_observation_supplied && skip,
+        "pre-accrued work remains single-segment when the observation list is consumed"
+    );
+    assert_eq!(
+        !skip,
+        selected_observation_supplied && !observations_preaccrued
+    );
+}
+
+fn assert_v16_crank_observation_authorization<const OBSERVATION_SUPPLIED: bool>(
+    long_segment: bool,
+) {
+    let now_slot = if long_segment { 4 } else { 2 };
+    let (mut header, mut markets, mut account_header) = one_market_view_fixture();
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        market
+            .set_asset_raw_oracle_target_not_atomic(0, 101)
+            .unwrap();
+    }
+    let slot_before = markets[0].engine;
+    let slot_last_before = slot_before.asset.slot_last.get();
+    let max_accrual_dt_slots = header.config.max_accrual_dt_slots.get();
+    let vault_before = header.vault;
+    let c_tot_before = header.c_tot;
+    let insurance_before = header.insurance;
+    assert!(!account_header.health_cert.try_to_runtime().unwrap().valid);
+
+    let skip_post_action_accrual =
+        kani_auto_crank_skip_post_action_accrual(false, OBSERVATION_SUPPLIED);
+    let effective_price = if OBSERVATION_SUPPLIED {
+        101
+    } else {
+        slot_before.asset.effective_price.get()
+    };
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let outcome = market.kani_permissionless_crank_with_skip_post_action_accrual(
+        &mut account,
+        PermissionlessCrankRequestV16 {
+            now_slot,
+            asset_index: 0,
+            effective_price,
+            funding_rate_e9: 0,
+            action: PermissionlessCrankActionV16::Refresh,
+        },
+        skip_post_action_accrual,
+    );
+
+    assert_eq!(
+        outcome,
+        Ok(PermissionlessProgressOutcomeV16::AccountCurrent)
+    );
+    assert!(account.header.health_cert.try_to_runtime().unwrap().valid);
+    assert_eq!(market.header.vault, vault_before);
+    assert_eq!(market.header.c_tot, c_tot_before);
+    assert_eq!(market.header.insurance, insurance_before);
+    if OBSERVATION_SUPPLIED {
+        let asset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+        let expected_dt = (now_slot - slot_last_before).min(max_accrual_dt_slots);
+        assert!(expected_dt > 0);
+        assert_eq!(asset.slot_last, slot_last_before + expected_dt);
+        assert_eq!(
+            market.header.loss_stale_active != 0,
+            asset.slot_last < now_slot
+        );
+        assert_eq!(asset.effective_price, 101);
+        assert!(!kani_eq_engine_asset_slot_v16_account(
+            &slot_before,
+            &market.markets[0].engine
+        ));
+    } else {
+        assert!(kani_eq_engine_asset_slot_v16_account(
+            &slot_before,
+            &market.markets[0].engine
+        ));
+    }
+}
+
+#[kani::proof]
+#[kani::unwind(64)]
+#[kani::solver(cadical)]
+fn proof_v16_observation_free_crank_preserves_asset_while_account_progresses() {
+    let long_segment: bool = kani::any();
+    kani::cover!(
+        !long_segment,
+        "short elapsed segment cannot be consumed by committed-price fallback"
+    );
+    kani::cover!(
+        long_segment,
+        "long elapsed segment cannot be consumed by committed-price fallback"
+    );
+    assert_v16_crank_observation_authorization::<false>(long_segment);
+}
+
+#[kani::proof]
+#[kani::unwind(64)]
+#[kani::solver(cadical)]
+fn proof_v16_observed_crank_accrues_asset_while_preserving_value() {
+    let long_segment: bool = kani::any();
+    kani::cover!(
+        !long_segment,
+        "short elapsed segment accrues with a selected observation"
+    );
+    kani::cover!(
+        long_segment,
+        "long elapsed segment accrues with a selected observation"
+    );
+    assert_v16_crank_observation_authorization::<true>(long_segment);
+}
 // LoF — no free open interest: a risk-increasing fill with nonzero size, nonzero
 // price, and nonzero fee_bps must charge a STRICTLY POSITIVE fee per side. The
 // pre-fix code derived the fee from trade_notional_floor, which rounds sub-atom

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3150,6 +3150,73 @@ fn v16_auto_crank_preaccrued_observation_does_not_apply_a_second_segment() {
     );
 }
 
+#[test]
+fn v16_auto_crank_missing_selected_observation_refreshes_without_accruing_asset() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut account_header = account_fixture(2, 24);
+    let mut counterparty_header = account_fixture(2, 25);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut account_header);
+        let mut counterparty = PortfolioV16ViewMut::new(&mut counterparty_header);
+        open_one_lot_pair(&mut market, &mut account, &mut counterparty);
+        market
+            .full_account_refresh_not_atomic(&mut account)
+            .unwrap();
+
+        // Move an unrelated asset to stale the account certificate. The selected
+        // asset remains asset 0, for which this crank carries no observation.
+        market
+            .set_asset_raw_oracle_target_not_atomic(1, 200)
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(1, 2, 200, 0, false)
+            .unwrap();
+        assert!(
+            market
+                .build_actionable_summary(&account.as_view())
+                .unwrap()
+                .stale
+        );
+    }
+
+    let selected_asset_before = markets[0].engine.asset;
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let result = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 2,
+                observations: &[],
+                observations_preaccrued: false,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("committed-state refresh must remain permissionless");
+
+    assert_eq!(
+        result.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    );
+    assert_eq!(
+        result.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+    );
+    assert_eq!(
+        market.markets[0].engine.asset, selected_asset_before,
+        "an absent observation may refresh the account but must not consume the asset's accrual slot"
+    );
+    assert!(
+        !market
+            .build_actionable_summary(&account.as_view())
+            .unwrap()
+            .stale
+    );
+}
+
 // ROADMAP 3C step 4 / NB2 finite-multi-step liveness via the self-classifying
 // crank: an uncertified, underwater account must be driven to a de-risked fixed
 // point by repeated auto-cranks — the classifier ESCALATES (stale -> refresh,
@@ -3326,7 +3393,7 @@ fn v16_auto_crank_liquidates_current_account_without_observation() {
     );
 
     let work = AutoCrankWorkV16 {
-        now_slot: 10,
+        now_slot: 12,
         observations: &[],
         observations_preaccrued: false,
         resolved_close_fee_rate_per_slot: 0,
@@ -3347,6 +3414,16 @@ fn v16_auto_crank_liquidates_current_account_without_observation() {
         account.header.active_bitmap[0].get(),
         0,
         "liquidation must close the selected position"
+    );
+    assert_eq!(
+        market.markets[0]
+            .engine
+            .asset
+            .try_to_runtime()
+            .unwrap()
+            .slot_last,
+        10,
+        "observation-free liquidation must not consume a later market-accrual slot"
     );
     market.validate_shape().unwrap();
     account.validate_with_market(&market.as_view()).unwrap();
@@ -3573,11 +3650,12 @@ fn v16_auto_crank_missing_observation_is_clean_nonprogress_no_mutation() {
 }
 
 // REALIZABILITY MATRIX — closes the no-DoS dispatch seam that hid the b-stale /
-// committed-state-liquidation stall. The faithful invariant is OBSERVATION-
-// INDEPENDENCE: for a plan that `auto_crank_plan_requires_caller_observation`
-// reports as NOT requiring one, the single public crank must return the SAME
-// outcome whether or not an observation is supplied (the observation is redundant
-// — the plan is realizable from committed state). For the one form that DOES
+// committed-state-liquidation stall. For a plan that
+// `auto_crank_plan_requires_caller_observation` reports as NOT requiring one, the
+// single public crank must select and complete the SAME account action whether or
+// not an observation is supplied. A supplied observation may additionally
+// authorize market accrual, so full post-state equality is intentionally not the
+// invariant. For the one form that DOES
 // require one (RefreshAccount with no active asset), the empty-observation call
 // cleanly stalls (NonProgress) while supplying the observation progresses. This
 // both guards liveness AND ties the pure predicate to the REAL dispatch per class,
@@ -3585,7 +3663,7 @@ fn v16_auto_crank_missing_observation_is_clean_nonprogress_no_mutation() {
 // still return a genuine economic terminal (e.g. RecoveryRequired) — that is fine,
 // because it returns the SAME terminal with or without the observation; the bug
 // was an outcome that DIFFERED on the observation.
-fn assert_observation_independent(
+fn assert_account_action_realizable_without_observation(
     label: &str,
     build: impl Fn() -> (
         MarketGroupV16HeaderAccount,
@@ -3669,7 +3747,7 @@ fn assert_observation_independent(
 fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
     // --- A1 stale with no active asset: fallback refresh has no committed asset
     // to use, so it still needs a caller observation.
-    assert_observation_independent(
+    assert_account_action_realizable_without_observation(
         "stale_empty_account",
         || {
             let (mut header, mut markets) = market_fixture(1, 100);
@@ -3690,7 +3768,7 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
     // --- A1 stale with an active asset: refresh is realizable from committed
     // state. This is the no-DoS case for stale multi-asset accounts whose first
     // active asset does not have a fresh oracle observation available.
-    assert_observation_independent(
+    assert_account_action_realizable_without_observation(
         "stale_active_asset",
         || {
             let (mut header, mut markets) = market_fixture(1, 100);
@@ -3717,7 +3795,7 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
     );
 
     // --- A2 b_stale: SettleBChunk ignores price -> observation REDUNDANT.
-    assert_observation_independent(
+    assert_account_action_realizable_without_observation(
         "b_stale",
         || {
             let (mut header, mut markets) = market_fixture(1, 100);
@@ -3760,7 +3838,7 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
     );
 
     // --- A5 liquidatable: Liquidate reads the current cert -> observation REDUNDANT.
-    assert_observation_independent(
+    assert_account_action_realizable_without_observation(
         "liquidatable",
         || {
             let (mut header, mut markets) = market_fixture(1, 100);
@@ -3815,7 +3893,7 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
     );
 
     // --- A4 expired_close: DeclareRecovery needs no price -> observation REDUNDANT.
-    assert_observation_independent(
+    assert_account_action_realizable_without_observation(
         "expired_close",
         || {
             use percolator::{CloseProgressLedgerV16, CloseProgressLedgerV16Account};
@@ -3857,7 +3935,7 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
     // --- A7 resolved_winner: CloseResolved needs no price -> observation REDUNDANT.
     // (Previously only its CLASSIFICATION was tested; the empty-observation DISPATCH
     // — including a legitimate RecoveryRequired terminal — was uncovered.)
-    assert_observation_independent(
+    assert_account_action_realizable_without_observation(
         "resolved_winner",
         || {
             let (mut header, mut markets) = market_fixture(1, 100);


### PR DESCRIPTION
## Bug

A permissionless auto-crank with no selected-asset observation could use the committed price for the account action and also advance that asset's positive-time accrual slot. A stale crank landing before the legitimate Hybrid observation could therefore consume the slot and suppress that observation; repeated permissionless landing-order races could pin Hybrid oracle progress.

The public wrapper LiteSVM reproduction uses only initialized markets/accounts and public instructions; it does not mutate protocol state out of band.

## Fix

- Preserve account-action progress using the committed price when the selected observation is absent.
- Authorize post-action market accrual iff the selected observation was supplied and the wrapper did not already pre-accrue it.
- Keep supplied-observation bounded accrual behavior unchanged.
- Leave the frozen `spec.md` unchanged.

## Proof-driven evidence

The native public-entrypoint TDD witnesses exercise stale-account refresh and liquidation. Before the fix, each omitted-observation call advanced the selected asset slot; after the fix, the account action progresses while the complete selected asset state remains unchanged.

The added Kani coverage is over production policy and the real production crank/accrual transition, not a modeled implementation clone:

- `proof_v16_auto_crank_accrual_requires_selected_observation_and_no_preaccrual` exhausts all four observation/pre-accrual states and proves the authorization biconditional. Result: 1 check, 4/4 covers, 0.026s.
- `proof_v16_observation_free_crank_preserves_asset_while_account_progresses` runs production refresh/certification/crank validation over both one-slot and multi-slot backlogs. It proves account progress, exact byte-for-byte asset-slot preservation, and unchanged vault/capital/insurance stocks. Result: 13,526 checks, 2/2 covers, 208.76s.
- `proof_v16_observed_crank_accrues_asset_while_preserving_value` proves the dual: a supplied observation consumes exactly one configured bounded segment, updates the effective price, reports remaining backlog correctly, and preserves value stocks. Result: 13,526 checks, 2/2 covers, 288.18s.

Mutation sensitivity:

- Restoring the original policy (missing observation authorizes post-action accrual) falsifies the broad omission theorem after 13,526 checks with both covers reached; the selected asset slot changes. Verification: failed as expected in 264.08s.
- Restoring the original policy and, separately, forcing all post-action accrual to skip each falsifies the four-state authorization theorem in about 0.03s.
- All mutations were restored before the clean runs and commit.

## Validation

- `cargo test --all-targets`: 132 passed, 0 failed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
- All added Kani harnesses terminate within 300 seconds.

Stacked on the pre-accrual API in the parent branch.