### PR TITLE
[REAL LoF] Prevent ADL basis reissue across split trades

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1342,6 +1342,8 @@ If `W == 0`, residual clears only by reserved insurance or explicit protocol-own
 
 Quantity ADL applies exactly once after residual durability and is atomic with closing exposure clear/finalization or protected by a non-preemptible finalization barrier.
 
+After quantity ADL, each side's subsequent K and F index increments MUST be scaled by that side's current `A_side`; aggregate price and funding settlement across matched effective OI remains zero-sum. While either side has `A_side != ADL_ONE`, trades may reduce matched risk but MUST NOT attach, flip, or enlarge a leg. This prevents a fresh `a_basis` from reissuing quantity already removed by ADL while preserving bilateral exit progress.
+
 `begin_full_drain_reset(asset, side)` requires zero OI, no close/pending barrier, no pending obligations, no liens, and side not already `ResetPending`.
 
 -------------------------------------------------------------------------------

--- a/spec.md
+++ b/spec.md
@@ -1342,8 +1342,6 @@ If `W == 0`, residual clears only by reserved insurance or explicit protocol-own
 
 Quantity ADL applies exactly once after residual durability and is atomic with closing exposure clear/finalization or protected by a non-preemptible finalization barrier.
 
-After quantity ADL, each side's subsequent K and F index increments MUST be scaled by that side's current `A_side`; aggregate price and funding settlement across matched effective OI remains zero-sum. While either side has `A_side != ADL_ONE`, trades may reduce matched risk but MUST NOT attach, flip, or enlarge a leg. This prevents a fresh `a_basis` from reissuing quantity already removed by ADL while preserving bilateral exit progress.
-
 `begin_full_drain_reset(asset, side)` requires zero OI, no close/pending barrier, no pending obligations, no liens, and side not already `ResetPending`.
 
 -------------------------------------------------------------------------------

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -764,6 +764,26 @@ impl V16Core {
     }
 
     #[inline]
+    pub(crate) fn kernel_adl_scaled_accrual_index_deltas(
+        price_delta: i128,
+        funding_index_delta: i128,
+        a_long: u128,
+        a_short: u128,
+    ) -> V16Result<(i128, i128, i128, i128)> {
+        let a_long = i128::try_from(a_long).map_err(|_| V16Error::ArithmeticOverflow)?;
+        let a_short = i128::try_from(a_short).map_err(|_| V16Error::ArithmeticOverflow)?;
+        let k_long = checked_i128_mul(price_delta, a_long)?;
+        let k_short = checked_i128_mul(price_delta, a_short)?
+            .checked_neg()
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        let f_long = checked_i128_mul(funding_index_delta, a_long)?
+            .checked_neg()
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        let f_short = checked_i128_mul(funding_index_delta, a_short)?;
+        Ok((k_long, k_short, f_long, f_short))
+    }
+
+    #[inline]
     fn liquidation_progress_from_scores(before: RiskScoreV16, after: RiskScoreV16) -> bool {
         after.strictly_reduces_from(before)
             || after.certified_liq_deficit < before.certified_liq_deficit
@@ -1394,6 +1414,19 @@ impl V16Core {
             PositionRouteV16::Flip
         } else {
             PositionRouteV16::Resize
+        }
+    }
+
+    #[inline]
+    pub(crate) fn kernel_position_route_requires_unit_adl(
+        route: PositionRouteV16,
+        current: i128,
+        new: i128,
+    ) -> bool {
+        match route {
+            PositionRouteV16::Attach | PositionRouteV16::Flip => true,
+            PositionRouteV16::Clear => false,
+            PositionRouteV16::Resize => new.unsigned_abs() > current.unsigned_abs(),
         }
     }
 
@@ -11422,10 +11455,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
 
         let price_delta = effective_price as i128 - old.effective_price as i128;
-        let a_long = i128::try_from(old.a_long).map_err(|_| V16Error::ArithmeticOverflow)?;
-        let a_short = i128::try_from(old.a_short).map_err(|_| V16Error::ArithmeticOverflow)?;
-        let k_delta_long = checked_i128_mul(price_delta, a_long)?;
-        let k_delta_short = checked_i128_mul(price_delta, a_short)?;
         let funding_index_delta = if activity.funding_active {
             let n = funding_rate_e9
                 .checked_mul(segment_dt as i128)
@@ -11435,23 +11464,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         } else {
             0
         };
-        let funding_delta_long = checked_i128_mul(funding_index_delta, a_long)?;
-        let funding_delta_short = checked_i128_mul(funding_index_delta, a_short)?;
+        let (k_delta_long, k_delta_short, funding_delta_long, funding_delta_short) =
+            V16Core::kernel_adl_scaled_accrual_index_deltas(
+                price_delta,
+                funding_index_delta,
+                old.a_long,
+                old.a_short,
+            )?;
 
         let mut asset = old;
         asset.k_long = add_non_min_i128(asset.k_long, k_delta_long)?;
-        asset.k_short = add_non_min_i128(
-            asset.k_short,
-            k_delta_short
-                .checked_neg()
-                .ok_or(V16Error::ArithmeticOverflow)?,
-        )?;
-        asset.f_long_num = add_non_min_i128(
-            asset.f_long_num,
-            funding_delta_long
-                .checked_neg()
-                .ok_or(V16Error::ArithmeticOverflow)?,
-        )?;
+        asset.k_short = add_non_min_i128(asset.k_short, k_delta_short)?;
+        asset.f_long_num = add_non_min_i128(asset.f_long_num, funding_delta_long)?;
         asset.f_short_num = add_non_min_i128(asset.f_short_num, funding_delta_short)?;
         asset.effective_price = effective_price;
         asset.fund_px_last = effective_price;
@@ -11978,6 +12002,19 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Err(V16Error::LockActive);
         }
         asset_risk_increase_gate(asset.lifecycle, asset.mode_long, asset.mode_short)
+    }
+
+    fn require_position_route_adl_safe(
+        &self,
+        asset_index: usize,
+        route: PositionRouteV16,
+        current: i128,
+        new: i128,
+    ) -> V16Result<()> {
+        if V16Core::kernel_position_route_requires_unit_adl(route, current, new) {
+            self.require_asset_risk_change_allowed(asset_index, true)?;
+        }
+        Ok(())
     }
 
     fn validate_configured_asset_index(&self, asset_index: usize) -> V16Result<()> {
@@ -12943,6 +12980,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // PRODUCTION KERNEL: classify the route (Attach/Clear/Flip/Resize) — the
         // exact decision this body dispatches on, factored out and contracted.
         let route = V16Core::kernel_classify_position_delta(current, new);
+        self.require_position_route_adl_safe(asset_index, route, current, new)?;
         if route == PositionRouteV16::Attach {
             let side = if new > 0 {
                 SideV16::Long
@@ -12991,7 +13029,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return self.clear_leg(account, asset_index);
         }
         if route == PositionRouteV16::Flip {
-            self.require_asset_risk_change_allowed(asset_index, true)?;
             self.clear_leg(account, asset_index)?;
             let side = if new > 0 {
                 SideV16::Long
@@ -12999,9 +13036,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 SideV16::Short
             };
             return self.attach_leg(account, asset_index, side, new);
-        }
-        if new.unsigned_abs() > current.unsigned_abs() {
-            self.require_asset_risk_change_allowed(asset_index, true)?;
         }
         let old_leg = account.header.legs[leg_slot].try_to_runtime()?;
         let new_weight = loss_weight_for_basis(new.unsigned_abs(), old_leg.a_basis)?;

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -11422,24 +11422,37 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
 
         let price_delta = effective_price as i128 - old.effective_price as i128;
-        let k_delta = checked_i128_mul(price_delta, ADL_ONE as i128)?;
-        let funding_delta = if activity.funding_active {
+        let a_long = i128::try_from(old.a_long).map_err(|_| V16Error::ArithmeticOverflow)?;
+        let a_short = i128::try_from(old.a_short).map_err(|_| V16Error::ArithmeticOverflow)?;
+        let k_delta_long = checked_i128_mul(price_delta, a_long)?;
+        let k_delta_short = checked_i128_mul(price_delta, a_short)?;
+        let funding_index_delta = if activity.funding_active {
             let n = funding_rate_e9
                 .checked_mul(segment_dt as i128)
                 .and_then(|v| v.checked_mul(effective_price as i128))
                 .ok_or(V16Error::ArithmeticOverflow)?;
             floor_div_signed_conservative_i128(n, FUNDING_DEN)
-                .checked_mul(ADL_ONE as i128)
-                .ok_or(V16Error::ArithmeticOverflow)?
         } else {
             0
         };
+        let funding_delta_long = checked_i128_mul(funding_index_delta, a_long)?;
+        let funding_delta_short = checked_i128_mul(funding_index_delta, a_short)?;
 
         let mut asset = old;
-        asset.k_long = add_non_min_i128(asset.k_long, k_delta)?;
-        asset.k_short = add_non_min_i128(asset.k_short, -k_delta)?;
-        asset.f_long_num = add_non_min_i128(asset.f_long_num, -funding_delta)?;
-        asset.f_short_num = add_non_min_i128(asset.f_short_num, funding_delta)?;
+        asset.k_long = add_non_min_i128(asset.k_long, k_delta_long)?;
+        asset.k_short = add_non_min_i128(
+            asset.k_short,
+            k_delta_short
+                .checked_neg()
+                .ok_or(V16Error::ArithmeticOverflow)?,
+        )?;
+        asset.f_long_num = add_non_min_i128(
+            asset.f_long_num,
+            funding_delta_long
+                .checked_neg()
+                .ok_or(V16Error::ArithmeticOverflow)?,
+        )?;
+        asset.f_short_num = add_non_min_i128(asset.f_short_num, funding_delta_short)?;
         asset.effective_price = effective_price;
         asset.fund_px_last = effective_price;
         asset.slot_last = asset
@@ -11961,6 +11974,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Ok(());
         }
         let asset = self.asset_state(asset_index)?;
+        if asset.a_long != ADL_ONE || asset.a_short != ADL_ONE {
+            return Err(V16Error::LockActive);
+        }
         asset_risk_increase_gate(asset.lifecycle, asset.mode_long, asset.mode_short)
     }
 

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -281,6 +281,25 @@ pub fn kani_position_delta_increases_risk(current: i128, delta_q: i128) -> V16Re
     position_delta_increases_risk(current, delta_q)
 }
 
+pub fn kani_position_change_requires_unit_adl(current: i128, new: i128) -> bool {
+    let route = V16Core::kernel_classify_position_delta(current, new);
+    V16Core::kernel_position_route_requires_unit_adl(route, current, new)
+}
+
+pub fn kani_adl_scaled_accrual_index_deltas(
+    price_delta: i128,
+    funding_index_delta: i128,
+    a_long: u128,
+    a_short: u128,
+) -> V16Result<(i128, i128, i128, i128)> {
+    V16Core::kernel_adl_scaled_accrual_index_deltas(
+        price_delta,
+        funding_index_delta,
+        a_long,
+        a_short,
+    )
+}
+
 pub fn kani_trade_preexisting_oi_reduction_gate(
     oi_long_q: u128,
     oi_short_q: u128,
@@ -883,6 +902,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         risk_increasing: bool,
     ) -> V16Result<()> {
         self.require_asset_risk_change_allowed(asset_index, risk_increasing)
+    }
+
+    pub fn kani_require_position_change_adl_safe(
+        &self,
+        asset_index: usize,
+        current: i128,
+        new: i128,
+    ) -> V16Result<()> {
+        let route = V16Core::kernel_classify_position_delta(current, new);
+        self.require_position_route_adl_safe(asset_index, route, current, new)
     }
 
     pub fn kani_ensure_close_progress_not_expired(

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -3,9 +3,9 @@
 use percolator::v16::{
     active_bitmap_count_ones, active_bitmap_get, active_bitmap_is_empty,
     backing_domain_fee_split_for_lien_delta_num, kani_active_bitmap_set as active_bitmap_set,
-    kani_add_open_interest_for_new_position, kani_apply_backing_provider_earnings_withdraw,
-    kani_apply_backing_utilization_fee_charge, kani_apply_resolved_payout_receipt_payment,
-    kani_available_backing_num_for_source_credit_state,
+    kani_add_open_interest_for_new_position, kani_adl_scaled_accrual_index_deltas,
+    kani_apply_backing_provider_earnings_withdraw, kani_apply_backing_utilization_fee_charge,
+    kani_apply_resolved_payout_receipt_payment, kani_available_backing_num_for_source_credit_state,
     kani_backing_utilization_fee_quote_atoms_for_lien,
     kani_backing_utilization_rate_e9_for_source_state, kani_cert_is_current,
     kani_expected_source_credit_rate_num_for_state, kani_health_cert_after_capital_debit,
@@ -14,7 +14,8 @@ use percolator::v16::{
     kani_liquidation_engine_close_request_q, kani_liquidation_fee_from_raw_fee,
     kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
-    kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
+    kani_pending_domain_loss_barrier_blocks_position_change,
+    kani_position_change_requires_unit_adl, kani_position_delta_increases_risk,
     kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
     kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
     kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
@@ -41,7 +42,7 @@ use percolator::v16::{
 };
 use percolator::{
     ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, MAX_ACCOUNT_NOTIONAL, MAX_MARGIN_BPS,
-    MAX_ORACLE_PRICE, MAX_POSITION_ABS_Q, MAX_TRADE_SIZE_Q, MAX_VAULT_TVL, POS_SCALE,
+    MAX_ORACLE_PRICE, MAX_POSITION_ABS_Q, MAX_TRADE_SIZE_Q, MAX_VAULT_TVL, MIN_A_SIDE, POS_SCALE,
     SOCIAL_LOSS_DEN, V16_ACTIVE_BITMAP_WORDS,
 };
 
@@ -881,7 +882,11 @@ fn proof_v16_persisted_risk_gate_is_complete_for_all_lifecycles_and_side_modes()
     let long_mode_raw: u8 = kani::any();
     let short_mode_raw: u8 = kani::any();
     let risk_increasing: bool = kani::any();
+    let a_long_raw: u64 = kani::any();
+    let a_short_raw: u64 = kani::any();
     kani::assume(lifecycle_raw <= 5 && long_mode_raw <= 2 && short_mode_raw <= 2);
+    kani::assume((MIN_A_SIDE as u64..=ADL_ONE as u64).contains(&a_long_raw));
+    kani::assume((MIN_A_SIDE as u64..=ADL_ONE as u64).contains(&a_short_raw));
 
     let decode_mode = |raw| match raw {
         0 => SideModeV16::Normal,
@@ -898,15 +903,21 @@ fn proof_v16_persisted_risk_gate_is_complete_for_all_lifecycles_and_side_modes()
     };
     let long_mode = decode_mode(long_mode_raw);
     let short_mode = decode_mode(short_mode_raw);
+    let a_long = a_long_raw as u128;
+    let a_short = a_short_raw as u128;
     let expected_ok = !risk_increasing
         || (lifecycle == AssetLifecycleV16::Active
             && long_mode == SideModeV16::Normal
-            && short_mode == SideModeV16::Normal);
-    let (mut header, mut markets, _) = one_market_view_fixture();
+            && short_mode == SideModeV16::Normal
+            && a_long == ADL_ONE
+            && a_short == ADL_ONE);
+    let (mut header, mut markets) = one_market_only_fixture();
     let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
     asset.lifecycle = lifecycle;
     asset.mode_long = long_mode;
     asset.mode_short = short_mode;
+    asset.a_long = a_long;
+    asset.a_short = a_short;
     markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
     let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
     let result = market.kani_require_asset_risk_change_allowed(0, risk_increasing);
@@ -915,8 +926,18 @@ fn proof_v16_persisted_risk_gate_is_complete_for_all_lifecycles_and_side_modes()
         risk_increasing
             && lifecycle == AssetLifecycleV16::Active
             && long_mode == SideModeV16::Normal
-            && short_mode == SideModeV16::Normal,
+            && short_mode == SideModeV16::Normal
+            && a_long == ADL_ONE
+            && a_short == ADL_ONE,
         "active Normal/Normal admits risk increase"
+    );
+    kani::cover!(
+        risk_increasing
+            && lifecycle == AssetLifecycleV16::Active
+            && long_mode == SideModeV16::Normal
+            && short_mode == SideModeV16::Normal
+            && (a_long != ADL_ONE || a_short != ADL_ONE),
+        "a non-unit ADL factor blocks fresh risk even in an otherwise live asset"
     );
     kani::cover!(
         risk_increasing
@@ -954,6 +975,282 @@ fn proof_v16_persisted_risk_gate_is_complete_for_all_lifecycles_and_side_modes()
     } else {
         assert_eq!(result, Err(V16Error::LockActive));
     }
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_adl_position_change_gate_is_route_complete_and_exit_live() {
+    let current_raw: i8 = kani::any();
+    let new_raw: i8 = kani::any();
+    let a_long_raw: u64 = kani::any();
+    let a_short_raw: u64 = kani::any();
+    kani::assume((-8..=8).contains(&current_raw));
+    kani::assume((-8..=8).contains(&new_raw));
+    kani::assume(current_raw != new_raw);
+    kani::assume((MIN_A_SIDE as u64..=ADL_ONE as u64).contains(&a_long_raw));
+    kani::assume((MIN_A_SIDE as u64..=ADL_ONE as u64).contains(&a_short_raw));
+
+    let current = i128::from(current_raw);
+    let new = i128::from(new_raw);
+    let a_long = u128::from(a_long_raw);
+    let a_short = u128::from(a_short_raw);
+    let requires_unit_adl = kani_position_change_requires_unit_adl(current, new);
+    let expected_requires = current == 0
+        || (new != 0 && current.signum() != new.signum())
+        || new.unsigned_abs() > current.unsigned_abs();
+    assert_eq!(requires_unit_adl, expected_requires);
+
+    let (mut header, mut markets) = one_market_only_fixture();
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.a_long = a_long;
+    asset.a_short = a_short;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let result = market.kani_require_position_change_adl_safe(0, current, new);
+    let unit_adl = a_long == ADL_ONE && a_short == ADL_ONE;
+    let expected_ok = !requires_unit_adl || unit_adl;
+
+    kani::cover!(
+        !unit_adl && current == 0 && new != 0 && result.is_err(),
+        "non-unit ADL blocks every fresh attachment"
+    );
+    kani::cover!(
+        !unit_adl
+            && current != 0
+            && new != 0
+            && current.signum() != new.signum()
+            && new.unsigned_abs() < current.unsigned_abs()
+            && result.is_err(),
+        "non-unit ADL blocks even a raw-basis-reducing side flip"
+    );
+    kani::cover!(
+        !unit_adl
+            && current.signum() == new.signum()
+            && new.unsigned_abs() > current.unsigned_abs()
+            && result.is_err(),
+        "non-unit ADL blocks same-side enlargement"
+    );
+    kani::cover!(
+        !unit_adl
+            && current.signum() == new.signum()
+            && new != 0
+            && new.unsigned_abs() < current.unsigned_abs()
+            && result.is_ok(),
+        "non-unit ADL preserves same-side reduction liveness"
+    );
+    kani::cover!(
+        !unit_adl && current != 0 && new == 0 && result.is_ok(),
+        "non-unit ADL preserves full-close liveness"
+    );
+    kani::cover!(
+        unit_adl && requires_unit_adl && result.is_ok(),
+        "unit ADL admits every otherwise-live position route"
+    );
+
+    assert_eq!(result.is_ok(), expected_ok);
+    if expected_ok {
+        assert_eq!(result, Ok(()));
+    } else {
+        assert_eq!(result, Err(V16Error::LockActive));
+    }
+}
+
+#[kani::proof]
+#[kani::unwind(4)]
+#[kani::solver(cadical)]
+fn proof_v16_adl_scaled_accrual_kernel_matches_every_valid_factor() {
+    let a_long_raw: u64 = kani::any();
+    let a_short_raw: u64 = kani::any();
+    let price_delta_raw: i8 = kani::any();
+    let funding_delta_raw: i8 = kani::any();
+    kani::assume((MIN_A_SIDE as u64..=ADL_ONE as u64).contains(&a_long_raw));
+    kani::assume((MIN_A_SIDE as u64..=ADL_ONE as u64).contains(&a_short_raw));
+    kani::assume((-8..=8).contains(&price_delta_raw));
+    kani::assume((-8..=8).contains(&funding_delta_raw));
+
+    let a_long = u128::from(a_long_raw);
+    let a_short = u128::from(a_short_raw);
+    let price_delta = i128::from(price_delta_raw);
+    let funding_delta = i128::from(funding_delta_raw);
+    let result = kani_adl_scaled_accrual_index_deltas(price_delta, funding_delta, a_long, a_short);
+    assert!(result.is_ok());
+    let (k_long, k_short, f_long, f_short) = result.unwrap();
+
+    kani::cover!(
+        a_long != a_short && price_delta > 0 && funding_delta < 0,
+        "unequal ADL factors cover simultaneous positive-price and negative-funding accrual"
+    );
+    kani::cover!(
+        a_long != a_short && price_delta < 0 && funding_delta > 0,
+        "unequal ADL factors cover the opposite signed accrual direction"
+    );
+    kani::cover!(
+        a_long == ADL_ONE && a_short == ADL_ONE && price_delta != 0,
+        "unit ADL remains the symmetric baseline"
+    );
+
+    assert_eq!(k_long, price_delta * i128::from(a_long_raw));
+    assert_eq!(k_short, -price_delta * i128::from(a_short_raw));
+    assert_eq!(f_long, -funding_delta * i128::from(a_long_raw));
+    assert_eq!(f_short, funding_delta * i128::from(a_short_raw));
+}
+
+#[kani::proof]
+#[kani::unwind(4)]
+#[kani::solver(cadical)]
+fn proof_v16_adl_scaled_accrual_is_cross_side_zero_sum_at_every_factor_quantum() {
+    let a_long_units: u8 = kani::any();
+    let a_short_units: u8 = kani::any();
+    let price_delta_raw: i8 = kani::any();
+    let funding_delta_raw: i8 = kani::any();
+    kani::assume((1..=10).contains(&a_long_units));
+    kani::assume((1..=10).contains(&a_short_units));
+    kani::assume((-8..=8).contains(&price_delta_raw));
+    kani::assume((-8..=8).contains(&funding_delta_raw));
+
+    assert_eq!(ADL_ONE, 10 * MIN_A_SIDE);
+    let a_long = u128::from(a_long_units) * MIN_A_SIDE;
+    let a_short = u128::from(a_short_units) * MIN_A_SIDE;
+    let (k_long, k_short, f_long, f_short) = kani_adl_scaled_accrual_index_deltas(
+        i128::from(price_delta_raw),
+        i128::from(funding_delta_raw),
+        a_long,
+        a_short,
+    )
+    .unwrap();
+    let a_long_i = i128::from(a_long_units);
+    let a_short_i = i128::from(a_short_units);
+
+    kani::cover!(
+        a_long_units != a_short_units && price_delta_raw != 0 && funding_delta_raw != 0,
+        "unequal ADL factors cover simultaneous nonzero price and funding accrual"
+    );
+    kani::cover!(
+        a_long_units == 1 && a_short_units == 10,
+        "minimum and maximum factors are covered together"
+    );
+    kani::cover!(
+        a_long_units == 10 && a_short_units == 1,
+        "maximum and minimum factors are covered together"
+    );
+
+    assert_eq!(k_long * a_short_i + k_short * a_long_i, 0);
+    assert_eq!(f_long * a_short_i + f_short * a_long_i, 0);
+}
+
+fn adl_partition_settlement_net(
+    market: &MarketGroupV16ViewMut<'_, u64>,
+    side: SideV16,
+    basis_units: u8,
+) -> i128 {
+    if basis_units == 0 {
+        return 0;
+    }
+    let abs_basis_q = u128::from(basis_units) * POS_SCALE;
+    let basis_pos_q = match side {
+        SideV16::Long => abs_basis_q as i128,
+        SideV16::Short => -(abs_basis_q as i128),
+    };
+    let leg = PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: 1,
+        side,
+        basis_pos_q,
+        a_basis: ADL_ONE,
+        k_snap: 0,
+        f_snap: 0,
+        epoch_snap: 0,
+        loss_weight: abs_basis_q,
+        b_snap: 0,
+        b_rem: 0,
+        b_epoch_snap: 0,
+        b_stale: false,
+        stale: false,
+    };
+    market.kani_leg_kf_delta_for_settlement(leg).unwrap().2
+}
+
+#[kani::proof]
+#[kani::unwind(16)]
+#[kani::solver(cadical)]
+fn proof_v16_adl_kf_settlement_is_account_partition_invariant_and_zero_sum() {
+    let a_long_units: u8 = kani::any();
+    let a_short_units: u8 = kani::any();
+    let long_first_units: u8 = kani::any();
+    let short_first_units: u8 = kani::any();
+    let price_units_raw: i8 = kani::any();
+    let funding_units_raw: i8 = kani::any();
+    kani::assume((1..=4).contains(&a_long_units));
+    kani::assume((1..=4).contains(&a_short_units));
+    kani::assume(long_first_units <= a_short_units);
+    kani::assume(short_first_units <= a_long_units);
+    kani::assume((-4..=4).contains(&price_units_raw));
+    kani::assume((-4..=4).contains(&funding_units_raw));
+    kani::assume(price_units_raw != 0 || funding_units_raw != 0);
+
+    assert_eq!(ADL_ONE % 4, 0);
+    let a_quantum = ADL_ONE / 4;
+    let a_long = u128::from(a_long_units) * a_quantum;
+    let a_short = u128::from(a_short_units) * a_quantum;
+    let price_units = i128::from(price_units_raw);
+    let funding_units = i128::from(funding_units_raw);
+    let (k_long, k_short, f_long, f_short) =
+        kani_adl_scaled_accrual_index_deltas(4 * price_units, 4 * funding_units, a_long, a_short)
+            .unwrap();
+
+    let (mut header, mut markets) = one_market_only_fixture();
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.a_long = a_long;
+    asset.a_short = a_short;
+    asset.k_long = k_long;
+    asset.k_short = k_short;
+    asset.f_long_num = f_long;
+    asset.f_short_num = f_short;
+    let matched_oi = u128::from(a_long_units)
+        .checked_mul(u128::from(a_short_units))
+        .and_then(|v| v.checked_mul(POS_SCALE))
+        .unwrap()
+        / 4;
+    asset.oi_eff_long_q = matched_oi;
+    asset.oi_eff_short_q = matched_oi;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+
+    let long_whole = adl_partition_settlement_net(&market, SideV16::Long, a_short_units);
+    let short_whole = adl_partition_settlement_net(&market, SideV16::Short, a_long_units);
+    let long_split = adl_partition_settlement_net(&market, SideV16::Long, long_first_units)
+        + adl_partition_settlement_net(&market, SideV16::Long, a_short_units - long_first_units);
+    let short_split = adl_partition_settlement_net(&market, SideV16::Short, short_first_units)
+        + adl_partition_settlement_net(&market, SideV16::Short, a_long_units - short_first_units);
+    let expected_long =
+        i128::from(a_long_units) * i128::from(a_short_units) * (price_units - funding_units);
+
+    kani::cover!(
+        a_long != a_short
+            && price_units != 0
+            && funding_units != 0
+            && long_first_units > 0
+            && long_first_units < a_short_units
+            && short_first_units > 0
+            && short_first_units < a_long_units,
+        "unequal ADL factors cover nontrivial two-account partitions on both matched sides"
+    );
+    kani::cover!(
+        a_long != a_short && price_units > 0 && funding_units < 0,
+        "unequal ADL factors cover reinforcing price and funding settlement"
+    );
+    kani::cover!(
+        a_long == ADL_ONE && a_short == ADL_ONE,
+        "unit ADL remains a covered partition-invariant baseline"
+    );
+
+    assert_eq!(long_whole, expected_long);
+    assert_eq!(short_whole, -expected_long);
+    assert_eq!(long_split, long_whole);
+    assert_eq!(short_split, short_whole);
+    assert_eq!(long_split + short_split, 0);
 }
 
 #[kani::proof]

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -10,7 +10,7 @@ use percolator::{
     PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
-    ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedPayoutLedgerV16,
+    ProvenanceHeaderV16, ProvenanceHeaderV16Account, RebalanceRequestV16, ResolvedPayoutLedgerV16,
     ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16, ResolvedPayoutReceiptV16Account,
     SideModeV16, SideV16, SourceCreditStateV16, SourceCreditStateV16Account, TradeRequestV16,
     V16Config, V16Error, V16PodI128, V16PodU128, V16PodU32, V16PodU64, V16_EMPTY_ACTIVE_BITMAP,
@@ -23,6 +23,161 @@ const FUNDING_COUNTER_ATOMS_PER_SLOT: u128 = 10;
 
 fn ids() -> ([u8; 32], [u8; 32], [u8; 32]) {
     ([1; 32], [2; 32], [3; 32])
+}
+
+#[test]
+fn v16_quantity_adl_blocks_fresh_basis_reissue_across_split_trades() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut long_header = account_fixture(1, 220);
+    let mut short_header = account_fixture(1, 221);
+    let mut successor_header = account_fixture(1, 222);
+    let open_q = 4 * POS_SCALE;
+
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        let mut successor = PortfolioV16ViewMut::new(&mut successor_header);
+        market.deposit_not_atomic(&mut long, 10_000).unwrap();
+        market.deposit_not_atomic(&mut short, 10_000).unwrap();
+        market.deposit_not_atomic(&mut successor, 10_000).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: signed_q(open_q),
+                    exec_price: 100,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+        market
+            .rebalance_reduce_position_not_atomic(
+                &mut long,
+                RebalanceRequestV16 {
+                    asset_index: 0,
+                    reduce_q: POS_SCALE,
+                },
+            )
+            .unwrap();
+    }
+
+    let asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(asset.oi_eff_long_q, 3 * POS_SCALE);
+    assert_eq!(asset.oi_eff_short_q, 3 * POS_SCALE);
+    assert_eq!(asset.a_short, ADL_ONE * 3 / 4);
+    assert_eq!(
+        short_header.legs[0]
+            .try_to_runtime()
+            .unwrap()
+            .basis_pos_q
+            .unsigned_abs(),
+        open_q
+    );
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    let mut successor = PortfolioV16ViewMut::new(&mut successor_header);
+    let result = market.execute_trade_with_fee_loss_stale_scoped_not_atomic(
+        &mut short,
+        &mut successor,
+        TradeRequestV16 {
+            asset_index: 0,
+            size_q: signed_q(open_q / 2),
+            exec_price: 100,
+            fee_bps: 0,
+        },
+    );
+
+    assert_eq!(result, Err(V16Error::LockActive));
+}
+
+#[test]
+fn v16_quantity_adl_price_and_funding_accrual_remain_zero_sum() {
+    let (mut header, mut markets) = funding_market_fixture(FUNDING_COUNTER_PRICE);
+    let mut long_header = account_fixture(1, 223);
+    let mut short_header = account_fixture(1, 224);
+    let open_q = 4 * POS_SCALE;
+
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market.deposit_not_atomic(&mut long, 100_000_000).unwrap();
+        market.deposit_not_atomic(&mut short, 100_000_000).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: signed_q(open_q),
+                    exec_price: FUNDING_COUNTER_PRICE,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+        market
+            .rebalance_reduce_position_not_atomic(
+                &mut long,
+                RebalanceRequestV16 {
+                    asset_index: 0,
+                    reduce_q: POS_SCALE,
+                },
+            )
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(
+                0,
+                2,
+                FUNDING_COUNTER_PRICE + 1,
+                FUNDING_COUNTER_RATE_E9,
+                true,
+            )
+            .unwrap();
+        market.markets[0].engine.asset.raw_oracle_target_price =
+            V16PodU64::new(FUNDING_COUNTER_PRICE + 1);
+    }
+
+    let asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    let scaled = (ADL_ONE * 3 / 4) as i128;
+    assert_eq!(asset.k_long, ADL_ONE as i128);
+    assert_eq!(asset.k_short, -scaled);
+    assert_eq!(
+        asset.f_long_num,
+        -(FUNDING_COUNTER_ATOMS_PER_SLOT as i128 * ADL_ONE as i128)
+    );
+    assert_eq!(
+        asset.f_short_num,
+        FUNDING_COUNTER_ATOMS_PER_SLOT as i128 * scaled
+    );
+
+    let total_value = |long: &PortfolioAccountV16Account,
+                       short: &PortfolioAccountV16Account|
+     -> i128 {
+        long.capital.get() as i128 + long.pnl.get() + short.capital.get() as i128 + short.pnl.get()
+    };
+    let value_before = total_value(&long_header, &short_header);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: -signed_q(POS_SCALE),
+                    exec_price: FUNDING_COUNTER_PRICE + 1,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+    }
+    assert_eq!(total_value(&long_header, &short_header), value_before);
 }
 
 fn market_fixture(


### PR DESCRIPTION
## Impact

After quantity ADL, a winning leg retained its pre-ADL raw basis while the side's effective OI and `A_side` were reduced. The public trade path could move that raw basis into a fresh portfolio in multiple fills. Each fresh leg snapped the reduced `A_side` as its new `a_basis`, reissuing previously haircutted exposure. A later mark move could therefore create more winner PnL than matched counterparty loss and consume honest backing.

The same accounting gap affected untouched post-ADL positions: K/F accrual used `ADL_ONE`, so unequal side factors produced unequal aggregate claims.

## Fix

- Scale each side's K and F index increments by that side's current A factor.
- Reject attach, flip, and same-side enlargement while either side has a non-unit A factor.
- Preserve same-side reduction and full-close liveness.
- Put the route gate in the common leg-mutation path so attach cannot rely only on an outer preflight.
- Keep the frozen `spec.md` unchanged.

## Production regressions

- `v16_quantity_adl_blocks_fresh_basis_reissue_across_split_trades` reproduces issue #131 after a quantity-ADL factor gap. The parent accepts the fresh split-transfer leg; this branch returns `LockActive` before mutation.
- `v16_quantity_adl_price_and_funding_accrual_remain_zero_sum` covers price and funding after quantity ADL, then executes a matched reduction and checks combined account value conservation.

The paired wrapper PR adds a public LiteSVM red/green exploit without direct state mutation: aeyakovenko/percolator-prog#250.

## Generalized proof obligations

The Kani suite now proves a wider ADL conservation theorem over production kernels and zero-copy views:

- Persisted admission is an exact biconditional over every lifecycle, both side modes, the full valid `A_long/A_short` range, and risk-increasing versus reducing changes.
- Route admission covers attach, flip, enlarge, reduce, and clear. Every fresh-risk route requires unit A factors, while reduce and clear remain live.
- Accrual matches the exact side-scaled K/F formulas for every valid persisted A factor.
- Cross-side K/F accrual is zero-sum for every one of the ten protocol factor quanta, including both min/max orientations.
- Production leg settlement is invariant to splitting each matched side across two accounts and remains market-level zero-sum under unequal factors.

All covers are satisfied. The production settlement theorem invokes the real leg-settlement path four times rather than proving a standalone arithmetic model.

## PDD evidence

- Mutating accrual back to `ADL_ONE` failed all four exact K/F equations in 2.04s with 3/3 covers satisfied.
- Replacing route classification with a magnitude-only gate failed the route biconditional in 14.45s; 5/6 covers remained, with the missing cover identifying the smaller side-flip bypass.

## Validation

- `cargo test --all-targets`: 131 passed
- persisted gate: 15.15s, 7/7 covers
- route-complete gate: 14.59s, 6/6 covers
- all-valid-factor accrual: 15.23s, 3/3 covers
- factor-quantum zero-sum: 8.05s, 3/3 covers
- account-partition settlement: 213.13s, 3/3 covers
- `cargo fmt --all -- --check`
- `git diff --check`
- `spec.md` has no diff from `master`

Fixes #131.