### PR TITLE
V16 recovery and settlement invariants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,8 @@ pub use v16::*;
 pub use v16::{
     active_bitmap_count_ones, active_bitmap_empty, active_bitmap_get, active_bitmap_is_empty,
     auto_crank_plan_requires_caller_observation, backing_domain_fee_split_for_lien_delta_num,
+    bankruptcy_asset_slot_has_lock_state, bankruptcy_hlock_active_from_wire,
+    bankruptcy_hlock_fully_attributed_from_wire, bankruptcy_hlock_to_wire,
     v16_domain_count_for_market_slots, v16_domain_pair_for_asset_index, AccrueAssetOutcomeV16,
     ActionableSummaryV16, AssetLifecycleV16, AssetStateV16, AssetStateV16Account,
     AutoCrankObservationV16, AutoCrankOutcomeV16, AutoCrankPlanV16, AutoCrankResultV16,

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -8,7 +8,7 @@
 
 use crate::wide_math::{
     checked_mul_div_ceil_u256, floor_div_signed_conservative_i128, mul_div_floor_u256_with_rem,
-    wide_mul_div_floor_u128, wide_signed_mul_div_floor_from_k_pair, U256,
+    wide_mul_div_floor_u128, wide_signed_mul_div_floor_with_carry_from_k_pair, U256,
 };
 use crate::{
     ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, FUNDING_DEN, MAX_ACCOUNT_NOTIONAL, MAX_MARGIN_BPS,
@@ -26,9 +26,11 @@ pub const V16_ACTIVE_BITMAP_WORDS: usize = (V16_MAX_PORTFOLIO_ASSETS_N + 63) / 6
 pub type V16ActiveBitmap = [u64; V16_ACTIVE_BITMAP_WORDS];
 pub const V16_EMPTY_ACTIVE_BITMAP: V16ActiveBitmap = [0; V16_ACTIVE_BITMAP_WORDS];
 pub const V16_BACKING_BUCKETS_PER_DOMAIN: usize = 1;
+const _: () = assert!(ADL_ONE % FUNDING_DEN == 0);
 // Bump whenever the on-chain account/header Pod layout changes (see the
 // PortfolioAccountV16Account size assertion). 17: added funding flow counters.
-pub const V16_LAYOUT_DISCRIMINATOR: u16 = 17;
+// 18: added per-leg K/F settlement remainders.
+pub const V16_LAYOUT_DISCRIMINATOR: u16 = 18;
 pub const V16_ACCOUNT_VERSION: u16 = 1;
 pub const BACKING_FEE_RATE_DEN_E9: u128 = 1_000_000_000;
 pub const MAX_BACKING_FEE_RATE_E9_PER_SLOT: u64 = 1_000_000_000;
@@ -170,12 +172,12 @@ pub fn v16_domain_pair_for_asset_index(asset_index: usize) -> V16Result<(usize, 
 /// dispatch hard-requires a caller-supplied oracle observation: there is no active
 /// account leg from which to choose a committed asset, so it must accrue a NEW
 /// price. `RefreshAccount { asset_index: Some(_) }` and EVERY other plan are
-/// dispatchable from committed on-chain state alone — `SettleBChunk` ignores
-/// price, `Liquidate` reads the current health cert, `DeclareRecovery` /
-/// `CloseResolved` / `NoAction` take no price — so a keeper holding no fresh
-/// observation can still drive the account forward (no liveness stall). A wrapper
-/// may call this to decide whether it must source an oracle observation before
-/// cranking.
+/// dispatchable from committed on-chain state alone — `AdvanceRecoveryClose`
+/// and `SettleBChunk` ignore price, `Liquidate` reads the current health cert,
+/// `DeclareRecovery` / `FinalizeRecovery` / `CloseResolved` / `NoAction` take no
+/// price — so a keeper holding no fresh observation can still drive the account
+/// forward (no liveness stall). A wrapper may call this to decide whether it must
+/// source an oracle observation before cranking.
 ///
 /// The exhaustive match forces a conscious classification if a plan variant is
 /// added. `proof_v16_auto_crank_refresh_is_unique_observation_requiring_plan` pins
@@ -187,9 +189,11 @@ pub fn v16_domain_pair_for_asset_index(asset_index: usize) -> V16Result<(usize, 
 pub fn auto_crank_plan_requires_caller_observation(plan: &AutoCrankPlanV16) -> bool {
     match plan {
         AutoCrankPlanV16::RefreshAccount { asset_index } => asset_index.is_none(),
-        AutoCrankPlanV16::SettleBChunk { .. }
+        AutoCrankPlanV16::AdvanceRecoveryClose { .. }
+        | AutoCrankPlanV16::SettleBChunk { .. }
         | AutoCrankPlanV16::Liquidate { .. }
         | AutoCrankPlanV16::DeclareRecovery { .. }
+        | AutoCrankPlanV16::FinalizeRecovery
         | AutoCrankPlanV16::CloseResolved
         | AutoCrankPlanV16::NoAction => false,
     }
@@ -273,6 +277,23 @@ fn active_bitmap_with_cleared(
 ) -> V16Result<V16ActiveBitmap> {
     active_bitmap_clear(&mut bitmap, leg_slot_index)?;
     Ok(bitmap)
+}
+
+#[inline]
+fn first_active_bitmap_slot(bitmap: V16ActiveBitmap) -> V16Result<Option<usize>> {
+    let mut word_index = 0usize;
+    while word_index < V16_ACTIVE_BITMAP_WORDS {
+        let word = bitmap[word_index];
+        if word != 0 {
+            let slot = word_index * 64 + word.trailing_zeros() as usize;
+            if slot >= V16_MAX_PORTFOLIO_ASSETS_N {
+                return Err(V16Error::InvalidLeg);
+            }
+            return Ok(Some(slot));
+        }
+        word_index += 1;
+    }
+    Ok(None)
 }
 
 #[inline]
@@ -635,9 +656,34 @@ pub fn active_bitmap_count_ones(bitmap: V16ActiveBitmap) -> u32 {
     total
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ResolvedSourceClosePhaseV16 {
+    ReleaseLien,
+    ExpireBacking,
+    ProcessClaim,
+}
+
 struct V16Core;
 
 impl V16Core {
+    #[inline]
+    fn resolved_source_close_phase(
+        source_claim_liened_num: u128,
+        bucket_status: BackingBucketStatusV16,
+        bucket_expiry_slot: u64,
+        current_slot: u64,
+    ) -> ResolvedSourceClosePhaseV16 {
+        if source_claim_liened_num != 0 {
+            ResolvedSourceClosePhaseV16::ReleaseLien
+        } else if bucket_status == BackingBucketStatusV16::Fresh
+            && bucket_expiry_slot <= current_slot
+        {
+            ResolvedSourceClosePhaseV16::ExpireBacking
+        } else {
+            ResolvedSourceClosePhaseV16::ProcessClaim
+        }
+    }
+
     fn loss_stale_trade_scope_allowed(
         market_loss_stale_active: bool,
         trade_asset_loss_stale: bool,
@@ -714,6 +760,247 @@ impl V16Core {
         .and_then(|v| v.try_into_u128())
         .ok_or(V16Error::ArithmeticOverflow)?;
         Ok((required_face_num, required_backing_num))
+    }
+
+    #[inline]
+    fn source_lien_backing_release_for_face_burn(
+        face_locked_num: u128,
+        backing_reserved_num: u128,
+        face_burn_num: u128,
+    ) -> V16Result<u128> {
+        if face_burn_num > face_locked_num || backing_reserved_num % BOUND_SCALE != 0 {
+            return Err(V16Error::InvalidLeg);
+        }
+        let effective_reserved = backing_reserved_num / BOUND_SCALE;
+        if effective_reserved > Self::amount_from_bound_num(face_locked_num)? {
+            return Err(V16Error::InvalidLeg);
+        }
+        let remaining_face_num = face_locked_num
+            .checked_sub(face_burn_num)
+            .ok_or(V16Error::CounterUnderflow)?;
+        let max_remaining_effective = Self::amount_from_bound_num(remaining_face_num)?;
+        let effective_release = effective_reserved.saturating_sub(max_remaining_effective);
+        Self::bound_num_from_amount(effective_release)
+    }
+
+    fn source_lien_fee_after_backing_release(
+        fee_revenue: u128,
+        backing_before: u128,
+        backing_after: u128,
+    ) -> V16Result<u128> {
+        if backing_after > backing_before {
+            return Err(V16Error::InvalidLeg);
+        }
+        if backing_after == 0 || fee_revenue == 0 {
+            return Ok(0);
+        }
+        if backing_after == backing_before {
+            return Ok(fee_revenue);
+        }
+        if backing_before == 0 {
+            return Err(V16Error::InvalidLeg);
+        }
+        Ok(wide_mul_div_floor_u128(
+            fee_revenue,
+            backing_after,
+            backing_before,
+        ))
+    }
+
+    /// PRODUCTION KERNEL: partition a liened-face burn across counterparty then
+    /// insurance support without overlap or omission.
+    fn source_lien_face_burn_partition(
+        counterparty_face_num: u128,
+        insurance_face_num: u128,
+        face_burn_num: u128,
+    ) -> V16Result<(u128, u128)> {
+        let total_face_num = counterparty_face_num
+            .checked_add(insurance_face_num)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        if face_burn_num > total_face_num {
+            return Err(V16Error::CounterUnderflow);
+        }
+        let counterparty_face_burn = face_burn_num.min(counterparty_face_num);
+        let insurance_face_burn = face_burn_num
+            .checked_sub(counterparty_face_burn)
+            .ok_or(V16Error::CounterUnderflow)?;
+        Ok((counterparty_face_burn, insurance_face_burn))
+    }
+
+    /// Compose the face partition with the minimum source-local backing release
+    /// needed to keep each remaining lien bounded by its remaining face.
+    fn source_lien_face_burn_plan(
+        counterparty_face_num: u128,
+        insurance_face_num: u128,
+        counterparty_backing_num: u128,
+        insurance_backing_num: u128,
+        face_burn_num: u128,
+    ) -> V16Result<(u128, u128, u128, u128, u128)> {
+        let (counterparty_face_burn, insurance_face_burn) = Self::source_lien_face_burn_partition(
+            counterparty_face_num,
+            insurance_face_num,
+            face_burn_num,
+        )?;
+        let counterparty_backing_release = Self::source_lien_backing_release_for_face_burn(
+            counterparty_face_num,
+            counterparty_backing_num,
+            counterparty_face_burn,
+        )?;
+        let insurance_backing_release = Self::source_lien_backing_release_for_face_burn(
+            insurance_face_num,
+            insurance_backing_num,
+            insurance_face_burn,
+        )?;
+        let backing_release_num = counterparty_backing_release
+            .checked_add(insurance_backing_release)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        Ok((
+            counterparty_face_burn,
+            insurance_face_burn,
+            counterparty_backing_release,
+            insurance_backing_release,
+            backing_release_num,
+        ))
+    }
+
+    fn prepare_account_counterparty_lien_impairment(
+        mut source: PortfolioSourceDomainV16Account,
+    ) -> V16Result<(PortfolioSourceDomainV16Account, u128)> {
+        let face = source.source_claim_counterparty_liened_num.get();
+        let backing_num = source.source_lien_counterparty_backing_num.get();
+        if face == 0 && backing_num == 0 {
+            return Ok((source, 0));
+        }
+        if face == 0 || backing_num == 0 || backing_num % BOUND_SCALE != 0 {
+            return Err(V16Error::InvalidLeg);
+        }
+        let effective = backing_num / BOUND_SCALE;
+        if effective == 0 {
+            return Err(V16Error::InvalidLeg);
+        }
+
+        Self::crystallize_source_lien_fee_for_effective(&mut source, effective)?;
+
+        source.source_claim_counterparty_liened_num = V16PodU128::new(0);
+        source.source_claim_liened_num = V16PodU128::new(
+            source
+                .source_claim_liened_num
+                .get()
+                .checked_sub(face)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        source.source_claim_impaired_num = V16PodU128::new(
+            source
+                .source_claim_impaired_num
+                .get()
+                .checked_add(face)
+                .ok_or(V16Error::CounterOverflow)?,
+        );
+        source.source_lien_counterparty_backing_num = V16PodU128::new(0);
+        source.source_lien_effective_reserved = V16PodU128::new(
+            source
+                .source_lien_effective_reserved
+                .get()
+                .checked_sub(effective)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        source.source_lien_impaired_effective_reserved = V16PodU128::new(
+            source
+                .source_lien_impaired_effective_reserved
+                .get()
+                .checked_add(effective)
+                .ok_or(V16Error::CounterOverflow)?,
+        );
+        source.source_lien_fee_last_slot = V16PodU64::new(0);
+        Ok((source, effective))
+    }
+
+    /// PRODUCTION KERNEL: one step of the compact source-domain scan. The
+    /// first sparse-tail entry or actionable domain terminates the scan.
+    fn kernel_live_source_backing_reconcile_scan_step(
+        selected: Option<(usize, bool, bool)>,
+        sparse_tail: bool,
+        occupied: bool,
+        domain: usize,
+        counterparty_backing_num: u128,
+        bucket_status: BackingBucketStatusV16,
+        expiry_slot: u64,
+        current_slot: u64,
+    ) -> (Option<(usize, bool, bool)>, bool) {
+        if selected.is_some() || sparse_tail {
+            return (selected, true);
+        }
+        if !occupied {
+            return (None, false);
+        }
+        let newly_lapsed =
+            bucket_status == BackingBucketStatusV16::Fresh && expiry_slot <= current_slot;
+        let impair_account = counterparty_backing_num != 0
+            && (newly_lapsed || bucket_status == BackingBucketStatusV16::Impaired);
+        if newly_lapsed || impair_account {
+            return (Some((domain, newly_lapsed, impair_account)), true);
+        }
+        (None, false)
+    }
+
+    fn crystallize_source_lien_fee_for_effective(
+        source: &mut PortfolioSourceDomainV16Account,
+        impaired_effective: u128,
+    ) -> V16Result<u128> {
+        let live_effective = source.source_lien_effective_reserved.get();
+        if impaired_effective > live_effective {
+            return Err(V16Error::CounterUnderflow);
+        }
+        let live_fee = source.source_lien_capital_at_risk_fee_revenue.get();
+        let impaired_fee = if impaired_effective == live_effective {
+            live_fee
+        } else if impaired_effective == 0 || live_fee == 0 {
+            0
+        } else {
+            U256::from_u128(live_fee)
+                .checked_mul(U256::from_u128(impaired_effective))
+                .ok_or(V16Error::ArithmeticOverflow)?
+                .checked_div(U256::from_u128(live_effective))
+                .ok_or(V16Error::ArithmeticOverflow)?
+                .try_into_u128()
+                .ok_or(V16Error::ArithmeticOverflow)?
+        };
+        source.source_lien_capital_at_risk_fee_revenue = V16PodU128::new(
+            live_fee
+                .checked_sub(impaired_fee)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        source.source_lien_impaired_capital_at_risk_fee_revenue = V16PodU128::new(
+            source
+                .source_lien_impaired_capital_at_risk_fee_revenue
+                .get()
+                .checked_add(impaired_fee)
+                .ok_or(V16Error::CounterOverflow)?,
+        );
+        Ok(impaired_fee)
+    }
+
+    #[inline(always)]
+    fn source_credit_lien_allocation_take(
+        remaining: u128,
+        unliened_face_num: u128,
+        available_backing_num: u128,
+        credit_rate_num: u128,
+    ) -> V16Result<u128> {
+        if remaining == 0 || unliened_face_num == 0 || credit_rate_num == 0 {
+            return Ok(0);
+        }
+        if credit_rate_num > CREDIT_RATE_SCALE {
+            return Err(V16Error::InvalidConfig);
+        }
+        let realizable_num = U256::from_u128(unliened_face_num)
+            .checked_mul(U256::from_u128(credit_rate_num))
+            .and_then(|v| v.checked_div(U256::from_u128(CREDIT_RATE_SCALE)))
+            .and_then(|v| v.try_into_u128())
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        Ok(remaining
+            .min(realizable_num / BOUND_SCALE)
+            .min(available_backing_num / BOUND_SCALE))
     }
 
     #[inline]
@@ -998,6 +1285,8 @@ impl V16Core {
                 && l.a_basis == leg.a_basis
                 && l.k_snap == leg.k_snap
                 && l.f_snap == leg.f_snap
+                && l.k_rem_num == leg.k_rem_num
+                && l.f_rem_num == leg.f_rem_num
                 && l.epoch_snap == leg.epoch_snap
                 && l.b_snap == leg.b_snap
                 && l.b_rem == leg.b_rem
@@ -1373,6 +1662,33 @@ impl V16Core {
         (payout, new_vault)
     }
 
+    fn resolved_close_terminal_payout_delta(
+        account_capital: u128,
+        resolved_claimable: u128,
+        vault: u128,
+        c_tot: u128,
+    ) -> V16Result<(u128, u128, u128, u128, u128)> {
+        let payout = account_capital
+            .checked_add(resolved_claimable)
+            .ok_or(V16Error::ArithmeticOverflow)?
+            .min(vault);
+        let capital_paid = account_capital.min(payout);
+        let resolved_paid = payout
+            .checked_sub(capital_paid)
+            .ok_or(V16Error::CounterUnderflow)?;
+        let vault_after = vault
+            .checked_sub(payout)
+            .ok_or(V16Error::CounterUnderflow)?;
+        let c_tot_after = c_tot.saturating_sub(account_capital.min(c_tot));
+        Ok((
+            payout,
+            capital_paid,
+            resolved_paid,
+            vault_after,
+            c_tot_after,
+        ))
+    }
+
     /// PRODUCTION KERNEL (roadmap 3A.1 trade spine): classify a position change
     /// from (current signed, new signed) into its leg route — the EXACT total
     /// decision the position-delta body dispatches on. `delta != 0` is enforced
@@ -1434,6 +1750,17 @@ impl V16Core {
             return Err(V16Error::LockActive);
         }
         Ok((long_reduction_q, short_reduction_q))
+    }
+
+    /// Cap unilateral close work by the account's stored basis and by matched
+    /// effective OI. Liquidation and owner rebalance share this bound so neither
+    /// can subtract more OI than either market side contains.
+    fn kernel_unilateral_close_capacity(
+        stored_abs: u128,
+        oi_eff_long_q: u128,
+        oi_eff_short_q: u128,
+    ) -> u128 {
+        stored_abs.min(oi_eff_long_q).min(oi_eff_short_q)
     }
 
     /// PRODUCTION KERNEL (roadmap 3A.2 risk-reduction / S-L3, A5.dec rank): the
@@ -1532,35 +1859,149 @@ impl V16Core {
         None
     }
 
+    #[inline]
+    fn kernel_permissionless_kf_settlement_commits_step(
+        allow_b_chunk: bool,
+        source_domain_count: usize,
+        has_pending_kf: bool,
+        leg_kf_pending: bool,
+    ) -> bool {
+        allow_b_chunk && source_domain_count != 0 && has_pending_kf && leg_kf_pending
+    }
+
+    /// Ordinary refresh accrual and liquidation may target only a live or
+    /// draining asset. Recovery legs remain exit obligations, but selecting one
+    /// for an ordinary action would deterministically fail.
+    fn kernel_auto_crank_lifecycle_dispatchable(lifecycle: AssetLifecycleV16) -> bool {
+        matches!(
+            lifecycle,
+            AssetLifecycleV16::Active | AssetLifecycleV16::DrainOnly
+        )
+    }
+
+    fn kernel_is_prior_reset_obligation(
+        side_mode: SideModeV16,
+        asset_epoch: u64,
+        leg_epoch_snap: u64,
+    ) -> bool {
+        side_mode == SideModeV16::ResetPending && leg_epoch_snap.checked_add(1) == Some(asset_epoch)
+    }
+
+    /// Classify one account leg for the bounded auto-crank scans. A prior-reset
+    /// obligation remains refreshable but cannot be dispatched as liquidation
+    /// work because its effective OI was already removed by the reset.
+    fn kernel_auto_crank_leg_flags(
+        active: bool,
+        lifecycle: AssetLifecycleV16,
+        basis_pos_q: i128,
+        side_oi_q: u128,
+        side_mode: SideModeV16,
+        asset_epoch: u64,
+        leg_epoch_snap: u64,
+        leg_b_stale: bool,
+    ) -> (bool, bool, bool, bool) {
+        let lifecycle_dispatchable = Self::kernel_auto_crank_lifecycle_dispatchable(lifecycle);
+        let prior_reset_obligation =
+            Self::kernel_is_prior_reset_obligation(side_mode, asset_epoch, leg_epoch_snap);
+        let refresh = active && lifecycle_dispatchable;
+        let liquidatable = refresh && basis_pos_q != 0 && side_oi_q != 0 && !prior_reset_obligation;
+        (
+            active && leg_b_stale,
+            refresh,
+            liquidatable,
+            active && prior_reset_obligation,
+        )
+    }
+
+    /// A refresh detaches at most one settled prior-reset obligation. A pending
+    /// close residual owns the account and blocks unrelated cleanup until that
+    /// continuation advances.
+    fn kernel_should_clear_prior_reset_obligation(
+        already_cleared: bool,
+        prior_reset_obligation: bool,
+        pending_close_residual: bool,
+    ) -> bool {
+        !already_cleared && prior_reset_obligation && !pending_close_residual
+    }
+
+    fn kernel_auto_crank_liquidatable(
+        live: bool,
+        cert_current: bool,
+        certified_liq_deficit: u128,
+        dispatchable_asset: Option<usize>,
+    ) -> bool {
+        live && cert_current && certified_liq_deficit != 0 && dispatchable_asset.is_some()
+    }
+
+    /// A close may force market-wide recovery only while it is outstanding,
+    /// expired, nonterminal, and not already isolated to a frozen Recovery
+    /// asset. Classification and dispatch share this O(1) decision.
+    fn kernel_close_requires_global_recovery(
+        close_outstanding: bool,
+        deadline_expired: bool,
+        market_terminal: bool,
+        asset_local_recovery: bool,
+    ) -> bool {
+        close_outstanding && deadline_expired && !market_terminal && !asset_local_recovery
+    }
+
+    /// A rollback-sensitive liquidation terminal counts as successful public
+    /// progress only when that same call left a complete Recovery declaration.
+    /// Bare `RecoveryRequired`, incomplete markers, and unrelated errors remain
+    /// errors and therefore fail closed at the transaction boundary.
+    #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result| {
+        match (error, mode, reason) {
+            (V16Error::RecoveryRequired, MarketModeV16::Recovery, Some(reason)) =>
+                *result == Ok(PermissionlessProgressOutcomeV16::RecoveryDeclared(reason)),
+            _ => *result == Err(error),
+        }
+    }))]
+    fn kernel_commit_declared_liquidation_recovery(
+        error: V16Error,
+        mode: MarketModeV16,
+        reason: Option<PermissionlessRecoveryReasonV16>,
+    ) -> V16Result<PermissionlessProgressOutcomeV16> {
+        match (error, mode, reason) {
+            (V16Error::RecoveryRequired, MarketModeV16::Recovery, Some(reason)) => {
+                Ok(PermissionlessProgressOutcomeV16::RecoveryDeclared(reason))
+            }
+            _ => Err(error),
+        }
+    }
+
     /// PRODUCTION KERNEL (engine.md selection semantics): from the actionable
     /// summary and the ENGINE-selected assets, choose the single highest-priority
     /// bounded plan, carrying the engine-chosen asset (the caller chooses neither
     /// the action nor the asset). PROVES: TOTALITY (an actionable account yields a
     /// non-NoAction plan), PRIORITY DETERMINISM (the documented order: recovery >
-    /// resolved-close > b-stale settle > liquidate > refresh), and SELECTED-ASSET
-    /// fidelity (SettleBChunk/Liquidate carry exactly the provided engine-selected
-    /// slot). `pending_close` is classifier-unreachable (build_actionable_summary
-    /// never sets it — a leg-bearing pending close is liquidatable; see the
-    /// AdvanceClose note), so it is required absent here. Pure.
-    #[cfg_attr(all(kani, feature = "contracts"), kani::requires(!summary.pending_close))]
+    /// resolved-close > recovery-close > b-stale settle > liquidate > refresh),
+    /// and SELECTED-ASSET fidelity (every asset-scoped plan carries exactly the
+    /// provided engine-selected slot). Pure.
     #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|r: &AutoCrankPlanV16| {
         let recovery = summary.expired_close || summary.recovery_eligible;
         match r {
             AutoCrankPlanV16::NoAction => !summary.is_actionable(),
             AutoCrankPlanV16::DeclareRecovery { reason } => recovery && *reason == recovery_reason,
+            AutoCrankPlanV16::FinalizeRecovery => false,
             AutoCrankPlanV16::CloseResolved => !recovery && summary.resolved_winner,
+            AutoCrankPlanV16::AdvanceRecoveryClose { asset_index } =>
+                !recovery && !summary.resolved_winner && summary.pending_close
+                    && *asset_index == pending_close_slot,
             AutoCrankPlanV16::SettleBChunk { asset_index } =>
-                !recovery && !summary.resolved_winner && summary.b_stale && *asset_index == b_stale_slot,
+                !recovery && !summary.resolved_winner && !summary.pending_close
+                    && summary.b_stale && *asset_index == b_stale_slot,
             AutoCrankPlanV16::Liquidate { asset_index } =>
-                !recovery && !summary.resolved_winner && !summary.b_stale && summary.liquidatable
-                    && *asset_index == liq_slot,
+                !recovery && !summary.resolved_winner && !summary.pending_close
+                    && !summary.b_stale && summary.liquidatable && *asset_index == liq_slot,
             AutoCrankPlanV16::RefreshAccount { asset_index } =>
-                !recovery && !summary.resolved_winner && !summary.b_stale && !summary.liquidatable
-                    && summary.stale && *asset_index == refresh_asset,
+                !recovery && !summary.resolved_winner && !summary.pending_close
+                    && !summary.b_stale && !summary.liquidatable && summary.stale
+                    && *asset_index == refresh_asset,
         }
     }))]
     pub(crate) fn select_auto_crank_plan(
         summary: ActionableSummaryV16,
+        pending_close_slot: usize,
         b_stale_slot: usize,
         liq_slot: usize,
         refresh_asset: Option<usize>,
@@ -1572,6 +2013,10 @@ impl V16Core {
             }
         } else if summary.resolved_winner {
             AutoCrankPlanV16::CloseResolved
+        } else if summary.pending_close {
+            AutoCrankPlanV16::AdvanceRecoveryClose {
+                asset_index: pending_close_slot,
+            }
         } else if summary.b_stale {
             AutoCrankPlanV16::SettleBChunk {
                 asset_index: b_stale_slot,
@@ -1648,6 +2093,16 @@ impl V16Core {
             && cert.cert_risk_epoch == risk_epoch
             && cert.cert_asset_set_epoch == asset_set_epoch
             && cert.active_bitmap_at_cert == account_bitmap
+    }
+
+    #[inline]
+    fn kernel_position_action_reuses_current_certificate(
+        account_stale: bool,
+        account_b_stale: bool,
+        cert_current: bool,
+        has_b_stale_leg: bool,
+    ) -> bool {
+        !account_stale && !account_b_stale && cert_current && !has_b_stale_leg
     }
 
     /// PRODUCTION FIDELITY BUILDER (roadmap 3C step 4, actionable-state
@@ -1907,6 +2362,8 @@ impl V16Core {
                 && l.a_basis == leg.a_basis
                 && l.k_snap == leg.k_snap
                 && l.f_snap == leg.f_snap
+                && l.k_rem_num == leg.k_rem_num
+                && l.f_rem_num == leg.f_rem_num
                 && l.epoch_snap == leg.epoch_snap
                 && l.loss_weight == leg.loss_weight
                 && l.b_epoch_snap == leg.b_epoch_snap
@@ -1928,11 +2385,170 @@ impl V16Core {
         Ok(leg)
     }
 
+    /// Fold one exiting leg's fractional social-loss remainder into the
+    /// side-level dust bucket. Both inputs are canonical fractions, so the sum
+    /// carries at most one whole quote atom.
+    #[cfg_attr(all(kani, feature = "contracts"), kani::requires(
+        current_dust < SOCIAL_LOSS_DEN && leg_remainder < SOCIAL_LOSS_DEN
+    ))]
+    #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &V16Result<(u128, u128)>| match result {
+        Ok((dust, carry)) => {
+            *dust < SOCIAL_LOSS_DEN
+                && *carry <= 1
+                && current_dust.checked_add(leg_remainder)
+                    == carry.checked_mul(SOCIAL_LOSS_DEN).and_then(|v| v.checked_add(*dust))
+        }
+        Err(_) => false,
+    }))]
+    pub(crate) fn kernel_fold_social_loss_dust(
+        current_dust: u128,
+        leg_remainder: u128,
+    ) -> V16Result<(u128, u128)> {
+        if current_dust >= SOCIAL_LOSS_DEN || leg_remainder >= SOCIAL_LOSS_DEN {
+            return Err(V16Error::InvalidConfig);
+        }
+        let total = current_dust
+            .checked_add(leg_remainder)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        if total >= SOCIAL_LOSS_DEN {
+            Ok((total - SOCIAL_LOSS_DEN, 1))
+        } else {
+            Ok((total, 0))
+        }
+    }
+
+    /// Move a side-wide B-division remainder into durable dust and audit
+    /// buckets before the side's weight basis is reset. A whole-atom carry is
+    /// explicit unallocated loss, never account equity or payout capacity.
+    #[cfg_attr(all(kani, feature = "contracts"), kani::requires(
+        current_dust < SOCIAL_LOSS_DEN
+            && social_remainder < SOCIAL_LOSS_DEN
+            && explicit_before < u128::MAX
+    ))]
+    #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &V16Result<(u128, u128)>| match result {
+        Ok((dust, explicit)) => {
+            *dust < SOCIAL_LOSS_DEN
+                && explicit.checked_sub(explicit_before).is_some_and(|carry| carry <= 1)
+                && current_dust.checked_add(social_remainder)
+                    == explicit.checked_sub(explicit_before)
+                        .and_then(|carry| carry.checked_mul(SOCIAL_LOSS_DEN))
+                        .and_then(|whole| whole.checked_add(*dust))
+        }
+        Err(_) => false,
+    }))]
+    pub(crate) fn kernel_quarantine_social_loss_remainder(
+        social_remainder: u128,
+        current_dust: u128,
+        explicit_before: u128,
+    ) -> V16Result<(u128, u128)> {
+        let (dust, carry) = Self::kernel_fold_social_loss_dust(current_dust, social_remainder)?;
+        let explicit = explicit_before
+            .checked_add(carry)
+            .ok_or(V16Error::CounterOverflow)?;
+        Ok((dust, explicit))
+    }
+
+    /// Move an exhausted side behind a reset epoch without touching the
+    /// opposite side. Prior-epoch legs can then detach without subtracting
+    /// their stored basis from already-zero effective OI.
+    pub(crate) fn kernel_begin_full_drain_reset(
+        mut asset: AssetStateV16,
+        side: SideV16,
+    ) -> V16Result<AssetStateV16> {
+        match side {
+            SideV16::Long => {
+                if asset.mode_long == SideModeV16::ResetPending
+                    || asset.oi_eff_long_q != 0
+                    || asset.pending_obligation_count_long != 0
+                {
+                    return Err(V16Error::LockActive);
+                }
+                let (dust, explicit) = Self::kernel_quarantine_social_loss_remainder(
+                    asset.social_loss_remainder_long_num,
+                    asset.social_loss_dust_long_num,
+                    asset.explicit_unallocated_loss_long,
+                )?;
+                asset.social_loss_remainder_long_num = 0;
+                asset.social_loss_dust_long_num = dust;
+                asset.explicit_unallocated_loss_long = explicit;
+                asset.k_epoch_start_long = asset.k_long;
+                asset.f_epoch_start_long_num = asset.f_long_num;
+                asset.b_epoch_start_long_num = asset.b_long_num;
+                asset.k_long = 0;
+                asset.f_long_num = 0;
+                asset.b_long_num = 0;
+                asset.loss_weight_sum_long = 0;
+                asset.a_long = ADL_ONE;
+                asset.epoch_long = asset
+                    .epoch_long
+                    .checked_add(1)
+                    .ok_or(V16Error::CounterOverflow)?;
+                asset.mode_long = SideModeV16::ResetPending;
+            }
+            SideV16::Short => {
+                if asset.mode_short == SideModeV16::ResetPending
+                    || asset.oi_eff_short_q != 0
+                    || asset.pending_obligation_count_short != 0
+                {
+                    return Err(V16Error::LockActive);
+                }
+                let (dust, explicit) = Self::kernel_quarantine_social_loss_remainder(
+                    asset.social_loss_remainder_short_num,
+                    asset.social_loss_dust_short_num,
+                    asset.explicit_unallocated_loss_short,
+                )?;
+                asset.social_loss_remainder_short_num = 0;
+                asset.social_loss_dust_short_num = dust;
+                asset.explicit_unallocated_loss_short = explicit;
+                asset.k_epoch_start_short = asset.k_short;
+                asset.f_epoch_start_short_num = asset.f_short_num;
+                asset.b_epoch_start_short_num = asset.b_short_num;
+                asset.k_short = 0;
+                asset.f_short_num = 0;
+                asset.b_short_num = 0;
+                asset.loss_weight_sum_short = 0;
+                asset.a_short = ADL_ONE;
+                asset.epoch_short = asset
+                    .epoch_short
+                    .checked_add(1)
+                    .ok_or(V16Error::CounterOverflow)?;
+                asset.mode_short = SideModeV16::ResetPending;
+            }
+        }
+        Ok(asset)
+    }
+
+    /// A unilateral close mutates both effective-OI sides. If the closed side
+    /// reaches zero while stored legs remain, those legs need the same old-
+    /// epoch reset route as the matching side or they become unreachable.
+    #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &bool| {
+        *result == (effective_oi == 0
+            && stored_position_count != 0
+            && pending_obligation_count == 0
+            && mode != SideModeV16::ResetPending)
+    }))]
+    pub(crate) fn kernel_side_needs_full_drain_reset(
+        effective_oi: u128,
+        stored_position_count: u64,
+        pending_obligation_count: u64,
+        mode: SideModeV16,
+    ) -> bool {
+        effective_oi == 0
+            && stored_position_count != 0
+            && pending_obligation_count == 0
+            && mode != SideModeV16::ResetPending
+    }
+
     /// PRODUCTION KERNEL: the clear-leg asset transform — decrement the
     /// side's stored-position count (and pending-obligation count for a
     /// zero-basis obligation leg), and unless the leg predates a side reset,
     /// fold its social-loss dust and remove its OI and loss weight. Pure on
     /// (PortfolioLegV16, AssetStateV16); the clear-leg glue calls exactly this.
+    #[cfg_attr(all(kani, feature = "contracts"), kani::requires(
+        leg.b_rem < SOCIAL_LOSS_DEN
+            && asset.social_loss_dust_long_num < SOCIAL_LOSS_DEN
+            && asset.social_loss_dust_short_num < SOCIAL_LOSS_DEN
+    ))]
     #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &V16Result<AssetStateV16>| match result {
         Ok(a) => {
             let prior_reset = match leg.side {
@@ -1955,8 +2571,13 @@ impl V16Core {
                     } else {
                         a.oi_eff_long_q == asset.oi_eff_long_q.wrapping_sub(leg.basis_pos_q.unsigned_abs())
                             && a.loss_weight_sum_long == asset.loss_weight_sum_long.wrapping_sub(leg.loss_weight)
-                            && a.social_loss_dust_long_num == asset.social_loss_dust_long_num.wrapping_add(leg.b_rem)
-                            && (leg.b_rem == 0 || a.social_loss_dust_long_num < SOCIAL_LOSS_DEN)
+                            && a.social_loss_dust_long_num == if asset.social_loss_dust_long_num
+                                .wrapping_add(leg.b_rem) >= SOCIAL_LOSS_DEN {
+                                    asset.social_loss_dust_long_num.wrapping_add(leg.b_rem)
+                                        .wrapping_sub(SOCIAL_LOSS_DEN)
+                                } else {
+                                    asset.social_loss_dust_long_num.wrapping_add(leg.b_rem)
+                                }
                     })
                     && a.oi_eff_short_q == asset.oi_eff_short_q
                     && a.loss_weight_sum_short == asset.loss_weight_sum_short
@@ -1973,8 +2594,13 @@ impl V16Core {
                     } else {
                         a.oi_eff_short_q == asset.oi_eff_short_q.wrapping_sub(leg.basis_pos_q.unsigned_abs())
                             && a.loss_weight_sum_short == asset.loss_weight_sum_short.wrapping_sub(leg.loss_weight)
-                            && a.social_loss_dust_short_num == asset.social_loss_dust_short_num.wrapping_add(leg.b_rem)
-                            && (leg.b_rem == 0 || a.social_loss_dust_short_num < SOCIAL_LOSS_DEN)
+                            && a.social_loss_dust_short_num == if asset.social_loss_dust_short_num
+                                .wrapping_add(leg.b_rem) >= SOCIAL_LOSS_DEN {
+                                    asset.social_loss_dust_short_num.wrapping_add(leg.b_rem)
+                                        .wrapping_sub(SOCIAL_LOSS_DEN)
+                                } else {
+                                    asset.social_loss_dust_short_num.wrapping_add(leg.b_rem)
+                                }
                     })
                     && a.oi_eff_long_q == asset.oi_eff_long_q
                     && a.loss_weight_sum_long == asset.loss_weight_sum_long
@@ -2028,17 +2654,12 @@ impl V16Core {
                     && leg.epoch_snap.checked_add(1) == Some(asset.epoch_short)
             }
         };
-        let dust_after_clear = if !prior_reset_epoch && leg.b_rem != 0 {
+        let dust_after_clear = if !prior_reset_epoch {
             let current_dust = match leg.side {
                 SideV16::Long => asset.social_loss_dust_long_num,
                 SideV16::Short => asset.social_loss_dust_short_num,
             };
-            let new_dust = current_dust
-                .checked_add(leg.b_rem)
-                .ok_or(V16Error::ArithmeticOverflow)?;
-            if new_dust >= SOCIAL_LOSS_DEN {
-                return Err(V16Error::RecoveryRequired);
-            }
+            let (new_dust, _) = Self::kernel_fold_social_loss_dust(current_dust, leg.b_rem)?;
             Some(new_dust)
         } else {
             None
@@ -2098,6 +2719,156 @@ impl V16Core {
         Ok(asset)
     }
 
+    /// Terminal resolved clear for an ADL-scaled leg. ADL can reduce effective
+    /// side OI below stored settlement basis. Consume only the effective OI
+    /// that remains while removing the full stored record and current-epoch
+    /// loss weight. Prior-reset records leave already-reset aggregates alone.
+    #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &V16Result<AssetStateV16>| match result {
+        Ok(a) => {
+            let prior_reset = match leg.side {
+                SideV16::Long => asset.mode_long == SideModeV16::ResetPending
+                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_long),
+                SideV16::Short => asset.mode_short == SideModeV16::ResetPending
+                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_short),
+            };
+            let obligation = leg.basis_pos_q == 0 && leg.loss_weight != 0;
+            (match leg.side {
+                SideV16::Long => {
+                    a.oi_eff_long_q == if prior_reset { asset.oi_eff_long_q } else {
+                        asset.oi_eff_long_q.saturating_sub(leg.basis_pos_q.unsigned_abs())
+                    }
+                    && a.oi_eff_short_q == asset.oi_eff_short_q
+                    && a.stored_pos_count_long == asset.stored_pos_count_long.wrapping_sub(1)
+                    && a.stored_pos_count_short == asset.stored_pos_count_short
+                    && a.pending_obligation_count_long == if obligation {
+                        asset.pending_obligation_count_long.wrapping_sub(1)
+                    } else {
+                        asset.pending_obligation_count_long
+                    }
+                    && a.pending_obligation_count_short == asset.pending_obligation_count_short
+                    && a.loss_weight_sum_long == if prior_reset { asset.loss_weight_sum_long } else {
+                        asset.loss_weight_sum_long.wrapping_sub(leg.loss_weight)
+                    }
+                    && a.loss_weight_sum_short == asset.loss_weight_sum_short
+                    && a.social_loss_dust_long_num == asset.social_loss_dust_long_num
+                    && a.social_loss_dust_short_num == asset.social_loss_dust_short_num
+                }
+                SideV16::Short => {
+                    a.oi_eff_short_q == if prior_reset { asset.oi_eff_short_q } else {
+                        asset.oi_eff_short_q.saturating_sub(leg.basis_pos_q.unsigned_abs())
+                    }
+                    && a.oi_eff_long_q == asset.oi_eff_long_q
+                    && a.stored_pos_count_short == asset.stored_pos_count_short.wrapping_sub(1)
+                    && a.stored_pos_count_long == asset.stored_pos_count_long
+                    && a.pending_obligation_count_short == if obligation {
+                        asset.pending_obligation_count_short.wrapping_sub(1)
+                    } else {
+                        asset.pending_obligation_count_short
+                    }
+                    && a.pending_obligation_count_long == asset.pending_obligation_count_long
+                    && a.loss_weight_sum_short == if prior_reset { asset.loss_weight_sum_short } else {
+                        asset.loss_weight_sum_short.wrapping_sub(leg.loss_weight)
+                    }
+                    && a.loss_weight_sum_long == asset.loss_weight_sum_long
+                    && a.social_loss_dust_short_num == asset.social_loss_dust_short_num
+                    && a.social_loss_dust_long_num == asset.social_loss_dust_long_num
+                }
+            })
+                && a.market_id == asset.market_id
+                && a.retired_slot == asset.retired_slot
+                && a.lifecycle == asset.lifecycle
+                && a.raw_oracle_target_price == asset.raw_oracle_target_price
+                && a.effective_price == asset.effective_price
+                && a.fund_px_last == asset.fund_px_last
+                && a.slot_last == asset.slot_last
+                && a.a_long == asset.a_long
+                && a.a_short == asset.a_short
+                && a.k_long == asset.k_long
+                && a.k_short == asset.k_short
+                && a.f_long_num == asset.f_long_num
+                && a.f_short_num == asset.f_short_num
+                && a.k_epoch_start_long == asset.k_epoch_start_long
+                && a.k_epoch_start_short == asset.k_epoch_start_short
+                && a.f_epoch_start_long_num == asset.f_epoch_start_long_num
+                && a.f_epoch_start_short_num == asset.f_epoch_start_short_num
+                && a.b_long_num == asset.b_long_num
+                && a.b_short_num == asset.b_short_num
+                && a.b_epoch_start_long_num == asset.b_epoch_start_long_num
+                && a.b_epoch_start_short_num == asset.b_epoch_start_short_num
+                && a.stale_account_count_long == asset.stale_account_count_long
+                && a.stale_account_count_short == asset.stale_account_count_short
+                && a.social_loss_remainder_long_num == asset.social_loss_remainder_long_num
+                && a.social_loss_remainder_short_num == asset.social_loss_remainder_short_num
+                && a.explicit_unallocated_loss_long == asset.explicit_unallocated_loss_long
+                && a.explicit_unallocated_loss_short == asset.explicit_unallocated_loss_short
+                && a.epoch_long == asset.epoch_long
+                && a.epoch_short == asset.epoch_short
+                && a.mode_long == asset.mode_long
+                && a.mode_short == asset.mode_short
+        }
+        Err(_) => true,
+    }))]
+    pub(crate) fn kernel_clear_resolved_leg(
+        leg: PortfolioLegV16,
+        mut asset: AssetStateV16,
+    ) -> V16Result<AssetStateV16> {
+        let prior_reset_epoch = match leg.side {
+            SideV16::Long => {
+                asset.mode_long == SideModeV16::ResetPending
+                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_long)
+            }
+            SideV16::Short => {
+                asset.mode_short == SideModeV16::ResetPending
+                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_short)
+            }
+        };
+        match leg.side {
+            SideV16::Long => {
+                asset.stored_pos_count_long = asset
+                    .stored_pos_count_long
+                    .checked_sub(1)
+                    .ok_or(V16Error::CounterUnderflow)?;
+                if leg.basis_pos_q == 0 && leg.loss_weight != 0 {
+                    asset.pending_obligation_count_long = asset
+                        .pending_obligation_count_long
+                        .checked_sub(1)
+                        .ok_or(V16Error::CounterUnderflow)?;
+                }
+                if !prior_reset_epoch {
+                    asset.oi_eff_long_q = asset
+                        .oi_eff_long_q
+                        .saturating_sub(leg.basis_pos_q.unsigned_abs());
+                    asset.loss_weight_sum_long = asset
+                        .loss_weight_sum_long
+                        .checked_sub(leg.loss_weight)
+                        .ok_or(V16Error::CounterUnderflow)?;
+                }
+            }
+            SideV16::Short => {
+                asset.stored_pos_count_short = asset
+                    .stored_pos_count_short
+                    .checked_sub(1)
+                    .ok_or(V16Error::CounterUnderflow)?;
+                if leg.basis_pos_q == 0 && leg.loss_weight != 0 {
+                    asset.pending_obligation_count_short = asset
+                        .pending_obligation_count_short
+                        .checked_sub(1)
+                        .ok_or(V16Error::CounterUnderflow)?;
+                }
+                if !prior_reset_epoch {
+                    asset.oi_eff_short_q = asset
+                        .oi_eff_short_q
+                        .saturating_sub(leg.basis_pos_q.unsigned_abs());
+                    asset.loss_weight_sum_short = asset
+                        .loss_weight_sum_short
+                        .checked_sub(leg.loss_weight)
+                        .ok_or(V16Error::CounterUnderflow)?;
+                }
+            }
+        }
+        Ok(asset)
+    }
+
     /// PRODUCTION KERNEL: the attach-leg core — snapshot the side's basis
     /// anchors, gate the a-basis range, add open interest, and construct the
     /// new leg. Pure on (AssetStateV16, scalars); the attach glue calls
@@ -2112,7 +2883,9 @@ impl V16Core {
                 && l.b_rem == 0 && !l.b_stale && !l.stale
                 && (match side {
                     SideV16::Long => l.a_basis == asset.a_long && l.k_snap == asset.k_long
-                        && l.f_snap == asset.f_long_num && l.b_snap == asset.b_long_num
+                        && l.f_snap == asset.f_long_num
+                        && l.k_rem_num == 0 && l.f_rem_num == 0
+                        && l.b_snap == asset.b_long_num
                         && l.epoch_snap == asset.epoch_long && l.b_epoch_snap == asset.epoch_long
                         && a.oi_eff_long_q == asset.oi_eff_long_q.wrapping_add(abs_q)
                         && a.loss_weight_sum_long == asset.loss_weight_sum_long.wrapping_add(loss_weight)
@@ -2120,7 +2893,9 @@ impl V16Core {
                                 && a.oi_eff_short_q == asset.oi_eff_short_q
                         && a.loss_weight_sum_short == asset.loss_weight_sum_short,
                     SideV16::Short => l.a_basis == asset.a_short && l.k_snap == asset.k_short
-                        && l.f_snap == asset.f_short_num && l.b_snap == asset.b_short_num
+                        && l.f_snap == asset.f_short_num
+                        && l.k_rem_num == 0 && l.f_rem_num == 0
+                        && l.b_snap == asset.b_short_num
                         && l.epoch_snap == asset.epoch_short && l.b_epoch_snap == asset.epoch_short
                         && a.oi_eff_short_q == asset.oi_eff_short_q.wrapping_add(abs_q)
                         && a.loss_weight_sum_short == asset.loss_weight_sum_short.wrapping_add(loss_weight)
@@ -2210,6 +2985,8 @@ impl V16Core {
             a_basis,
             k_snap,
             f_snap,
+            k_rem_num: 0,
+            f_rem_num: 0,
             epoch_snap,
             loss_weight,
             b_snap,
@@ -2358,6 +3135,67 @@ impl V16Core {
             }
         }
         Ok((bucket, source))
+    }
+
+    pub(crate) fn prepare_counterparty_backing_expiry_delta(
+        mut bucket: BackingBucketV16,
+        mut source: SourceCreditStateV16,
+        now_slot: u64,
+    ) -> V16Result<(BackingBucketV16, SourceCreditStateV16)> {
+        if bucket.status != BackingBucketStatusV16::Fresh || now_slot < bucket.expiry_slot {
+            return Err(V16Error::Stale);
+        }
+        let expired_unliened = bucket.fresh_unliened_backing_num;
+        let expired_liened = bucket.valid_liened_backing_num;
+        let expired_total = expired_unliened
+            .checked_add(expired_liened)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        if source.fresh_reserved_backing_num < expired_total
+            || source.valid_liened_backing_num < expired_liened
+        {
+            return Err(V16Error::CounterUnderflow);
+        }
+        source.fresh_reserved_backing_num -= expired_total;
+        source.valid_liened_backing_num -= expired_liened;
+        source.impaired_liened_backing_num = source
+            .impaired_liened_backing_num
+            .checked_add(expired_liened)
+            .ok_or(V16Error::CounterOverflow)?;
+        bucket.fresh_unliened_backing_num = 0;
+        bucket.valid_liened_backing_num = 0;
+        bucket.impaired_liened_backing_num = bucket
+            .impaired_liened_backing_num
+            .checked_add(expired_liened)
+            .ok_or(V16Error::CounterOverflow)?;
+        bucket.status = if expired_liened == 0 && bucket.impaired_liened_backing_num == 0 {
+            BackingBucketStatusV16::Expired
+        } else {
+            BackingBucketStatusV16::Impaired
+        };
+        Ok((bucket, source))
+    }
+
+    /// One step of the compact source-domain expiry scan. The first sparse
+    /// tail terminates the scan; otherwise the first occupied lapsed Fresh
+    /// bucket is selected and terminates the scan.
+    #[cfg(any(kani, feature = "fuzz"))]
+    pub(crate) fn kernel_lapsed_source_backing_scan_step(
+        selected: Option<usize>,
+        sparse_tail: bool,
+        occupied: bool,
+        domain: usize,
+        bucket_status: BackingBucketStatusV16,
+        expiry_slot: u64,
+        current_slot: u64,
+    ) -> (Option<usize>, bool) {
+        if selected.is_some() || sparse_tail {
+            return (selected, true);
+        }
+        if occupied && bucket_status == BackingBucketStatusV16::Fresh && expiry_slot <= current_slot
+        {
+            return (Some(domain), true);
+        }
+        (None, false)
     }
 
     #[cfg(any(kani, feature = "fuzz"))]
@@ -2625,7 +3463,6 @@ impl V16Core {
         Ok((reservation, source))
     }
 
-    #[cfg(any(kani, feature = "fuzz"))]
     // Contract layer: insurance lien release un-encumbers reserved credit —
     // exact mirror of creation; reservation total and backing-side untouched.
     #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &V16Result<(InsuranceCreditReservationV16, SourceCreditStateV16)>| match result {
@@ -4190,24 +5027,7 @@ impl<'a> PortfolioV16View<'a> {
             if source.source_claim_bound_num.get() > domain_credit.positive_claim_bound_num {
                 return Err(V16Error::InvalidLeg);
             }
-            let proof = SourceCreditLienAggregateProofV16 {
-                domain: u16::try_from(d).map_err(|_| V16Error::ArithmeticOverflow)?,
-                source_claim_bound_num: source.source_claim_bound_num.get(),
-                face_claim_locked_num: source.source_claim_liened_num.get(),
-                counterparty_face_claim_locked_num: source
-                    .source_claim_counterparty_liened_num
-                    .get(),
-                insurance_face_claim_locked_num: source.source_claim_insurance_liened_num.get(),
-                effective_credit_reserved: source.source_lien_effective_reserved.get(),
-                counterparty_backing_reserved_num: source
-                    .source_lien_counterparty_backing_num
-                    .get(),
-                insurance_backing_reserved_num: source.source_lien_insurance_backing_num.get(),
-                impaired_face_claim_num: source.source_claim_impaired_num.get(),
-                impaired_effective_credit_reserved: source
-                    .source_lien_impaired_effective_reserved
-                    .get(),
-            };
+            let proof = Self::source_credit_lien_aggregate_proof(source, d)?;
             proof.validate()?;
             let locked = proof
                 .face_claim_locked_num
@@ -4254,6 +5074,26 @@ impl<'a> PortfolioV16View<'a> {
             slot_index += 1;
         }
         Ok(())
+    }
+
+    fn source_credit_lien_aggregate_proof(
+        source: PortfolioSourceDomainV16Account,
+        domain: usize,
+    ) -> V16Result<SourceCreditLienAggregateProofV16> {
+        Ok(SourceCreditLienAggregateProofV16 {
+            domain: u16::try_from(domain).map_err(|_| V16Error::ArithmeticOverflow)?,
+            source_claim_bound_num: source.source_claim_bound_num.get(),
+            face_claim_locked_num: source.source_claim_liened_num.get(),
+            counterparty_face_claim_locked_num: source.source_claim_counterparty_liened_num.get(),
+            insurance_face_claim_locked_num: source.source_claim_insurance_liened_num.get(),
+            effective_credit_reserved: source.source_lien_effective_reserved.get(),
+            counterparty_backing_reserved_num: source.source_lien_counterparty_backing_num.get(),
+            insurance_backing_reserved_num: source.source_lien_insurance_backing_num.get(),
+            impaired_face_claim_num: source.source_claim_impaired_num.get(),
+            impaired_effective_credit_reserved: source
+                .source_lien_impaired_effective_reserved
+                .get(),
+        })
     }
 
     fn source_claim_bound_sum_num(&self) -> V16Result<u128> {
@@ -4423,6 +5263,8 @@ pub struct PortfolioLegV16 {
     pub a_basis: u128,
     pub k_snap: i128,
     pub f_snap: i128,
+    pub k_rem_num: u128,
+    pub f_rem_num: u128,
     pub epoch_snap: u64,
     pub loss_weight: u128,
     pub b_snap: u128,
@@ -4442,6 +5284,8 @@ impl PortfolioLegV16 {
         a_basis: ADL_ONE,
         k_snap: 0,
         f_snap: 0,
+        k_rem_num: 0,
+        f_rem_num: 0,
         epoch_snap: 0,
         loss_weight: 0,
         b_snap: 0,
@@ -4460,6 +5304,8 @@ impl PortfolioLegV16 {
             && self.a_basis == ADL_ONE
             && self.k_snap == 0
             && self.f_snap == 0
+            && self.k_rem_num == 0
+            && self.f_rem_num == 0
             && self.epoch_snap == 0
             && self.loss_weight == 0
             && self.b_snap == 0
@@ -4824,7 +5670,18 @@ pub struct AutoCrankObservationV16 {
 pub struct AutoCrankWorkV16<'a> {
     pub now_slot: u64,
     pub observations: &'a [AutoCrankObservationV16],
+    /// The trusted wrapper already authenticated and applied its bounded market-accrual stage in
+    /// this transaction. The selected account action must not accrue a second segment.
+    pub observations_preaccrued: bool,
     pub resolved_close_fee_rate_per_slot: u128,
+}
+
+#[inline(always)]
+const fn auto_crank_skip_post_action_accrual(
+    observations_preaccrued: bool,
+    selected_observation_supplied: bool,
+) -> bool {
+    observations_preaccrued || !selected_observation_supplied
 }
 
 /// The bounded progress step the engine SELECTED from current state (engine.md).
@@ -4836,6 +5693,9 @@ pub enum AutoCrankPlanV16 {
     RefreshAccount {
         asset_index: Option<usize>,
     },
+    AdvanceRecoveryClose {
+        asset_index: usize,
+    },
     SettleBChunk {
         asset_index: usize,
     },
@@ -4845,16 +5705,18 @@ pub enum AutoCrankPlanV16 {
     DeclareRecovery {
         reason: PermissionlessRecoveryReasonV16,
     },
+    FinalizeRecovery,
     CloseResolved,
 }
 
 /// The outcome of one self-classifying crank step: nothing actionable, a
 /// permissionless-progress outcome (refresh / settle-B / liquidate / recovery),
-/// or a resolved-close outcome.
+/// a Recovery-to-Resolved transition, or a resolved-close outcome.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AutoCrankOutcomeV16 {
     NoAction,
     Progressed(PermissionlessProgressOutcomeV16),
+    RecoveryResolved,
     ResolvedClose(ResolvedCloseOutcomeV16),
 }
 
@@ -4906,7 +5768,9 @@ struct PositionDeltaLookupV16 {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum AccountRefreshCertOutcomeV16 {
     Certified(HealthCertV16),
+    LegSettled { asset_index: usize },
     BChunk(AccountBSettlementChunkV16),
+    SourceBackingExpired(usize),
 }
 
 #[cfg(kani)]
@@ -5483,6 +6347,7 @@ pub enum BResidualStepV16 {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PermissionlessCrankActionV16 {
     Refresh,
+    AdvanceRecoveryClose { asset_index: usize },
     SettleB { asset_index: usize },
     Liquidate(LiquidationRequestV16),
     Recover(PermissionlessRecoveryReasonV16),
@@ -6126,6 +6991,7 @@ pub struct EngineAssetSlotV16Account {
     pub insurance_domain_spent_short: V16PodU128,
     pub pending_domain_loss_barrier_long: V16PodU64,
     pub pending_domain_loss_barrier_short: V16PodU64,
+    pub bankruptcy_hlock_active: u8,
     pub source_credit_long: SourceCreditStateV16Account,
     pub source_credit_short: SourceCreditStateV16Account,
     pub backing_long: BackingBucketV16Account,
@@ -6196,6 +7062,7 @@ impl EngineAssetSlotV16Account {
             && self.insurance_domain_spent_short.get() == 0
             && self.pending_domain_loss_barrier_long.get() == 0
             && self.pending_domain_loss_barrier_short.get() == 0
+            && self.bankruptcy_hlock_active == 0
             && Self::source_credit_account_is_empty_for_activation(self.source_credit_long)
             && Self::source_credit_account_is_empty_for_activation(self.source_credit_short)
             && Self::backing_bucket_account_is_empty_for_activation(self.backing_long)
@@ -6228,6 +7095,7 @@ impl EngineAssetSlotV16Account {
             insurance_domain_spent_short: V16PodU128::default(),
             pending_domain_loss_barrier_long: V16PodU64::default(),
             pending_domain_loss_barrier_short: V16PodU64::default(),
+            bankruptcy_hlock_active: 0,
             source_credit_long: SourceCreditStateV16Account::from_runtime(
                 &SourceCreditStateV16::EMPTY,
             ),
@@ -6398,6 +7266,9 @@ pub struct MarketGroupV16HeaderAccount {
     pub funding_epoch: V16PodU64,
     pub slot_last: V16PodU64,
     pub current_slot: V16PodU64,
+    pub bankruptcy_hlock_asset_count: V16PodU32,
+    // 0 = inactive, 1 = active with an unattributed event, 2 = active and fully attributed.
+    // Per-asset bits identify attributed events; this count keeps teardown constant-time.
     pub bankruptcy_hlock_active: u8,
     pub threshold_stress_active: u8,
     pub loss_stale_active: u8,
@@ -6511,6 +7382,7 @@ impl MarketGroupV16HeaderAccount {
             funding_epoch: V16PodU64::default(),
             slot_last: V16PodU64::new(init_slot),
             current_slot: V16PodU64::new(init_slot),
+            bankruptcy_hlock_asset_count: V16PodU32::default(),
             bankruptcy_hlock_active: 0,
             threshold_stress_active: 0,
             loss_stale_active: 0,
@@ -6610,6 +7482,32 @@ impl MarketGroupV16HeaderAccount {
                 .is_zero_fill_or_canonical_disabled_slot()?
         {
             return Err(V16Error::InvalidConfig);
+        }
+        Ok(())
+    }
+
+    fn clear_attributed_bankruptcy_asset_for_reuse(
+        &mut self,
+        slot: &mut EngineAssetSlotV16Account,
+    ) -> V16Result<()> {
+        validate_bankruptcy_hlock_summary(
+            self.bankruptcy_hlock_active,
+            self.bankruptcy_hlock_asset_count.get(),
+        )?;
+        if !bankruptcy_asset_slot_has_lock_state(slot)? {
+            return Ok(());
+        }
+        let next_count = self
+            .bankruptcy_hlock_asset_count
+            .get()
+            .checked_sub(1)
+            .ok_or(V16Error::CounterUnderflow)?;
+        slot.bankruptcy_hlock_active = 0;
+        self.bankruptcy_hlock_asset_count = V16PodU32::new(next_count);
+        if next_count == 0
+            && bankruptcy_hlock_fully_attributed_from_wire(self.bankruptcy_hlock_active)?
+        {
+            self.bankruptcy_hlock_active = 0;
         }
         Ok(())
     }
@@ -6714,6 +7612,7 @@ impl MarketGroupV16HeaderAccount {
         asset.effective_price = authenticated_price;
         asset.fund_px_last = authenticated_price;
         asset.slot_last = now_slot;
+        self.clear_attributed_bankruptcy_asset_for_reuse(slot)?;
         *slot = EngineAssetSlotV16Account {
             asset: AssetStateV16Account::from_runtime(&asset),
             insurance_domain_budget_long: V16PodU128::default(),
@@ -6722,6 +7621,7 @@ impl MarketGroupV16HeaderAccount {
             insurance_domain_spent_short: V16PodU128::default(),
             pending_domain_loss_barrier_long: V16PodU64::default(),
             pending_domain_loss_barrier_short: V16PodU64::default(),
+            bankruptcy_hlock_active: 0,
             source_credit_long: SourceCreditStateV16Account::from_runtime(
                 &SourceCreditStateV16::EMPTY,
             ),
@@ -6770,6 +7670,7 @@ struct MarketAggregateTotalsV16 {
     source_insurance_credit_reserved_atoms: u128,
     insurance_domain_budget_remaining_atoms: u128,
     resolved_payout_blocker_count: u64,
+    bankruptcy_hlock_asset_count: u32,
 }
 
 impl<'a, T> MarketGroupV16View<'a, T> {
@@ -6780,7 +7681,15 @@ impl<'a, T> MarketGroupV16View<'a, T> {
             self.header.config.max_market_slots.get() as usize,
         )?;
         self.header.config.try_to_runtime_shape()?;
-        decode_bool(self.header.bankruptcy_hlock_active)?;
+        validate_bankruptcy_hlock_summary(
+            self.header.bankruptcy_hlock_active,
+            self.header.bankruptcy_hlock_asset_count.get(),
+        )?;
+        if self.header.bankruptcy_hlock_asset_count.get()
+            > self.header.config.max_market_slots.get()
+        {
+            return Err(V16Error::InvalidConfig);
+        }
         decode_bool(self.header.threshold_stress_active)?;
         decode_bool(self.header.loss_stale_active)?;
         decode_bool(self.header.payout_snapshot_captured)?;
@@ -6890,6 +7799,7 @@ impl<'a, T> MarketGroupV16View<'a, T> {
                 != self.header.insurance_domain_budget_remaining_total.get()
             || totals.resolved_payout_blocker_count
                 != self.header.resolved_payout_blocker_count.get()
+            || totals.bankruptcy_hlock_asset_count != self.header.bankruptcy_hlock_asset_count.get()
         {
             return Err(V16Error::InvalidConfig);
         }
@@ -6904,6 +7814,10 @@ impl<'a, T> MarketGroupV16View<'a, T> {
         let mut i = 0usize;
         while i < self.markets.len() {
             let slot = self.markets[i].engine_slot();
+            totals.bankruptcy_hlock_asset_count = totals
+                .bankruptcy_hlock_asset_count
+                .checked_add(u32::from(bankruptcy_asset_slot_has_lock_state(slot)?))
+                .ok_or(V16Error::CounterOverflow)?;
             totals.resolved_payout_blocker_count = totals
                 .resolved_payout_blocker_count
                 .checked_add(slot_resolved_payout_blockers_v16(slot)?)
@@ -7040,6 +7954,10 @@ impl<'a, T> MarketGroupV16View<'a, T> {
             || (mode == MarketModeV16::Live && asset.oi_eff_long_q != asset.oi_eff_short_q)
             || asset.loss_weight_sum_long > SOCIAL_LOSS_DEN
             || asset.loss_weight_sum_short > SOCIAL_LOSS_DEN
+            || asset.social_loss_remainder_long_num >= SOCIAL_LOSS_DEN
+            || asset.social_loss_remainder_short_num >= SOCIAL_LOSS_DEN
+            || asset.social_loss_dust_long_num >= SOCIAL_LOSS_DEN
+            || asset.social_loss_dust_short_num >= SOCIAL_LOSS_DEN
             || (asset.oi_eff_long_q != 0 && asset.loss_weight_sum_long == 0)
             || (asset.oi_eff_short_q != 0 && asset.loss_weight_sum_short == 0)
             || (asset.loss_weight_sum_long != 0 && asset.stored_pos_count_long == 0)
@@ -7138,6 +8056,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             V16PodU128::new(totals.insurance_domain_budget_remaining_atoms);
         self.header.resolved_payout_blocker_count =
             V16PodU64::new(totals.resolved_payout_blocker_count);
+        self.header.bankruptcy_hlock_asset_count =
+            V16PodU32::new(totals.bankruptcy_hlock_asset_count);
         Ok(())
     }
 
@@ -7468,6 +8388,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
+    #[cfg(any(kani, feature = "fuzz"))]
     fn refresh_source_credit_domain_after_mutation(&mut self, domain: usize) -> V16Result<()> {
         self.recompute_source_credit_domain_after_mutation(domain)?;
         self.reservation_encumbrance_proof_for_domain(domain)?
@@ -7687,46 +8608,30 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.validate_shape()
     }
 
+    fn expire_source_backing_bucket_core_not_atomic(
+        &mut self,
+        domain: usize,
+        now_slot: u64,
+    ) -> V16Result<()> {
+        let (bucket, source) = V16Core::prepare_counterparty_backing_expiry_delta(
+            self.backing_bucket_for_domain(domain)?,
+            self.source_credit_for_domain(domain)?,
+            now_slot,
+        )?;
+        self.set_backing_bucket_for_domain(domain, bucket)?;
+        self.set_source_credit_for_domain(domain, source)?;
+        self.recompute_source_credit_domain_after_mutation(domain)?;
+        self.reservation_encumbrance_proof_for_domain(domain)?
+            .validate()
+    }
+
     pub fn expire_source_backing_bucket_not_atomic(
         &mut self,
         domain: usize,
         now_slot: u64,
     ) -> V16Result<()> {
-        let mut bucket = self.backing_bucket_for_domain(domain)?;
-        if bucket.status != BackingBucketStatusV16::Fresh || now_slot < bucket.expiry_slot {
-            return Err(V16Error::Stale);
-        }
-        let mut source = self.source_credit_for_domain(domain)?;
-        let expired_unliened = bucket.fresh_unliened_backing_num;
-        let expired_liened = bucket.valid_liened_backing_num;
-        let expired_total = expired_unliened
-            .checked_add(expired_liened)
-            .ok_or(V16Error::ArithmeticOverflow)?;
-        if source.fresh_reserved_backing_num < expired_total
-            || source.valid_liened_backing_num < expired_liened
-        {
-            return Err(V16Error::CounterUnderflow);
-        }
-        source.fresh_reserved_backing_num -= expired_total;
-        source.valid_liened_backing_num -= expired_liened;
-        source.impaired_liened_backing_num = source
-            .impaired_liened_backing_num
-            .checked_add(expired_liened)
-            .ok_or(V16Error::CounterOverflow)?;
-        bucket.fresh_unliened_backing_num = 0;
-        bucket.valid_liened_backing_num = 0;
-        bucket.impaired_liened_backing_num = bucket
-            .impaired_liened_backing_num
-            .checked_add(expired_liened)
-            .ok_or(V16Error::CounterOverflow)?;
-        bucket.status = if expired_liened == 0 && bucket.impaired_liened_backing_num == 0 {
-            BackingBucketStatusV16::Expired
-        } else {
-            BackingBucketStatusV16::Impaired
-        };
-        self.set_backing_bucket_for_domain(domain, bucket)?;
-        self.set_source_credit_for_domain(domain, source)?;
-        self.refresh_source_credit_domain_after_mutation(domain)
+        self.expire_source_backing_bucket_core_not_atomic(domain, now_slot)?;
+        self.validate_shape()
     }
 
     #[cfg(any(kani, feature = "fuzz"))]
@@ -8026,8 +8931,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
-    #[cfg(any(kani, feature = "fuzz"))]
-    pub fn release_source_credit_lien_from_insurance_not_atomic(
+    fn release_source_credit_lien_from_insurance_core_not_atomic(
         &mut self,
         domain: usize,
         amount: u128,
@@ -8055,6 +8959,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.set_insurance_reservation_for_domain(domain, reservation)?;
         self.set_source_credit_for_domain(domain, source)?;
         self.header.risk_epoch = V16PodU64::new(next_risk_epoch);
+        Ok(())
+    }
+
+    #[cfg(any(kani, feature = "fuzz"))]
+    pub fn release_source_credit_lien_from_insurance_not_atomic(
+        &mut self,
+        domain: usize,
+        amount: u128,
+    ) -> V16Result<()> {
+        self.release_source_credit_lien_from_insurance_core_not_atomic(domain, amount)?;
         self.validate_shape()
     }
 
@@ -8361,6 +9275,34 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(total_fee)
     }
 
+    fn account_source_domain_count(account: &PortfolioV16View<'_>) -> usize {
+        let mut count = 0usize;
+        while count < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let source = account.source_domains()[count];
+            if source.has_default_sparse_tag() && !source.is_occupied() {
+                break;
+            }
+            count += 1;
+        }
+        count
+    }
+
+    fn account_has_pending_kf_settlement(&self, account: &PortfolioV16View<'_>) -> V16Result<bool> {
+        let mut slot = 0usize;
+        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg = account.header.legs[slot].try_to_runtime()?;
+            if leg.active {
+                let asset = self.asset_state(leg.asset_index as usize)?;
+                let (target_k, target_f) = Self::kf_target_for_leg_from_asset(asset, leg)?;
+                if leg.k_snap != target_k || leg.f_snap != target_f {
+                    return Ok(true);
+                }
+            }
+            slot += 1;
+        }
+        Ok(false)
+    }
+
     fn account_source_claim_bound_sum_num(account: &PortfolioV16View<'_>) -> V16Result<u128> {
         let mut sum = 0u128;
         let mut d = 0usize;
@@ -8379,6 +9321,75 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
 
     fn account_has_source_claims(account: &PortfolioV16View<'_>) -> V16Result<bool> {
         Ok(Self::account_source_claim_bound_sum_num(account)? != 0)
+    }
+
+    fn first_live_account_source_backing_reconcile_action(
+        &self,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<Option<(usize, bool, bool)>> {
+        // A valid Fresh bucket always contributes nonzero fresh backing to the
+        // market aggregate. Once that aggregate is zero, only an account-local
+        // counterparty lien against an already-Impaired bucket can remain
+        // actionable. Avoid decoding every market bucket for the common clean
+        // post-reconciliation path.
+        if self.header.source_fresh_backing_total_num.get() == 0 {
+            let mut slot = 0usize;
+            while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
+                let source = account.source_domains()[slot];
+                if source.has_default_sparse_tag() && !source.is_occupied() {
+                    return Ok(None);
+                }
+                if source.is_occupied() && source.source_lien_counterparty_backing_num.get() != 0 {
+                    break;
+                }
+                slot += 1;
+            }
+            if slot == PORTFOLIO_SOURCE_DOMAIN_CAP {
+                return Ok(None);
+            }
+        }
+        let current_slot = self.header.current_slot.get();
+        let mut selected = None;
+        let mut slot = 0usize;
+        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let source = account.source_domains()[slot];
+            let occupied = source.is_occupied();
+            let sparse_tail = source.has_default_sparse_tag() && !occupied;
+            let (domain, counterparty_backing_num, bucket_status, expiry_slot) = if occupied {
+                let domain = source.domain.get() as usize;
+                let bucket = self.backing_bucket_for_domain(domain)?;
+                (
+                    domain,
+                    source.source_lien_counterparty_backing_num.get(),
+                    bucket.status,
+                    bucket.expiry_slot,
+                )
+            } else {
+                (0, 0, BackingBucketStatusV16::Empty, 0)
+            };
+            let (next_selected, stop) = V16Core::kernel_live_source_backing_reconcile_scan_step(
+                selected,
+                sparse_tail,
+                occupied,
+                domain,
+                counterparty_backing_num,
+                bucket_status,
+                expiry_slot,
+                current_slot,
+            );
+            selected = next_selected;
+            if stop {
+                break;
+            }
+            slot += 1;
+        }
+        Ok(selected)
+    }
+
+    fn account_has_lapsed_source_backing(&self, account: &PortfolioV16View<'_>) -> V16Result<bool> {
+        Ok(self
+            .first_live_account_source_backing_reconcile_action(account)?
+            .is_some())
     }
 
     fn source_claim_unliened_num(account: &PortfolioV16View<'_>, domain: usize) -> V16Result<u128> {
@@ -8468,35 +9479,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .ok_or(V16Error::CounterOverflow)?,
         );
         source.source_lien_insurance_backing_num = V16PodU128::new(0);
-        // Genesis counter: move the pro-rata live capital-at-risk fee revenue to the impaired counter,
-        // matched to the backing capital that actually crystallized. Compute BEFORE shrinking the live
-        // effective reserve (the denominator). Floor rounding keeps dust with the still-live counter
-        // (conservative for residual farming; never over-credits).
-        let live_effective_before = source.source_lien_effective_reserved.get();
-        let live_fee = source.source_lien_capital_at_risk_fee_revenue.get();
-        let fee_to_crystallize = if live_effective_before == 0 || live_fee == 0 {
-            0
-        } else {
-            U256::from_u128(live_fee)
-                .checked_mul(U256::from_u128(effective))
-                .ok_or(V16Error::ArithmeticOverflow)?
-                .checked_div(U256::from_u128(live_effective_before))
-                .ok_or(V16Error::ArithmeticOverflow)?
-                .try_into_u128()
-                .ok_or(V16Error::ArithmeticOverflow)?
-        };
-        source.source_lien_capital_at_risk_fee_revenue = V16PodU128::new(
-            live_fee
-                .checked_sub(fee_to_crystallize)
-                .ok_or(V16Error::CounterUnderflow)?,
-        );
-        source.source_lien_impaired_capital_at_risk_fee_revenue = V16PodU128::new(
-            source
-                .source_lien_impaired_capital_at_risk_fee_revenue
-                .get()
-                .checked_add(fee_to_crystallize)
-                .ok_or(V16Error::CounterOverflow)?,
-        );
+        V16Core::crystallize_source_lien_fee_for_effective(source, effective)?;
         source.source_lien_effective_reserved = V16PodU128::new(
             source
                 .source_lien_effective_reserved
@@ -8513,6 +9496,55 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         );
         account.header.health_cert.valid = 0;
         Ok(effective)
+    }
+
+    fn impair_account_source_credit_counterparty_lien_fields(
+        account: &mut PortfolioV16ViewMut<'_>,
+        domain: usize,
+    ) -> V16Result<u128> {
+        let slot = account
+            .source_domain_slot(domain)?
+            .ok_or(V16Error::InvalidLeg)?;
+        let (source, effective) = V16Core::prepare_account_counterparty_lien_impairment(
+            account.header.source_domains[slot],
+        )?;
+        account.header.source_domains[slot] = source;
+        account.header.health_cert.valid = 0;
+        Ok(effective)
+    }
+
+    fn reconcile_first_live_account_source_backing_expiry_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+    ) -> V16Result<Option<usize>> {
+        if decode_market_mode(self.header.mode)? != MarketModeV16::Live {
+            return Ok(None);
+        }
+        let current_slot = self.header.current_slot.get();
+        let Some((domain, newly_lapsed, impair_account)) =
+            self.first_live_account_source_backing_reconcile_action(&account.as_view())?
+        else {
+            return Ok(None);
+        };
+        let source = account.as_view().source_domain(domain)?;
+        if impair_account {
+            self.collect_account_backing_utilization_fee_for_domain_not_atomic(account, domain)?;
+        }
+        if newly_lapsed {
+            self.expire_source_backing_bucket_core_not_atomic(domain, current_slot)?;
+        }
+        if impair_account {
+            let impaired_backing = self
+                .backing_bucket_for_domain(domain)?
+                .impaired_liened_backing_num;
+            if impaired_backing < source.source_lien_counterparty_backing_num.get() {
+                return Err(V16Error::CounterUnderflow);
+            }
+            Self::impair_account_source_credit_counterparty_lien_fields(account, domain)?;
+        }
+        account.validate_with_market(&self.as_view())?;
+        self.validate_shape()?;
+        Ok(Some(domain))
     }
 
     // Release one domain's counterparty/insurance source-credit lien (returning the
@@ -8558,6 +9590,156 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
+    fn decrement_account_source_claim_for_domain_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        slot: usize,
+        domain: usize,
+        burn_num: u128,
+    ) -> V16Result<()> {
+        if burn_num == 0 {
+            return Ok(());
+        }
+        if slot >= PORTFOLIO_SOURCE_DOMAIN_CAP {
+            return Err(V16Error::InvalidLeg);
+        }
+        let source = &mut account.header.source_domains[slot];
+        source.source_claim_bound_num = V16PodU128::new(
+            source
+                .source_claim_bound_num
+                .get()
+                .checked_sub(burn_num)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        let mut source_credit = self.source_credit_for_domain(domain)?;
+        source_credit.positive_claim_bound_num = source_credit
+            .positive_claim_bound_num
+            .checked_sub(burn_num)
+            .ok_or(V16Error::CounterUnderflow)?;
+        source_credit.exact_positive_claim_num = source_credit
+            .exact_positive_claim_num
+            .checked_sub(burn_num.min(source_credit.exact_positive_claim_num))
+            .ok_or(V16Error::CounterUnderflow)?;
+        self.set_source_credit_for_domain(domain, source_credit)?;
+        account.reset_source_domain_slot_if_empty(slot);
+        self.recompute_source_credit_domain_after_mutation(domain)
+    }
+
+    fn burn_account_source_lien_face_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        slot: usize,
+        domain: usize,
+        face_burn_num: u128,
+    ) -> V16Result<()> {
+        if face_burn_num == 0 {
+            return Ok(());
+        }
+        if slot >= PORTFOLIO_SOURCE_DOMAIN_CAP {
+            return Err(V16Error::InvalidLeg);
+        }
+        let source_before = account.header.source_domains[slot];
+        if face_burn_num > source_before.source_claim_liened_num.get() {
+            return Err(V16Error::CounterUnderflow);
+        }
+        let (
+            counterparty_face_burn,
+            insurance_face_burn,
+            counterparty_backing_release,
+            insurance_backing_release,
+            backing_release_num,
+        ) = V16Core::source_lien_face_burn_plan(
+            source_before.source_claim_counterparty_liened_num.get(),
+            source_before.source_claim_insurance_liened_num.get(),
+            source_before.source_lien_counterparty_backing_num.get(),
+            source_before.source_lien_insurance_backing_num.get(),
+            face_burn_num,
+        )?;
+
+        if counterparty_backing_release != 0 {
+            // Unwinding returns already-liened principal; it does not extend new
+            // credit, so expiry must not block a loss from being recognized.
+            self.release_source_credit_lien_from_counterparty_terminal_not_atomic(
+                domain,
+                counterparty_backing_release,
+            )?;
+        }
+        if insurance_backing_release != 0 {
+            if decode_market_mode(self.header.mode)? == MarketModeV16::Resolved {
+                self.release_source_credit_lien_from_insurance_terminal_not_atomic(
+                    domain,
+                    insurance_backing_release,
+                )?;
+            } else {
+                self.release_source_credit_lien_from_insurance_core_not_atomic(
+                    domain,
+                    insurance_backing_release,
+                )?;
+            }
+        }
+
+        let effective_release = backing_release_num / BOUND_SCALE;
+        let counterparty_backing_after = source_before
+            .source_lien_counterparty_backing_num
+            .get()
+            .checked_sub(counterparty_backing_release)
+            .ok_or(V16Error::CounterUnderflow)?;
+        let fee_revenue_after = V16Core::source_lien_fee_after_backing_release(
+            source_before.source_lien_capital_at_risk_fee_revenue.get(),
+            source_before.source_lien_counterparty_backing_num.get(),
+            counterparty_backing_after,
+        )?;
+
+        let source = &mut account.header.source_domains[slot];
+        source.source_claim_liened_num = V16PodU128::new(
+            source
+                .source_claim_liened_num
+                .get()
+                .checked_sub(face_burn_num)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        source.source_claim_counterparty_liened_num = V16PodU128::new(
+            source
+                .source_claim_counterparty_liened_num
+                .get()
+                .checked_sub(counterparty_face_burn)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        source.source_claim_insurance_liened_num = V16PodU128::new(
+            source
+                .source_claim_insurance_liened_num
+                .get()
+                .checked_sub(insurance_face_burn)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        source.source_lien_effective_reserved = V16PodU128::new(
+            source
+                .source_lien_effective_reserved
+                .get()
+                .checked_sub(effective_release)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        source.source_lien_counterparty_backing_num = V16PodU128::new(counterparty_backing_after);
+        source.source_lien_insurance_backing_num = V16PodU128::new(
+            source
+                .source_lien_insurance_backing_num
+                .get()
+                .checked_sub(insurance_backing_release)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        source.source_lien_capital_at_risk_fee_revenue = V16PodU128::new(fee_revenue_after);
+        if counterparty_backing_after == 0 {
+            source.source_lien_fee_last_slot = V16PodU64::new(0);
+        }
+        account.header.health_cert.valid = 0;
+        self.decrement_account_source_claim_for_domain_not_atomic(
+            account,
+            slot,
+            domain,
+            face_burn_num,
+        )
+    }
+
     fn burn_account_source_claim_bound_num(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
@@ -8585,45 +9767,21 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
             let d = source_snapshot.domain.get() as usize;
             self.domain_asset_side(d)?;
-            // Terminal wind-down: a counterparty/insurance source-credit lien is created
-            // in Live to collateralize unrealized PnL and can only be released in Live.
-            // Forcing the winner's claim to zero in Resolved (close_resolved ->
-            // set_account_pnl(0)) would otherwise dead-lock on the liened portion
-            // (burn can only consume the unliened part -> LockActive forever). In
-            // Resolved mode release the domain's lien (returning backing) so the claim
-            // is burnable and the account/market can actually wind down.
-            if decode_market_mode(self.header.mode)? == MarketModeV16::Resolved
-                && account.header.source_domains[slot]
-                    .source_claim_liened_num
-                    .get()
-                    != 0
-            {
-                self.release_account_source_credit_lien_for_domain_not_atomic(account, d)?;
-            }
             let burnable = Self::source_claim_unliened_num(&account.as_view(), d)?;
             let burn = burnable.min(burn_num);
             if burn != 0 {
-                let source = &mut account.header.source_domains[slot];
-                source.source_claim_bound_num = V16PodU128::new(
-                    source
-                        .source_claim_bound_num
-                        .get()
-                        .checked_sub(burn)
-                        .ok_or(V16Error::CounterUnderflow)?,
-                );
-                let mut source_credit = self.source_credit_for_domain(d)?;
-                source_credit.positive_claim_bound_num = source_credit
-                    .positive_claim_bound_num
-                    .checked_sub(burn)
-                    .ok_or(V16Error::CounterUnderflow)?;
-                source_credit.exact_positive_claim_num = source_credit
-                    .exact_positive_claim_num
-                    .checked_sub(burn.min(source_credit.exact_positive_claim_num))
-                    .ok_or(V16Error::CounterUnderflow)?;
-                self.set_source_credit_for_domain(d, source_credit)?;
+                self.decrement_account_source_claim_for_domain_not_atomic(account, slot, d, burn)?;
                 burn_num -= burn;
-                account.reset_source_domain_slot_if_empty(slot);
-                self.recompute_source_credit_domain_after_mutation(d)?;
+            }
+            if burn_num != 0 {
+                let liened_burn = account.header.source_domains[slot]
+                    .source_claim_liened_num
+                    .get()
+                    .min(burn_num);
+                if liened_burn != 0 {
+                    self.burn_account_source_lien_face_not_atomic(account, slot, d, liened_burn)?;
+                    burn_num -= liened_burn;
+                }
             }
             if burn_num != 0 {
                 let (impaired_burn, impaired_effective_burn) =
@@ -9235,7 +10393,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if account.header.pnl.get() >= 0 {
             return Ok(0);
         }
-        self.header.bankruptcy_hlock_active = 1;
+        self.mark_attributed_bankruptcy_hlock(asset_index)?;
         let domain_available = self.available_domain_insurance(domain)?;
         let (_, spent_before) = self.domain_insurance_budget_spent(domain)?;
         // PRODUCTION KERNEL: insurance-draw core (capped by deficit AND domain
@@ -9262,14 +10420,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(used)
     }
 
-    fn preflight_liquidation_residual_durability(
-        &mut self,
+    fn liquidation_residual_after_principal_and_insurance(
+        &self,
         asset_index: usize,
         bankrupt_side: SideV16,
         account: &PortfolioV16View<'_>,
-    ) -> V16Result<()> {
+    ) -> V16Result<u128> {
         let domain = self.insurance_domain_index(asset_index, opposite_side(bankrupt_side))?;
-        let residual_after_principal_and_insurance = if account.header.pnl.get() < 0 {
+        Ok(if account.header.pnl.get() < 0 {
             account
                 .header
                 .pnl
@@ -9279,16 +10437,46 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .saturating_sub(self.available_domain_insurance(domain)?)
         } else {
             0
-        };
+        })
+    }
+
+    fn liquidation_residual_exceeds_single_step_capacity(
+        &self,
+        asset_index: usize,
+        bankrupt_side: SideV16,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<bool> {
+        let residual_after_principal_and_insurance = self
+            .liquidation_residual_after_principal_and_insurance(
+                asset_index,
+                bankrupt_side,
+                account,
+            )?;
         if residual_after_principal_and_insurance == 0 {
-            return Ok(());
+            return Ok(false);
+        }
+        if self.header.config.public_b_chunk_atoms.get() < residual_after_principal_and_insurance {
+            return Ok(true);
         }
         let capacity = self.bankruptcy_residual_single_step_capacity(
             asset_index,
             bankrupt_side,
             residual_after_principal_and_insurance,
         )?;
-        if capacity < residual_after_principal_and_insurance {
+        Ok(capacity < residual_after_principal_and_insurance)
+    }
+
+    fn preflight_liquidation_residual_durability(
+        &mut self,
+        asset_index: usize,
+        bankrupt_side: SideV16,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<()> {
+        if self.liquidation_residual_exceeds_single_step_capacity(
+            asset_index,
+            bankrupt_side,
+            account,
+        )? {
             self.declare_permissionless_recovery(
                 PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
             )?;
@@ -9461,14 +10649,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             let unliened = Self::source_claim_unliened_num(&account.as_view(), d)?;
             if rate != 0 && unliened != 0 {
                 self.validate_source_domain_ledger_current(d)?;
-                let soft_num = U256::from_u128(unliened)
-                    .checked_mul(U256::from_u128(rate))
-                    .and_then(|v| v.checked_div(U256::from_u128(CREDIT_RATE_SCALE)))
-                    .and_then(|v| v.try_into_u128())
-                    .ok_or(V16Error::ArithmeticOverflow)?;
-                let by_claim = soft_num / BOUND_SCALE;
-                let by_backing = self.source_credit_available_backing_num(d)? / BOUND_SCALE;
-                let take = remaining.min(by_claim).min(by_backing);
+                let take = V16Core::source_credit_lien_allocation_take(
+                    remaining,
+                    unliened,
+                    self.source_credit_available_backing_num(d)?,
+                    rate,
+                )?;
                 if take != 0 {
                     let (face_num, backing_num) =
                         V16Core::source_credit_lien_amounts_for_effective(take, rate)?;
@@ -9608,13 +10794,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
-    fn create_account_source_credit_lien_for_effective_not_atomic(
+    // The allocating caller validates once before this per-domain core runs, and
+    // finish_trade_checks_not_atomic performs the committed-state audit afterward.
+    fn create_account_source_credit_lien_for_effective_core_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
         domain: usize,
         effective_credit: u128,
     ) -> V16Result<()> {
-        account.validate_with_market(&self.as_view())?;
         self.domain_asset_side(domain)?;
         if effective_credit == 0 {
             return Ok(());
@@ -9639,7 +10826,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             self.header.current_slot.get(),
         )?;
         account.header.health_cert.valid = 0;
-        account.validate_with_market(&self.as_view())
+        Ok(())
     }
 
     fn create_account_source_credit_lien_for_effective_any_not_atomic(
@@ -9664,16 +10851,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             let unliened = Self::source_claim_unliened_num(&account.as_view(), d)?;
             if rate != 0 && unliened != 0 {
                 self.validate_source_domain_ledger_current(d)?;
-                let soft_num = U256::from_u128(unliened)
-                    .checked_mul(U256::from_u128(rate))
-                    .and_then(|v| v.checked_div(U256::from_u128(CREDIT_RATE_SCALE)))
-                    .and_then(|v| v.try_into_u128())
-                    .ok_or(V16Error::ArithmeticOverflow)?;
-                let by_claim = soft_num / BOUND_SCALE;
-                let by_backing = self.source_credit_available_backing_num(d)? / BOUND_SCALE;
-                let take = remaining.min(by_claim).min(by_backing);
+                let take = V16Core::source_credit_lien_allocation_take(
+                    remaining,
+                    unliened,
+                    self.source_credit_available_backing_num(d)?,
+                    rate,
+                )?;
                 if take != 0 {
-                    self.create_account_source_credit_lien_for_effective_not_atomic(
+                    self.create_account_source_credit_lien_for_effective_core_not_atomic(
                         account, d, take,
                     )?;
                     remaining -= take;
@@ -10482,45 +11667,52 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     fn leg_kf_delta_components_for_settlement_from_asset(
         asset: AssetStateV16,
         leg: PortfolioLegV16,
-    ) -> V16Result<(i128, i128, i128, i128, i128)> {
+    ) -> V16Result<(i128, i128, i128, i128, u128, u128, i128)> {
         let (k_now, f_now) = Self::kf_target_for_leg_from_asset(asset, leg)?;
         let den = leg
             .a_basis
             .checked_mul(POS_SCALE)
             .ok_or(V16Error::ArithmeticOverflow)?;
-        let k_delta = scaled_adl_delta_fast(
+        if leg.k_rem_num >= den || leg.f_rem_num >= den {
+            return Err(V16Error::InvalidLeg);
+        }
+        let (k_delta, k_rem_num) = scaled_adl_delta_with_carry_fast(
             leg.basis_pos_q.unsigned_abs(),
             leg.a_basis,
             leg.k_snap,
             k_now,
+            leg.k_rem_num,
         )
         .unwrap_or_else(|| {
-            wide_signed_mul_div_floor_from_k_pair(
+            wide_signed_mul_div_floor_with_carry_from_k_pair(
                 leg.basis_pos_q.unsigned_abs(),
                 leg.k_snap,
                 k_now,
                 den,
+                leg.k_rem_num,
             )
         });
-        let f_delta = scaled_adl_delta_fast(
+        let (f_delta, f_rem_num) = scaled_adl_delta_with_carry_fast(
             leg.basis_pos_q.unsigned_abs(),
             leg.a_basis,
             leg.f_snap,
             f_now,
+            leg.f_rem_num,
         )
         .unwrap_or_else(|| {
-            wide_signed_mul_div_floor_from_k_pair(
+            wide_signed_mul_div_floor_with_carry_from_k_pair(
                 leg.basis_pos_q.unsigned_abs(),
                 leg.f_snap,
                 f_now,
                 den,
+                leg.f_rem_num,
             )
         });
         let net = k_delta
             .checked_add(f_delta)
             .ok_or(V16Error::ArithmeticOverflow)?;
         validate_non_min_i128(net)?;
-        Ok((k_now, f_now, k_delta, f_delta, net))
+        Ok((k_now, f_now, k_delta, f_delta, k_rem_num, f_rem_num, net))
     }
 
     #[cfg(kani)]
@@ -10529,7 +11721,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         asset: AssetStateV16,
         leg: PortfolioLegV16,
     ) -> V16Result<(i128, i128, i128)> {
-        let (k_now, f_now, _k_delta, _f_delta, net) =
+        let (k_now, f_now, _k_delta, _f_delta, _k_rem_num, _f_rem_num, net) =
             Self::leg_kf_delta_components_for_settlement_from_asset(asset, leg)?;
         Ok((k_now, f_now, net))
     }
@@ -10578,7 +11770,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         {
             return Err(V16Error::InvalidLeg);
         }
-        let (k_now, f_now, _k_delta, f_delta, net) =
+        let (k_now, f_now, _k_delta, f_delta, k_rem_num, f_rem_num, net) =
             Self::leg_kf_delta_components_for_settlement_from_asset(asset, leg)?;
         if net != 0 {
             if net > 0 {
@@ -10601,6 +11793,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Self::record_account_funding_flow(account, leg.side, f_delta)?;
         leg.k_snap = k_now;
         leg.f_snap = f_now;
+        leg.k_rem_num = k_rem_num;
+        leg.f_rem_num = f_rem_num;
         account.header.legs[leg_slot] = PortfolioLegV16Account::from_runtime(&leg);
         account.header.health_cert.valid = 0;
         Ok(())
@@ -10704,7 +11898,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     ) -> V16Result<HealthCertV16> {
         match self.refresh_account_and_certify_not_atomic(account, None, 0, false)? {
             AccountRefreshCertOutcomeV16::Certified(cert) => Ok(cert),
+            AccountRefreshCertOutcomeV16::LegSettled { .. } => Err(V16Error::Stale),
             AccountRefreshCertOutcomeV16::BChunk(_) => Err(V16Error::BStale),
+            AccountRefreshCertOutcomeV16::SourceBackingExpired(_) => Err(V16Error::Stale),
         }
     }
 
@@ -10724,11 +11920,32 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .validate_source_credit_shape_with_market(&self.as_view())?;
             Self::account_source_claim_bound_sum_num(&account.as_view())?
         };
+        let source_domain_count = if allow_b_chunk {
+            Self::account_source_domain_count(&account.as_view())
+        } else {
+            0
+        };
+        let has_pending_kf = if allow_b_chunk {
+            self.account_has_pending_kf_settlement(&account.as_view())?
+        } else {
+            false
+        };
         if source_claim_sum_num != 0 {
             V16Core::validate_positive_pnl_source_attribution(
                 account.header.pnl.get(),
                 source_claim_sum_num,
             )?;
+        }
+        if allow_b_chunk {
+            if let Some(domain) =
+                self.reconcile_first_live_account_source_backing_expiry_not_atomic(account)?
+            {
+                return Ok(AccountRefreshCertOutcomeV16::SourceBackingExpired(domain));
+            }
+        } else if decode_market_mode(self.header.mode)? == MarketModeV16::Live
+            && self.account_has_lapsed_source_backing(&account.as_view())?
+        {
+            return Err(V16Error::Stale);
         }
         if decode_bool(account.header.b_stale_state)? && !allow_b_chunk {
             return Err(V16Error::BStale);
@@ -10742,6 +11959,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let bitmap = account.header.active_bitmap.map(V16PodU64::get);
         let mut seen_assets = [u32::MAX; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut seen_asset_count = 0usize;
+        let mut reset_obligation_cleared = false;
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
@@ -10768,7 +11986,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             if asset_index >= configured_assets || asset_index >= self.markets.len() {
                 return Err(V16Error::HiddenLeg);
             }
-            let asset = self.markets[asset_index].engine.asset.try_to_runtime()?;
+            let mut asset = self.markets[asset_index].engine.asset.try_to_runtime()?;
             if leg.market_id != asset.market_id
                 || !matches!(
                     asset.lifecycle,
@@ -10789,7 +12007,34 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
             seen_assets[seen_asset_count] = leg.asset_index;
             seen_asset_count += 1;
+            // Legacy state can retain nonzero stored basis after ADL exhausted
+            // this side's effective OI. Establish the reset epoch before
+            // settlement so clearing the record cannot subtract stored basis
+            // from zero OI. Close-ledger and loss-barrier ownership stay first.
+            if Self::leg_has_exhausted_effective_oi(asset, leg)
+                && !account
+                    .header
+                    .close_progress
+                    .try_to_runtime()?
+                    .has_pending_residual()
+                && !self.has_pending_domain_loss_barrier(asset_index, leg.side)?
+            {
+                self.begin_full_drain_reset_inner(asset_index, leg.side)?;
+                asset = self.asset_state(asset_index)?;
+            }
+            let (target_k, target_f) = Self::kf_target_for_leg_from_asset(asset, leg)?;
+            let kf_settlement_pending = leg.k_snap != target_k || leg.f_snap != target_f;
             self.settle_leg_kf_effects_at_slot_with_asset(account, slot, asset)?;
+            if V16Core::kernel_permissionless_kf_settlement_commits_step(
+                allow_b_chunk,
+                source_domain_count,
+                has_pending_kf,
+                kf_settlement_pending,
+            ) {
+                self.validate_account_audit_scan(&account.as_view())?;
+                self.validate_shape_audit_scan()?;
+                return Ok(AccountRefreshCertOutcomeV16::LegSettled { asset_index });
+            }
             let mut refreshed = account.header.legs[slot].try_to_runtime()?;
             let target = Self::b_target_for_leg_from_asset(asset, refreshed)?;
             if target > refreshed.b_snap {
@@ -10817,6 +12062,25 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     ));
                 }
                 return Err(V16Error::BStale);
+            }
+            // A prior-reset leg no longer owns effective OI. Once its terminal
+            // K/F/B claims are settled above, detaching it is bookkeeping rather
+            // than a position close. Clear at most one per call to bound work;
+            // another obligation remains refresh-actionable on the next call.
+            let should_clear_reset = V16Core::kernel_should_clear_prior_reset_obligation(
+                reset_obligation_cleared,
+                Self::leg_is_prior_reset_obligation(asset, refreshed),
+                account
+                    .header
+                    .close_progress
+                    .try_to_runtime()?
+                    .has_pending_residual(),
+            );
+            if should_clear_reset {
+                self.clear_leg(account, asset_index)?;
+                reset_obligation_cleared = true;
+                slot += 1;
+                continue;
             }
             let price = if let Some((override_asset, override_price)) = price_override {
                 if override_asset == asset_index {
@@ -10982,12 +12246,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 V16PodU64::new(self.header.current_slot.get());
             return Ok(0);
         }
+        let mut bucket = self.backing_bucket_for_domain(domain)?;
+        let fee_through_slot = if bucket.expiry_slot == 0 {
+            self.header.current_slot.get()
+        } else {
+            self.header.current_slot.get().min(bucket.expiry_slot)
+        };
         let fee = V16Core::backing_utilization_fee_quote_atoms_for_lien(
             self.header.config.try_to_runtime_shape()?,
             self.source_credit_for_domain(domain)?,
             lien_backing_num,
             last_slot,
-            self.header.current_slot.get(),
+            fee_through_slot,
         )?;
         // Carry the floored-away fractional accrual forward: when the rent quote
         // floors to zero this interval, do NOT advance the fee cursor, so a later
@@ -10998,8 +12268,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Ok(0);
         }
         account.header.source_domains[slot].source_lien_fee_last_slot =
-            V16PodU64::new(self.header.current_slot.get());
-        let mut bucket = self.backing_bucket_for_domain(domain)?;
+            V16PodU64::new(fee_through_slot);
         let (charged, next_capital, next_c_tot, next_earnings) =
             apply_backing_utilization_fee_charge(
                 account.header.capital.get(),
@@ -11159,6 +12428,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         b_delta_budget: u128,
     ) -> V16Result<PermissionlessProgressOutcomeV16> {
         account.validate_with_market(&self.as_view())?;
+        if decode_market_mode(self.header.mode)? == MarketModeV16::Live
+            && self.account_has_lapsed_source_backing(&account.as_view())?
+        {
+            return Err(V16Error::Stale);
+        }
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
@@ -11237,10 +12511,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             || asset.loss_weight_sum_short != 0
             || asset.social_loss_remainder_long_num != 0
             || asset.social_loss_remainder_short_num != 0
-            || asset.social_loss_dust_long_num != 0
-            || asset.social_loss_dust_short_num != 0
-            || asset.explicit_unallocated_loss_long != 0
-            || asset.explicit_unallocated_loss_short != 0
+            // Canonical dust and explicit loss are audit state, not positions,
+            // liabilities, or oracle-anchor reset blockers.
             || asset.mode_long != SideModeV16::Normal
             || asset.mode_short != SideModeV16::Normal
             || slot.pending_domain_loss_barrier_long.get() != 0
@@ -11252,7 +12524,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             || self.header.stale_certificate_count.get() != 0
             || self.header.b_stale_account_count.get() != 0
             || self.header.negative_pnl_account_count.get() != 0
-            || decode_bool(self.header.bankruptcy_hlock_active)?
+            || bankruptcy_hlock_active_from_wire(self.header.bankruptcy_hlock_active)?
             || decode_bool(self.header.threshold_stress_active)?
             || decode_bool(self.header.loss_stale_active)?
             || self.header.recovery_reason.try_to_runtime()?.is_some()
@@ -11395,6 +12667,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         } else {
             dt_total
         };
+        let exposed = old.oi_eff_long_q != 0 || old.oi_eff_short_q != 0;
+        if segment_dt != 0
+            && exposed
+            && old.raw_oracle_target_price != old.effective_price
+            && effective_price == old.effective_price
+        {
+            return Err(V16Error::NonProgress);
+        }
         let activity = V16Core::accrual_activity_for_asset_segment(
             old,
             segment_dt,
@@ -11422,24 +12702,47 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
 
         let price_delta = effective_price as i128 - old.effective_price as i128;
-        let k_delta = checked_i128_mul(price_delta, ADL_ONE as i128)?;
-        let funding_delta = if activity.funding_active {
+        let a_long = i128::try_from(old.a_long).map_err(|_| V16Error::ArithmeticOverflow)?;
+        let a_short = i128::try_from(old.a_short).map_err(|_| V16Error::ArithmeticOverflow)?;
+        let k_delta_long = checked_i128_mul(price_delta, a_long)?;
+        let k_delta_short = checked_i128_mul(price_delta, a_short)?;
+        let funding_index_numerator = if activity.funding_active {
             let n = funding_rate_e9
                 .checked_mul(segment_dt as i128)
                 .and_then(|v| v.checked_mul(effective_price as i128))
                 .ok_or(V16Error::ArithmeticOverflow)?;
-            floor_div_signed_conservative_i128(n, FUNDING_DEN)
-                .checked_mul(ADL_ONE as i128)
-                .ok_or(V16Error::ArithmeticOverflow)?
+            n
         } else {
             0
         };
+        // Keep the coefficient linear in elapsed slots so the cadence-invariant
+        // K/F carry remains effective after quantity ADL. Dividing the segment
+        // numerator first would make sub-denominator funding disappear when a
+        // keeper splits one interval into smaller cranks.
+        let funding_delta_long = checked_i128_mul(
+            funding_index_numerator,
+            i128::try_from(old.a_long / FUNDING_DEN).map_err(|_| V16Error::ArithmeticOverflow)?,
+        )?;
+        let funding_delta_short = checked_i128_mul(
+            funding_index_numerator,
+            i128::try_from(old.a_short / FUNDING_DEN).map_err(|_| V16Error::ArithmeticOverflow)?,
+        )?;
 
         let mut asset = old;
-        asset.k_long = add_non_min_i128(asset.k_long, k_delta)?;
-        asset.k_short = add_non_min_i128(asset.k_short, -k_delta)?;
-        asset.f_long_num = add_non_min_i128(asset.f_long_num, -funding_delta)?;
-        asset.f_short_num = add_non_min_i128(asset.f_short_num, funding_delta)?;
+        asset.k_long = add_non_min_i128(asset.k_long, k_delta_long)?;
+        asset.k_short = add_non_min_i128(
+            asset.k_short,
+            k_delta_short
+                .checked_neg()
+                .ok_or(V16Error::ArithmeticOverflow)?,
+        )?;
+        asset.f_long_num = add_non_min_i128(
+            asset.f_long_num,
+            funding_delta_long
+                .checked_neg()
+                .ok_or(V16Error::ArithmeticOverflow)?,
+        )?;
+        asset.f_short_num = add_non_min_i128(asset.f_short_num, funding_delta_short)?;
         asset.effective_price = effective_price;
         asset.fund_px_last = effective_price;
         asset.slot_last = asset
@@ -11516,6 +12819,15 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
         request: PermissionlessCrankRequestV16,
     ) -> V16Result<PermissionlessProgressOutcomeV16> {
+        self.permissionless_crank_impl_not_atomic(account, request, false)
+    }
+
+    fn permissionless_crank_impl_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        request: PermissionlessCrankRequestV16,
+        skip_post_action_accrual: bool,
+    ) -> V16Result<PermissionlessProgressOutcomeV16> {
         self.validate_unconfigured_market_tail()?;
         if decode_market_mode(self.header.mode)? != MarketModeV16::Live
             && !matches!(request.action, PermissionlessCrankActionV16::Recover(_))
@@ -11535,12 +12847,29 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     true,
                 )? {
                     AccountRefreshCertOutcomeV16::Certified(_) => {}
+                    AccountRefreshCertOutcomeV16::LegSettled { asset_index } => {
+                        self.validate_shape_audit_scan()?;
+                        return Ok(PermissionlessProgressOutcomeV16::AccountLegSettled {
+                            asset_index,
+                        });
+                    }
                     AccountRefreshCertOutcomeV16::BChunk(out) => {
                         self.validate_shape_audit_scan()?;
                         return Ok(PermissionlessProgressOutcomeV16::AccountBChunk(out));
                     }
+                    AccountRefreshCertOutcomeV16::SourceBackingExpired(domain) => {
+                        self.validate_shape_audit_scan()?;
+                        return Ok(PermissionlessProgressOutcomeV16::SourceBackingExpired {
+                            domain,
+                        });
+                    }
                 }
                 touches_accrued_asset
+            }
+            PermissionlessCrankActionV16::AdvanceRecoveryClose { asset_index } => {
+                let (outcome, _) =
+                    self.advance_asset_local_recovery_close_not_atomic(account, asset_index)?;
+                return Ok(PermissionlessProgressOutcomeV16::ResidualBooked(outcome));
             }
             PermissionlessCrankActionV16::SettleB { asset_index } => {
                 let out = self.settle_account_b_chunk(
@@ -11553,7 +12882,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             PermissionlessCrankActionV16::Liquidate(_) => {
                 if let PermissionlessCrankActionV16::Liquidate(liq) = request.action {
                     let liquidated_asset_index = liq.asset_index;
-                    self.liquidate_account_not_atomic(account, liq)?;
+                    if let Err(error) = self.liquidate_account_not_atomic(account, liq) {
+                        let mode = decode_market_mode(self.header.mode)?;
+                        let reason = self.header.recovery_reason.try_to_runtime()?;
+                        return V16Core::kernel_commit_declared_liquidation_recovery(
+                            error, mode, reason,
+                        );
+                    }
                     liquidated_asset_index == request.asset_index
                 } else {
                     unreachable!()
@@ -11563,6 +12898,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 return self.declare_permissionless_recovery(reason);
             }
         };
+        if skip_post_action_accrual {
+            self.validate_shape_audit_scan()?;
+            return Ok(PermissionlessProgressOutcomeV16::AccountCurrent);
+        }
         self.accrue_asset_to_not_atomic(
             request.asset_index,
             request.now_slot,
@@ -11577,12 +12916,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     /// state to the ActionableState summary the self-classifying crank dispatches
     /// from. Each flag is exactly its production eligibility predicate, MODE-
     /// GATED so every flag that can be set has a currently-valid dispatch target:
-    ///   stale            — Live, health cert not current (kernel_cert_is_current==false)
+    ///   stale            — Live, health cert not current, source backing needs expiry
+    ///                      reconciliation, or a settled prior-reset obligation remains
     ///   b_stale          — Live, some active leg flagged b-stale (has_b_stale_leg)
-    ///   pending_close    — Live, a close-progress ledger is active
-    ///   expired_close    — Live, that ledger is past its max-close slot
+    ///   pending_close    — Live, outstanding close on a frozen Recovery asset
+    ///   expired_close    — Live, expired close not safely isolated to Recovery asset
     ///   liquidatable     — Live, current cert with nonzero certified liq deficit
-    ///   recovery_eligible— Resolved, unattributed-insolvent negative-PnL recovery
+    ///   recovery_eligible— reserved for selector-level proactive Recovery
     ///   resolved_winner  — Resolved, positive PnL, resolved payout ready
     /// Assembled via the proven actionable_summary_from_signals kernel. Live-only
     /// flags need cert currentness only where their entrypoint does (liquidate),
@@ -11607,42 +12947,55 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         );
         let ledger = account.header.close_progress.try_to_runtime()?;
 
-        let has_open_risk =
-            !active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get));
+        let (_, _, liquidatable_asset, reset_obligation_asset) =
+            self.auto_crank_selected_assets(account)?;
         // A close ledger with residual_remaining==0 is already fully booked/covered
         // (e.g. insurance absorbed the loss); only OUTSTANDING residual is real,
         // actionable close work. The `active` flag can linger past that.
         let close_outstanding = ledger.active && ledger.residual_remaining > 0;
-        let stale = live && !cert_current;
+        let recovery_asset_close = if close_outstanding {
+            self.close_progress_is_asset_local_recovery(ledger)?
+        } else {
+            false
+        };
+        // Expiry is itself actionable even when price/funding epochs did not move:
+        // refresh atomically expires the aggregate bucket and relabels this
+        // account's counterparty lien as impaired before reading source credit.
+        let stale = live
+            && (!cert_current
+                || reset_obligation_asset.is_some()
+                || self.account_has_lapsed_source_backing(account)?);
         let b_stale = live && Self::has_b_stale_leg(account)?;
-        // pending_close is NOT proactively classified: the close-ledger residual is
-        // booked ONLY inside the liquidation/resolved path that owns it
-        // (book_bankruptcy_residual_chunk_for_account_core) — settle_account_b_chunk
-        // does not touch it, so an AdvanceClose->SettleB dispatch would not advance
-        // the ledger. An outstanding Live close with a leg is liquidatable (the
-        // residual is an open deficit), so the Liquidate continuation books the
-        // residual chunk; the leg-less / expired cases are handled by expired_close
-        // -> recovery or are the documented backstopped A3 route. AdvanceClose is
-        // therefore classifier-unreachable (the proven selector still admits it).
-        let pending_close = false;
-        // Expired outstanding close -> terminal recovery (Recover needs no leg).
-        let expired_close =
-            live && close_outstanding && self.header.current_slot.get() > ledger.max_close_slot;
-        // liquidatable requires a current certified deficit AND actual open risk:
+        // Once an asset is in Recovery its mark is frozen. A ledger already opened
+        // by the owner therefore has a stable loss snapshot and can be advanced one
+        // public B chunk at a time without promoting an untrusted asset to global
+        // market Recovery. Other expired ledgers retain the terminal fallback.
+        let deadline_expired = self.header.current_slot.get() > ledger.max_close_slot;
+        let pending_close = live && close_outstanding && recovery_asset_close;
+        let expired_close = live
+            && V16Core::kernel_close_requires_global_recovery(
+                close_outstanding,
+                deadline_expired,
+                resolved,
+                recovery_asset_close,
+            );
+        // Liquidation requires a current certified deficit and a leg that still
+        // owns effective OI. Prior-reset obligations are detached by Refresh
+        // first, so they cannot poison dispatch to a later live-risk leg.
         // a stale cert can still report a deficit after the position was already
-        // closed, but with no active leg there is nothing to liquidate (the real
-        // liquidate entrypoint requires an active leg), so the flag must be false.
-        let liquidatable = live && cert_current && cert.certified_liq_deficit != 0 && has_open_risk;
-        // Permissionless recovery (declare_permissionless_recovery) is a LIVE-mode
-        // action — it rejects Resolved mode with LockActive. The proactive Live
-        // recovery condition the auto-crank declares is an EXPIRED outstanding
-        // close (expired_close -> DeclareRecovery, reason
-        // ActiveBankruptCloseCannotProgress); every other recovery reason is
-        // declared REACTIVELY inside the dispatched crank op when it detects
-        // non-progress (BIndexHeadroomExhausted, etc.). Resolved bad-debt
-        // wind-down is handled by CloseResolved itself, not by the recovery
-        // selector flag, so recovery_eligible stays in the summary type for the
-        // proven selector but is driven by expired_close.
+        // closed, and a Recovery-only account has no ordinary liquidation target.
+        let liquidatable = !pending_close
+            && reset_obligation_asset.is_none()
+            && V16Core::kernel_auto_crank_liquidatable(
+                live,
+                cert_current,
+                cert.certified_liq_deficit,
+                liquidatable_asset,
+            );
+        // Liquidation-only recovery is discovered by liquidation itself. The
+        // auto-crank converts only its complete committed Recovery terminal into
+        // successful progress, without repeating liquidation sizing or residual
+        // scans in the selector.
         let recovery_eligible = false;
         // resolved_winner routes to close_resolved, which LAZILY captures the
         // payout snapshot itself (initialize_resolved_payout_ledger_if_needed is
@@ -11675,22 +13028,96 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     /// dispatch target is valid in the mode that the classifier gated its flag to.
     /// ENGINE asset self-selection (engine.md): scan the account's bounded legs and
     /// return, for each asset-scoped continuation, the engine-chosen asset_index —
-    /// the FIRST active b-stale leg's asset (SettleBChunk), and the FIRST active
-    /// leg's asset (used for both Liquidate and the refresh accrual target). The
-    /// selection is proven in-range / actionable / first-match / complete by the
-    /// first_actionable_slot contract; the slot->asset_index read is by inspection.
+    /// the FIRST active b-stale leg's asset (SettleBChunk), the FIRST active leg
+    /// eligible for ordinary refresh, and the FIRST leg that still owns effective
+    /// OI and is eligible for liquidation. Prior-reset obligations remain
+    /// refreshable until their bookkeeping is detached, but are never selected as
+    /// liquidation work. Recovery legs stay available to the separate frozen-mark
+    /// exit/force-close route. The selection is proven in-range / actionable /
+    /// first-match / complete by the first_actionable_slot contract; the
+    /// slot->asset_index and lifecycle reads are by inspection.
+    fn leg_is_prior_reset_obligation(asset: AssetStateV16, leg: PortfolioLegV16) -> bool {
+        let (side_mode, asset_epoch) = match leg.side {
+            SideV16::Long => (asset.mode_long, asset.epoch_long),
+            SideV16::Short => (asset.mode_short, asset.epoch_short),
+        };
+        V16Core::kernel_is_prior_reset_obligation(side_mode, asset_epoch, leg.epoch_snap)
+    }
+
+    fn side_effective_oi(asset: AssetStateV16, side: SideV16) -> u128 {
+        match side {
+            SideV16::Long => asset.oi_eff_long_q,
+            SideV16::Short => asset.oi_eff_short_q,
+        }
+    }
+
+    fn side_stored_position_count(asset: AssetStateV16, side: SideV16) -> u64 {
+        match side {
+            SideV16::Long => asset.stored_pos_count_long,
+            SideV16::Short => asset.stored_pos_count_short,
+        }
+    }
+
+    fn side_pending_obligation_count(asset: AssetStateV16, side: SideV16) -> u64 {
+        match side {
+            SideV16::Long => asset.pending_obligation_count_long,
+            SideV16::Short => asset.pending_obligation_count_short,
+        }
+    }
+
+    fn side_mode(asset: AssetStateV16, side: SideV16) -> SideModeV16 {
+        match side {
+            SideV16::Long => asset.mode_long,
+            SideV16::Short => asset.mode_short,
+        }
+    }
+
+    fn leg_has_exhausted_effective_oi(asset: AssetStateV16, leg: PortfolioLegV16) -> bool {
+        leg.active
+            && leg.basis_pos_q != 0
+            && Self::side_effective_oi(asset, leg.side) == 0
+            && Self::side_stored_position_count(asset, leg.side) != 0
+            && Self::side_pending_obligation_count(asset, leg.side) == 0
+            && Self::side_mode(asset, leg.side) != SideModeV16::ResetPending
+    }
+
     fn auto_crank_selected_assets(
+        &self,
         account: &PortfolioV16View<'_>,
-    ) -> V16Result<(Option<usize>, Option<usize>)> {
+    ) -> V16Result<(Option<usize>, Option<usize>, Option<usize>, Option<usize>)> {
         let bitmap = account.header.active_bitmap.map(V16PodU64::get);
-        let mut active_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+        let mut refresh_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+        let mut liquidation_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+        let mut reset_obligation_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut b_stale_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
             let active = active_bitmap_get(bitmap, slot) && leg.active;
-            active_flags[slot] = active;
-            b_stale_flags[slot] = active && leg.b_stale;
+            if active {
+                let asset = self.asset_state(leg.asset_index as usize)?;
+                let (side_mode, asset_epoch) = match leg.side {
+                    SideV16::Long => (asset.mode_long, asset.epoch_long),
+                    SideV16::Short => (asset.mode_short, asset.epoch_short),
+                };
+                let matched_oi_q = asset.oi_eff_long_q.min(asset.oi_eff_short_q);
+                let (b_stale, refresh, liquidatable, reset_obligation) =
+                    V16Core::kernel_auto_crank_leg_flags(
+                        true,
+                        asset.lifecycle,
+                        leg.basis_pos_q,
+                        matched_oi_q,
+                        side_mode,
+                        asset_epoch,
+                        leg.epoch_snap,
+                        leg.b_stale,
+                    );
+                b_stale_flags[slot] = b_stale;
+                refresh_flags[slot] = refresh;
+                liquidation_flags[slot] = liquidatable;
+                reset_obligation_flags[slot] =
+                    reset_obligation || Self::leg_has_exhausted_effective_oi(asset, leg);
+            }
             slot += 1;
         }
         let asset_of = |s: Option<usize>| -> V16Result<Option<usize>> {
@@ -11702,15 +13129,55 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
         };
         let b_stale_asset = asset_of(V16Core::first_actionable_slot(b_stale_flags))?;
-        let active_asset = asset_of(V16Core::first_actionable_slot(active_flags))?;
-        Ok((b_stale_asset, active_asset))
+        let refresh_asset = asset_of(V16Core::first_actionable_slot(refresh_flags))?;
+        let liquidatable_asset = asset_of(V16Core::first_actionable_slot(liquidation_flags))?;
+        let reset_obligation_asset =
+            asset_of(V16Core::first_actionable_slot(reset_obligation_flags))?;
+        Ok((
+            b_stale_asset,
+            refresh_asset,
+            liquidatable_asset,
+            reset_obligation_asset,
+        ))
+    }
+
+    /// Pure production plan query for wrappers that must authenticate the oracle
+    /// observation required by the exact continuation the engine will dispatch.
+    /// Keeping this query beside execution prevents wrappers from duplicating
+    /// lifecycle-sensitive asset selection.
+    pub fn build_auto_crank_plan(
+        &self,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<AutoCrankPlanV16> {
+        let summary = self.build_actionable_summary(account)?;
+        let (b_stale_asset, refresh_asset, liquidatable_asset, _) =
+            self.auto_crank_selected_assets(account)?;
+        let pending_close_asset = if summary.pending_close {
+            account.header.close_progress.asset_index.get() as usize
+        } else {
+            0
+        };
+        let recovery_reason = if summary.expired_close {
+            PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
+        } else {
+            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow
+        };
+        Ok(V16Core::select_auto_crank_plan(
+            summary,
+            pending_close_asset,
+            b_stale_asset.unwrap_or(0),
+            liquidatable_asset.unwrap_or(0),
+            refresh_asset,
+            recovery_reason,
+        ))
     }
 
     /// THE SINGLE PUBLIC PERMISSIONLESS CRANK (engine.md): the only crank the
     /// wrapper should call — order-insensitive and engine-selected, built for a
     /// swarm of opportunistic keepers whose transactions land out of order. The
-    /// per-action primitives (refresh / settle-B / liquidate / recover /
-    /// close-resolved) are internal dispatch targets, not wrapper entrypoints.
+    /// per-action primitives (refresh / recovery-close / settle-B / liquidate /
+    /// recover / close-resolved) are internal dispatch targets, not wrapper
+    /// entrypoints.
     ///
     /// Calling convention (wrapper side):
     /// 1. Decode a public auto-crank instruction carrying a bounded set of oracle
@@ -11718,66 +13185,76 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     ///    keeper has fresh data for — plus the `resolved_close_fee_rate_per_slot`.
     /// 2. Authenticate clock/slot + each observation against the oracle.
     /// 3. Build `AutoCrankWorkV16 { now_slot, observations,
-    ///    resolved_close_fee_rate_per_slot }` and call this ONCE (one ix = one
-    ///    step; never loop to a fixed point — CU).
+    ///    observations_preaccrued, resolved_close_fee_rate_per_slot }` and call
+    ///    this ONCE (one ix = one step; never loop to a fixed point — CU). Set
+    ///    `observations_preaccrued` only when the wrapper already applied the
+    ///    authenticated bounded market-accrual stage in the same transaction.
     /// 4. The engine classifies the account, selects the highest-priority step AND
     ///    its asset (self-selected — the caller never chooses action or asset),
     ///    matches the observation that step needs, derives the liquidation fee from
-    ///    CONFIG (never the caller), and dispatches one bounded primitive.
+    ///    CONFIG (never the caller), and dispatches one bounded primitive. A
+    ///    pre-accrued call dispatches the account primitive without accruing a
+    ///    second market segment. When the matching observation is absent, a step
+    ///    realizable from committed state may still update the account but cannot
+    ///    advance the selected asset's accrual segment.
     /// 5. On `Ok(result)`, mirror any wrapper-owned token/custody movement keyed off
     ///    `result.selected` (the `AutoCrankPlanV16`): refresh / settle-B move no
     ///    custody; liquidate / close-resolved may. `NoAction` => nothing was needed.
-    ///    `Err(NonProgress)` => the selected step needed an observation the caller
-    ///    did not supply (currently the no-active-asset refresh fallback, or a
-    ///    stale/late tx whose task changed) — no mutation, so SVM rollback is a
-    ///    clean no-op and arbitrary landing order is safe.
+    ///    In Recovery, the next call selects `FinalizeRecovery` and performs the
+    ///    value-neutral transition to Resolved so terminal account close remains
+    ///    publicly reachable. `Err(NonProgress)` => the selected step needed an
+    ///    observation the caller did not supply (currently the no-active-asset
+    ///    refresh fallback, or a stale/late tx whose task changed) — no mutation,
+    ///    so SVM rollback is a clean no-op and arbitrary landing order is safe.
     pub fn permissionless_auto_crank_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
         work: AutoCrankWorkV16<'_>,
     ) -> V16Result<AutoCrankResultV16> {
-        let summary = self.build_actionable_summary(&account.as_view())?;
-        let (b_stale_asset, active_asset) = Self::auto_crank_selected_assets(&account.as_view())?;
-        let recovery_reason = if summary.expired_close {
-            PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
-        } else {
-            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow
-        };
+        if decode_market_mode(self.header.mode)? == MarketModeV16::Recovery {
+            account.validate_with_market(&self.as_view())?;
+            self.resolve_market_not_atomic(work.now_slot)?;
+            account.validate_with_market(&self.as_view())?;
+            return Ok(AutoCrankResultV16 {
+                selected: AutoCrankPlanV16::FinalizeRecovery,
+                outcome: AutoCrankOutcomeV16::RecoveryResolved,
+            });
+        }
         // PRODUCTION KERNEL: the proven plan selector (priority + totality +
-        // engine-selected asset). refresh accrues the first active leg's asset.
-        let plan = V16Core::select_auto_crank_plan(
-            summary,
-            b_stale_asset.unwrap_or(0),
-            active_asset.unwrap_or(0),
-            active_asset,
-            recovery_reason,
-        );
+        // engine-selected asset), exposed through the same pure query wrappers
+        // use to authenticate its selected observation.
+        let plan = self.build_auto_crank_plan(&account.as_view())?;
 
-        let obs_or_current_asset = |me: &Self, i: usize| -> V16Result<AutoCrankObservationV16> {
-            match work
-                .observations
-                .iter()
-                .copied()
-                .find(|o| o.asset_index == i)
-            {
-                Some(obs) => Ok(obs),
-                None => {
-                    let asset = me.asset_state(i)?;
-                    Ok(AutoCrankObservationV16 {
-                        asset_index: i,
-                        effective_price: asset.effective_price,
-                        funding_rate_e9: 0,
-                    })
+        let obs_or_current_asset =
+            |me: &Self, i: usize| -> V16Result<(AutoCrankObservationV16, bool)> {
+                match work
+                    .observations
+                    .iter()
+                    .copied()
+                    .find(|o| o.asset_index == i)
+                {
+                    Some(obs) => Ok((obs, true)),
+                    None => {
+                        let asset = me.asset_state(i)?;
+                        Ok((
+                            AutoCrankObservationV16 {
+                                asset_index: i,
+                                effective_price: asset.effective_price,
+                                funding_rate_e9: 0,
+                            },
+                            false,
+                        ))
+                    }
                 }
-            }
-        };
+            };
         let crank_with = |me: &mut Self,
                           account: &mut PortfolioV16ViewMut<'_>,
                           asset_index: usize,
                           obs: AutoCrankObservationV16,
+                          observation_supplied: bool,
                           action: PermissionlessCrankActionV16|
          -> V16Result<PermissionlessProgressOutcomeV16> {
-            me.permissionless_crank_not_atomic(
+            me.permissionless_crank_impl_not_atomic(
                 account,
                 PermissionlessCrankRequestV16 {
                     now_slot: work.now_slot,
@@ -11786,24 +13263,31 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     funding_rate_e9: obs.funding_rate_e9,
                     action,
                 },
+                auto_crank_skip_post_action_accrual(
+                    work.observations_preaccrued,
+                    observation_supplied,
+                ),
             )
         };
 
         let outcome = match plan {
             AutoCrankPlanV16::NoAction => AutoCrankOutcomeV16::NoAction,
             AutoCrankPlanV16::RefreshAccount { asset_index } => {
-                // Accrue the engine-selected active asset from either a fresh
-                // observation or committed state; if no active asset exists, use
-                // the first supplied observation to give the refresh a price.
-                let (ai, obs) = match asset_index {
-                    Some(i) => (i, obs_or_current_asset(self, i)?),
+                // A committed-state fallback can refresh the account, but only a
+                // supplied observation authorizes advancing the asset's accrual
+                // segment. If no active asset exists, an observation is required.
+                let (ai, obs, observation_supplied) = match asset_index {
+                    Some(i) => {
+                        let (obs, supplied) = obs_or_current_asset(self, i)?;
+                        (i, obs, supplied)
+                    }
                     None => {
                         let o = work
                             .observations
                             .first()
                             .copied()
                             .ok_or(V16Error::NonProgress)?;
-                        (o.asset_index, o)
+                        (o.asset_index, o, true)
                     }
                 };
                 AutoCrankOutcomeV16::Progressed(crank_with(
@@ -11811,26 +13295,41 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     account,
                     ai,
                     obs,
+                    observation_supplied,
                     PermissionlessCrankActionV16::Refresh,
                 )?)
             }
+            AutoCrankPlanV16::AdvanceRecoveryClose { asset_index } => {
+                AutoCrankOutcomeV16::Progressed(self.permissionless_crank_not_atomic(
+                    account,
+                    PermissionlessCrankRequestV16 {
+                        now_slot: work.now_slot,
+                        asset_index,
+                        effective_price: 0,
+                        funding_rate_e9: 0,
+                        action: PermissionlessCrankActionV16::AdvanceRecoveryClose { asset_index },
+                    },
+                )?)
+            }
             AutoCrankPlanV16::SettleBChunk { asset_index } => {
-                let obs = obs_or_current_asset(self, asset_index)?;
+                let (obs, observation_supplied) = obs_or_current_asset(self, asset_index)?;
                 AutoCrankOutcomeV16::Progressed(crank_with(
                     self,
                     account,
                     asset_index,
                     obs,
+                    observation_supplied,
                     PermissionlessCrankActionV16::SettleB { asset_index },
                 )?)
             }
             AutoCrankPlanV16::Liquidate { asset_index } => {
-                let obs = obs_or_current_asset(self, asset_index)?;
+                let (obs, observation_supplied) = obs_or_current_asset(self, asset_index)?;
                 AutoCrankOutcomeV16::Progressed(crank_with(
                     self,
                     account,
                     asset_index,
                     obs,
+                    observation_supplied,
                     PermissionlessCrankActionV16::Liquidate(LiquidationRequestV16 { asset_index }),
                 )?)
             }
@@ -11847,6 +13346,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     },
                 )?)
             }
+            AutoCrankPlanV16::FinalizeRecovery => return Err(V16Error::InvalidConfig),
             AutoCrankPlanV16::CloseResolved => {
                 AutoCrankOutcomeV16::ResolvedClose(self.close_resolved_account_not_atomic(
                     account,
@@ -11961,6 +13461,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Ok(());
         }
         let asset = self.asset_state(asset_index)?;
+        if asset.a_long != ADL_ONE || asset.a_short != ADL_ONE {
+            return Err(V16Error::LockActive);
+        }
         asset_risk_increase_gate(asset.lifecycle, asset.mode_long, asset.mode_short)
     }
 
@@ -12082,6 +13585,28 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         canonical_slot
     }
 
+    #[inline(always)]
+    fn asset_has_empty_lifecycle_blocker(asset: AssetStateV16) -> bool {
+        asset.mode_long != SideModeV16::Normal
+            || asset.mode_short != SideModeV16::Normal
+            || !((asset.a_long == ADL_ONE && asset.a_short == ADL_ONE)
+                || (asset.a_long == 0 && asset.a_short == 0))
+            || asset.oi_eff_long_q != 0
+            || asset.oi_eff_short_q != 0
+            || asset.stored_pos_count_long != 0
+            || asset.stored_pos_count_short != 0
+            || asset.stale_account_count_long != 0
+            || asset.stale_account_count_short != 0
+            || asset.pending_obligation_count_long != 0
+            || asset.pending_obligation_count_short != 0
+            || asset.loss_weight_sum_long != 0
+            || asset.loss_weight_sum_short != 0
+            || asset.social_loss_remainder_long_num != 0
+            || asset.social_loss_remainder_short_num != 0
+        // Retirement canonicalizes audit-only dust and explicit loss once
+        // all positions, weights, remainders, and barriers are empty.
+    }
+
     fn require_asset_live_reducible(&self, asset_index: usize) -> V16Result<()> {
         let asset = self.asset_state(asset_index)?;
         match asset.lifecycle {
@@ -12121,40 +13646,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             long_spent != 0 || short_spent != 0
         };
 
+        // K, funding, and B indices are already-settled history, not outstanding liabilities. Once
+        // all position, stale, obligation, weight, remainder, barrier, source, backing, and
+        // reservation state below is empty, no account can still settle any current or
+        // epoch-start K/F/B anchor. A restart changes market_id and canonicalizes the slot.
         if slot.pending_domain_loss_barrier_long.get() != 0
             || slot.pending_domain_loss_barrier_short.get() != 0
-            || asset.mode_long != SideModeV16::Normal
-            || asset.mode_short != SideModeV16::Normal
-            || !((asset.a_long == ADL_ONE && asset.a_short == ADL_ONE)
-                || (asset.a_long == 0 && asset.a_short == 0))
-            || asset.k_long != 0
-            || asset.k_short != 0
-            || asset.f_long_num != 0
-            || asset.f_short_num != 0
-            || asset.k_epoch_start_long != 0
-            || asset.k_epoch_start_short != 0
-            || asset.f_epoch_start_long_num != 0
-            || asset.f_epoch_start_short_num != 0
-            || asset.b_long_num != 0
-            || asset.b_short_num != 0
-            || asset.b_epoch_start_long_num != 0
-            || asset.b_epoch_start_short_num != 0
-            || asset.oi_eff_long_q != 0
-            || asset.oi_eff_short_q != 0
-            || asset.stored_pos_count_long != 0
-            || asset.stored_pos_count_short != 0
-            || asset.stale_account_count_long != 0
-            || asset.stale_account_count_short != 0
-            || asset.pending_obligation_count_long != 0
-            || asset.pending_obligation_count_short != 0
-            || asset.loss_weight_sum_long != 0
-            || asset.loss_weight_sum_short != 0
-            || asset.social_loss_remainder_long_num != 0
-            || asset.social_loss_remainder_short_num != 0
-            || asset.social_loss_dust_long_num != 0
-            || asset.social_loss_dust_short_num != 0
-            || asset.explicit_unallocated_loss_long != 0
-            || asset.explicit_unallocated_loss_short != 0
+            || Self::asset_has_empty_lifecycle_blocker(asset)
             || spent_blocks_empty
             || !long_source.is_empty_amount_shape()
             || !short_source.is_empty_amount_shape()
@@ -12308,9 +13806,145 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(false)
     }
 
+    fn asset_has_bankruptcy_lock_state(&self, asset_index: usize) -> V16Result<bool> {
+        self.validate_configured_asset_index(asset_index)?;
+        bankruptcy_asset_slot_has_lock_state(self.markets[asset_index].engine_slot())
+    }
+
+    fn account_references_bankrupt_asset(&self, account: &PortfolioV16View<'_>) -> V16Result<bool> {
+        let mut slot = 0usize;
+        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg = &account.header.legs[slot];
+            if decode_bool(leg.active)?
+                && self.asset_has_bankruptcy_lock_state(leg.asset_index.get() as usize)?
+            {
+                return Ok(true);
+            }
+            slot += 1;
+        }
+        slot = 0;
+        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let source = account.source_domains()[slot];
+            if source.has_default_sparse_tag() && !source.is_occupied() {
+                break;
+            }
+            if source.is_occupied() {
+                let domain = source.domain.get() as usize;
+                let (asset_index, _) = self.domain_asset_side(domain)?;
+                if self.asset_has_bankruptcy_lock_state(asset_index)? {
+                    return Ok(true);
+                }
+            }
+            slot += 1;
+        }
+        let close = &account.header.close_progress;
+        if decode_bool(close.active)? {
+            self.asset_has_bankruptcy_lock_state(close.asset_index.get() as usize)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn bankruptcy_hlock_is_only_unrelated_to_account(
+        &self,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<bool> {
+        if !bankruptcy_hlock_active_from_wire(self.header.bankruptcy_hlock_active)?
+            || !bankruptcy_hlock_fully_attributed_from_wire(self.header.bankruptcy_hlock_active)?
+        {
+            return Ok(false);
+        }
+        Ok(!self.account_references_bankrupt_asset(account)?)
+    }
+
+    fn mark_bankruptcy_asset(&mut self, asset_index: usize) -> V16Result<()> {
+        self.validate_configured_asset_index(asset_index)?;
+        validate_bankruptcy_hlock_summary(
+            self.header.bankruptcy_hlock_active,
+            self.header.bankruptcy_hlock_asset_count.get(),
+        )?;
+        if self.asset_has_bankruptcy_lock_state(asset_index)? {
+            return Ok(());
+        }
+        let next_count = self
+            .header
+            .bankruptcy_hlock_asset_count
+            .get()
+            .checked_add(1)
+            .ok_or(V16Error::CounterOverflow)?;
+        self.markets[asset_index]
+            .engine_slot_mut()
+            .bankruptcy_hlock_active = 1;
+        self.header.bankruptcy_hlock_asset_count = V16PodU32::new(next_count);
+        Ok(())
+    }
+
+    fn mark_attributed_bankruptcy_hlock(&mut self, asset_index: usize) -> V16Result<()> {
+        let active = bankruptcy_hlock_active_from_wire(self.header.bankruptcy_hlock_active)?;
+        let fully_attributed =
+            bankruptcy_hlock_fully_attributed_from_wire(self.header.bankruptcy_hlock_active)?;
+        self.mark_bankruptcy_asset(asset_index)?;
+        self.header.bankruptcy_hlock_active =
+            bankruptcy_hlock_to_wire(true, !active || fully_attributed);
+        Ok(())
+    }
+
+    fn mark_attributed_bankruptcy_hlock_after_principal_settlement(
+        &mut self,
+        prior: u8,
+        asset_index: usize,
+    ) -> V16Result<()> {
+        let prior_active = bankruptcy_hlock_active_from_wire(prior)?;
+        let prior_fully_attributed = bankruptcy_hlock_fully_attributed_from_wire(prior)?;
+        bankruptcy_hlock_active_from_wire(self.header.bankruptcy_hlock_active)?;
+        self.mark_bankruptcy_asset(asset_index)?;
+        self.header.bankruptcy_hlock_active =
+            bankruptcy_hlock_to_wire(true, !prior_active || prior_fully_attributed);
+        Ok(())
+    }
+
+    fn mark_unattributed_bankruptcy_hlock(&mut self) -> V16Result<()> {
+        bankruptcy_hlock_active_from_wire(self.header.bankruptcy_hlock_active)?;
+        self.header.bankruptcy_hlock_active = bankruptcy_hlock_to_wire(true, false);
+        Ok(())
+    }
+
+    fn mark_bankruptcy_hlock_for_account(
+        &mut self,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<()> {
+        let close = account.header.close_progress.try_to_runtime()?;
+        if close.active {
+            return self.mark_attributed_bankruptcy_hlock(close.asset_index as usize);
+        }
+        let mut attributed_asset = None;
+        let mut slot = 0usize;
+        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg = account.header.legs[slot].try_to_runtime()?;
+            if leg.active {
+                self.validate_configured_asset_index(leg.asset_index as usize)?;
+                match attributed_asset {
+                    None => attributed_asset = Some(leg.asset_index),
+                    Some(asset_index) if asset_index == leg.asset_index => {}
+                    Some(_) => return self.mark_unattributed_bankruptcy_hlock(),
+                }
+            }
+            slot += 1;
+        }
+        if let Some(asset_index) = attributed_asset {
+            self.mark_attributed_bankruptcy_hlock(asset_index as usize)
+        } else {
+            self.mark_unattributed_bankruptcy_hlock()
+        }
+    }
+
     fn ensure_favorable_action_allowed(&self, account: &PortfolioV16View<'_>) -> V16Result<()> {
         account.validate_with_market(&self.as_view())?;
-        if self.h_lock_lane(Some(account), false)? == HLockLaneV16::HMax {
+        let ignore_unrelated_bankruptcy_hlock =
+            self.bankruptcy_hlock_is_only_unrelated_to_account(account)?;
+        if self.h_lock_lane_scoped(Some(account), false, !ignore_unrelated_bankruptcy_hlock)?
+            == HLockLaneV16::HMax
+        {
             return Err(V16Error::LockActive);
         }
         self.ensure_favorable_action_current_certificate(account)?;
@@ -12456,10 +14090,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         ))
     }
 
-    fn h_lock_lane(
+    fn h_lock_lane_scoped(
         &self,
         account: Option<&PortfolioV16View<'_>>,
         instruction_bankruptcy_candidate: bool,
+        bankruptcy_hlock_applies: bool,
     ) -> V16Result<HLockLaneV16> {
         if let Some(account) = account {
             if decode_bool(account.header.stale_state)?
@@ -12481,13 +14116,22 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
         }
         if decode_bool(self.header.threshold_stress_active)?
-            || decode_bool(self.header.bankruptcy_hlock_active)?
+            || (bankruptcy_hlock_applies
+                && bankruptcy_hlock_active_from_wire(self.header.bankruptcy_hlock_active)?)
             || decode_market_mode(self.header.mode)? == MarketModeV16::Recovery
             || instruction_bankruptcy_candidate
         {
             return Ok(HLockLaneV16::HMax);
         }
         Ok(HLockLaneV16::HMin)
+    }
+
+    fn h_lock_lane(
+        &self,
+        account: Option<&PortfolioV16View<'_>>,
+        instruction_bankruptcy_candidate: bool,
+    ) -> V16Result<HLockLaneV16> {
+        self.h_lock_lane_scoped(account, instruction_bankruptcy_candidate, true)
     }
 
     fn asset_has_target_effective_lag(&self, asset_index: usize) -> V16Result<bool> {
@@ -12789,12 +14433,65 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Err(V16Error::Stale);
         }
         let asset = self.asset_state(asset_index)?;
-        let asset = V16Core::kernel_clear_leg(leg, asset)?;
+        let prior_reset_epoch = match leg.side {
+            SideV16::Long => {
+                asset.mode_long == SideModeV16::ResetPending
+                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_long)
+            }
+            SideV16::Short => {
+                asset.mode_short == SideModeV16::ResetPending
+                    && leg.epoch_snap.checked_add(1) == Some(asset.epoch_short)
+            }
+        };
+        let current_dust = match leg.side {
+            SideV16::Long => asset.social_loss_dust_long_num,
+            SideV16::Short => asset.social_loss_dust_short_num,
+        };
+        let dust_carry = if prior_reset_epoch {
+            0
+        } else {
+            V16Core::kernel_fold_social_loss_dust(current_dust, leg.b_rem)?.1
+        };
+        let mut asset = V16Core::kernel_clear_leg(leg, asset)?;
+
+        // A whole atom assembled from fractional remainders is already-booked
+        // social loss. Rebook it over the remaining side, or charge the
+        // exiting account if no recipient weight or B headroom remains.
+        let exit_loss_charge = if dust_carry == 0 {
+            0
+        } else if V16Core::apply_bankruptcy_residual_chunk_to_loss_side(
+            &mut asset, leg.side, dust_carry, dust_carry,
+        )?
+        .is_some()
+        {
+            self.mark_attributed_bankruptcy_hlock(asset_index)?;
+            self.header.risk_epoch = V16PodU64::new(
+                self.header
+                    .risk_epoch
+                    .get()
+                    .checked_add(1)
+                    .ok_or(V16Error::CounterOverflow)?,
+            );
+            0
+        } else {
+            dust_carry
+        };
+        if exit_loss_charge != 0 {
+            let charge =
+                i128::try_from(exit_loss_charge).map_err(|_| V16Error::ArithmeticOverflow)?;
+            let new_pnl = account
+                .header
+                .pnl
+                .get()
+                .checked_sub(charge)
+                .ok_or(V16Error::ArithmeticOverflow)?;
+            self.set_account_pnl(account, new_pnl)?;
+        }
         account.header.legs[leg_slot] =
             PortfolioLegV16Account::from_runtime(&PortfolioLegV16::EMPTY);
-        let mut bitmap = account.header.active_bitmap.map(V16PodU64::get);
-        active_bitmap_clear(&mut bitmap, leg_slot)?;
-        account.header.active_bitmap = bitmap.map(V16PodU64::new);
+        account.header.active_bitmap =
+            active_bitmap_with_cleared(account.header.active_bitmap.map(V16PodU64::get), leg_slot)?
+                .map(V16PodU64::new);
         account.header.health_cert.valid = 0;
         self.set_asset_state(asset_index, asset)?;
         Ok(())
@@ -12809,7 +14506,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Err(V16Error::LockActive);
         }
         let leg_slot = Self::require_active_leg_slot_for_asset(&account.as_view(), asset_index)?;
-        let mut leg = account.header.legs[leg_slot].try_to_runtime()?;
+        let leg = account.header.legs[leg_slot].try_to_runtime()?;
         if !leg.active || leg.b_stale || leg.stale {
             return Err(V16Error::InvalidLeg);
         }
@@ -12831,14 +14528,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if self.b_target_for_leg(asset_index, leg)? != leg.b_snap {
             return Err(V16Error::Stale);
         }
-        leg.b_rem = 0;
         let asset = self.asset_state(asset_index)?;
-        let asset = V16Core::kernel_clear_leg(leg, asset)?;
+        let asset = V16Core::kernel_clear_resolved_leg(leg, asset)?;
         account.header.legs[leg_slot] =
             PortfolioLegV16Account::from_runtime(&PortfolioLegV16::EMPTY);
-        let mut bitmap = account.header.active_bitmap.map(V16PodU64::get);
-        active_bitmap_clear(&mut bitmap, leg_slot)?;
-        account.header.active_bitmap = bitmap.map(V16PodU64::new);
+        account.header.active_bitmap =
+            active_bitmap_with_cleared(account.header.active_bitmap.map(V16PodU64::get), leg_slot)?
+                .map(V16PodU64::new);
         account.header.health_cert.valid = 0;
         self.set_asset_state(asset_index, asset)?;
         Ok(())
@@ -13083,12 +14779,35 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.validate_account_audit_scan(&account.as_view())
     }
 
+    fn close_progress_is_asset_local_recovery(
+        &self,
+        ledger: CloseProgressLedgerV16,
+    ) -> V16Result<bool> {
+        let asset_index = ledger.asset_index as usize;
+        self.validate_configured_asset_index(asset_index)?;
+        let asset = self.asset_state(asset_index)?;
+        if asset.market_id != ledger.market_id {
+            return Err(V16Error::InvalidLeg);
+        }
+        Ok(asset.lifecycle == AssetLifecycleV16::Recovery)
+    }
+
     fn ensure_close_progress_not_expired(
         &mut self,
         ledger: CloseProgressLedgerV16,
     ) -> V16Result<()> {
         if ledger.active && self.header.current_slot.get() > ledger.max_close_slot {
-            if decode_market_mode(self.header.mode)? == MarketModeV16::Resolved {
+            let terminal = decode_market_mode(self.header.mode)? == MarketModeV16::Resolved;
+            if terminal {
+                return Ok(());
+            }
+            let asset_local_recovery = self.close_progress_is_asset_local_recovery(ledger)?;
+            if !V16Core::kernel_close_requires_global_recovery(
+                true,
+                true,
+                false,
+                asset_local_recovery,
+            ) {
                 return Ok(());
             }
             self.declare_permissionless_recovery(
@@ -13112,7 +14831,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             && Self::active_leg_slot_for_asset(account, asset_index)?.is_some()
             && self.header.current_slot.get() > ledger.drift_reference_slot
         {
-            if decode_market_mode(self.header.mode)? == MarketModeV16::Resolved {
+            if decode_market_mode(self.header.mode)? == MarketModeV16::Resolved
+                || self.close_progress_is_asset_local_recovery(ledger)?
+            {
                 return Ok(());
             }
             self.declare_permissionless_recovery(
@@ -13307,7 +15028,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 if let Some(asset_mut) = new_asset {
                     self.set_asset_state(asset_index, asset_mut)?;
                 }
-                self.header.bankruptcy_hlock_active = 1;
+                self.mark_attributed_bankruptcy_hlock(asset_index)?;
                 Ok(outcome)
             }
             BResidualStepV16::DeclareRecovery => {
@@ -13374,64 +15095,70 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(outcome)
     }
 
+    fn advance_asset_local_recovery_close_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        asset_index: usize,
+    ) -> V16Result<(BResidualBookingOutcomeV16, bool)> {
+        account.validate_with_market(&self.as_view())?;
+        let ledger = account.header.close_progress.try_to_runtime()?;
+        if !ledger.active
+            || ledger.finalized
+            || ledger.residual_remaining == 0
+            || ledger.asset_index as usize != asset_index
+            || !self.close_progress_is_asset_local_recovery(ledger)?
+        {
+            return Err(V16Error::LockActive);
+        }
+        let leg = Self::active_leg_for_asset(&account.as_view(), asset_index)?;
+        if !leg.active || ledger.domain_side != opposite_side(leg.side) {
+            return Err(V16Error::InvalidLeg);
+        }
+        if account.header.pnl.get() >= 0
+            || account.header.pnl.get().unsigned_abs() != ledger.residual_remaining
+        {
+            return Err(V16Error::InvalidLeg);
+        }
+
+        let outcome = self.book_bankruptcy_residual_chunk_for_account_core(
+            account,
+            asset_index,
+            leg.side,
+            ledger.residual_remaining,
+        )?;
+        let cleared = outcome
+            .booked_loss
+            .checked_add(outcome.explicit_loss)
+            .ok_or(V16Error::ArithmeticOverflow)?
+            .min(ledger.residual_remaining);
+        if cleared == 0 {
+            return Err(V16Error::NonProgress);
+        }
+        let cleared_i128 = i128::try_from(cleared).map_err(|_| V16Error::ArithmeticOverflow)?;
+        let new_pnl = account
+            .header
+            .pnl
+            .get()
+            .checked_add(cleared_i128)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        self.set_account_pnl(account, new_pnl)?;
+
+        let ledger_after = account.header.close_progress.try_to_runtime()?;
+        let detached = ledger_after.residual_remaining == 0 && new_pnl == 0;
+        if detached {
+            self.clear_leg(account, asset_index)?;
+        }
+        self.validate_shape()?;
+        account.validate_with_market(&self.as_view())?;
+        Ok((outcome, detached))
+    }
+
     fn begin_full_drain_reset_inner(&mut self, asset_index: usize, side: SideV16) -> V16Result<()> {
         self.validate_configured_asset_index(asset_index)?;
         if self.has_pending_domain_loss_barrier(asset_index, side)? {
             return Err(V16Error::LockActive);
         }
-        let mut asset = self.asset_state(asset_index)?;
-        match side {
-            SideV16::Long => {
-                if asset.mode_long == SideModeV16::ResetPending {
-                    return Err(V16Error::LockActive);
-                }
-                if asset.oi_eff_long_q != 0 || asset.pending_obligation_count_long != 0 {
-                    return Err(V16Error::LockActive);
-                }
-                quarantine_remainder(
-                    &mut asset.social_loss_remainder_long_num,
-                    &mut asset.social_loss_dust_long_num,
-                )?;
-                asset.k_epoch_start_long = asset.k_long;
-                asset.f_epoch_start_long_num = asset.f_long_num;
-                asset.b_epoch_start_long_num = asset.b_long_num;
-                asset.k_long = 0;
-                asset.f_long_num = 0;
-                asset.b_long_num = 0;
-                asset.loss_weight_sum_long = 0;
-                asset.a_long = ADL_ONE;
-                asset.epoch_long = asset
-                    .epoch_long
-                    .checked_add(1)
-                    .ok_or(V16Error::CounterOverflow)?;
-                asset.mode_long = SideModeV16::ResetPending;
-            }
-            SideV16::Short => {
-                if asset.mode_short == SideModeV16::ResetPending {
-                    return Err(V16Error::LockActive);
-                }
-                if asset.oi_eff_short_q != 0 || asset.pending_obligation_count_short != 0 {
-                    return Err(V16Error::LockActive);
-                }
-                quarantine_remainder(
-                    &mut asset.social_loss_remainder_short_num,
-                    &mut asset.social_loss_dust_short_num,
-                )?;
-                asset.k_epoch_start_short = asset.k_short;
-                asset.f_epoch_start_short_num = asset.f_short_num;
-                asset.b_epoch_start_short_num = asset.b_short_num;
-                asset.k_short = 0;
-                asset.f_short_num = 0;
-                asset.b_short_num = 0;
-                asset.loss_weight_sum_short = 0;
-                asset.a_short = ADL_ONE;
-                asset.epoch_short = asset
-                    .epoch_short
-                    .checked_add(1)
-                    .ok_or(V16Error::CounterOverflow)?;
-                asset.mode_short = SideModeV16::ResetPending;
-            }
-        }
+        let asset = V16Core::kernel_begin_full_drain_reset(self.asset_state(asset_index)?, side)?;
         self.set_asset_state(asset_index, asset)?;
         self.header.risk_epoch = V16PodU64::new(
             self.header
@@ -13494,6 +15221,55 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if opp_oi_after == 0 {
             self.begin_full_drain_reset_inner(asset_index, opp)?;
         }
+        let asset = self.asset_state(asset_index)?;
+        let (closed_oi, closed_stored, closed_pending, closed_mode) = match closed_side {
+            SideV16::Long => (
+                asset.oi_eff_long_q,
+                asset.stored_pos_count_long,
+                asset.pending_obligation_count_long,
+                asset.mode_long,
+            ),
+            SideV16::Short => (
+                asset.oi_eff_short_q,
+                asset.stored_pos_count_short,
+                asset.pending_obligation_count_short,
+                asset.mode_short,
+            ),
+        };
+        if V16Core::kernel_side_needs_full_drain_reset(
+            closed_oi,
+            closed_stored,
+            closed_pending,
+            closed_mode,
+        ) {
+            self.begin_full_drain_reset_inner(asset_index, closed_side)?;
+        }
+        Ok(())
+    }
+
+    fn unilateral_close_capacity(&self, asset_index: usize, stored_abs: u128) -> V16Result<u128> {
+        let asset = self.asset_state(asset_index)?;
+        Ok(V16Core::kernel_unilateral_close_capacity(
+            stored_abs,
+            asset.oi_eff_long_q,
+            asset.oi_eff_short_q,
+        ))
+    }
+
+    fn begin_side_reset_if_effective_oi_exhausted(
+        &mut self,
+        asset_index: usize,
+        side: SideV16,
+    ) -> V16Result<()> {
+        let asset = self.asset_state(asset_index)?;
+        if Self::side_effective_oi(asset, side) == 0
+            && Self::side_stored_position_count(asset, side) != 0
+            && Self::side_pending_obligation_count(asset, side) == 0
+            && Self::side_mode(asset, side) != SideModeV16::ResetPending
+            && !self.has_pending_domain_loss_barrier(asset_index, side)?
+        {
+            self.begin_full_drain_reset_inner(asset_index, side)?;
+        }
         Ok(())
     }
 
@@ -13518,6 +15294,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             SideV16::Short => close_i128,
         };
         self.apply_position_delta(account, asset_index, delta)?;
+        self.begin_side_reset_if_effective_oi_exhausted(asset_index, leg.side)?;
         self.reduce_matching_open_interest_for_unilateral_close(asset_index, leg.side, close_q)
     }
 
@@ -13535,18 +15312,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         let fee_bps = config.liquidation_fee_bps;
         self.require_asset_live_reducible(request.asset_index)?;
-        self.validate_account_scalar_preflight(&account.as_view())?;
+        let cert = self.settle_account_for_position_action_and_refresh_not_atomic(account)?;
         Self::require_active_leg_slot_for_asset(&account.as_view(), request.asset_index)?;
-        match self.refresh_account_and_certify_not_atomic(
-            account,
-            None,
-            self.header.config.public_b_chunk_atoms.get(),
-            false,
-        )? {
-            AccountRefreshCertOutcomeV16::Certified(_) => {}
-            AccountRefreshCertOutcomeV16::BChunk(_) => return Err(V16Error::BStale),
-        }
-        let cert = account.header.health_cert.try_to_runtime()?;
         if cert.certified_liq_deficit == 0 {
             return Err(V16Error::NonProgress);
         }
@@ -13572,9 +15339,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // risk-reduction kernel rebalance uses, so A5.dec's strict-progress
         // contract now governs the real liquidation route (3C). Liquidation size
         // is engine-selected: close just enough to restore maintenance health
-        // when possible, otherwise close the selected leg fully.
+        // when possible, otherwise close the selected leg fully. Matched OI is
+        // the hard capacity when ADL left stored basis above effective exposure.
+        let close_budget = close_request_q.min(
+            self.unilateral_close_capacity(request.asset_index, leg.basis_pos_q.unsigned_abs())?,
+        );
+        if close_budget == 0 {
+            return Err(V16Error::NonProgress);
+        }
         let (close_q, close_delta) =
-            V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, close_request_q)?;
+            V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, close_budget)?;
         if self.position_delta_touches_pending_domain_loss_barrier(
             &account.as_view(),
             request.asset_index,
@@ -13609,7 +15383,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             close_q == leg.basis_pos_q.unsigned_abs(),
         )?;
         let charged_fee = self.charge_account_fee_not_atomic(account, fee)?;
+        let bankruptcy_hlock_before_principal = self.header.bankruptcy_hlock_active;
         self.settle_negative_pnl_from_principal_core_not_atomic(account)?;
+        if account.header.pnl.get() < 0 {
+            self.mark_attributed_bankruptcy_hlock_after_principal_settlement(
+                bankruptcy_hlock_before_principal,
+                request.asset_index,
+            )?;
+        }
         let gross_bankruptcy_residual = if account.header.pnl.get() < 0 {
             account.header.pnl.get().unsigned_abs()
         } else {
@@ -13656,7 +15437,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .checked_add(cleared_i128)
                 .ok_or(V16Error::ArithmeticOverflow)?;
             self.set_account_pnl(account, new_pnl)?;
-            self.header.bankruptcy_hlock_active = 1;
+            self.mark_attributed_bankruptcy_hlock(request.asset_index)?;
         }
         self.reduce_position(account, request.asset_index, close_q)?;
         self.certify_account_after_local_settlement_with_price_override(account, None)?;
@@ -13698,8 +15479,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         // PRODUCTION KERNEL: clamp + toward-zero reduction delta (rank decrease,
         // never over-closes, full close clears).
+        let reduce_budget = request.reduce_q.min(
+            self.unilateral_close_capacity(request.asset_index, leg.basis_pos_q.unsigned_abs())?,
+        );
         let (reduce_q, reduce_delta) =
-            V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, request.reduce_q)?;
+            V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, reduce_budget)?;
         if reduce_q == 0 {
             return Err(V16Error::NonProgress);
         }
@@ -13711,7 +15495,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Err(V16Error::LockActive);
         }
         self.reduce_position(account, request.asset_index, reduce_q)?;
-        self.settle_negative_pnl_from_principal_not_atomic(account)?;
+        if account.header.pnl.get() < 0 {
+            self.settle_negative_pnl_from_principal_not_atomic(account)?;
+        }
         self.certify_account_after_local_settlement_with_price_override(account, None)?;
         self.validate_liquidation_progress_from_score(before_score, &account.as_view())?;
         self.validate_shape_audit_scan()?;
@@ -13726,18 +15512,31 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
     ) -> V16Result<HealthCertV16> {
         self.validate_account_scalar_preflight(&account.as_view())?;
-        if !decode_bool(account.header.stale_state)?
-            && !decode_bool(account.header.b_stale_state)?
+        let account_stale = decode_bool(account.header.stale_state)?;
+        let account_b_stale = decode_bool(account.header.b_stale_state)?;
+        let cert_current = !account_stale
+            && !account_b_stale
             && self
                 .ensure_favorable_action_current_certificate(&account.as_view())
-                .is_ok()
-            && !Self::has_b_stale_leg(&account.as_view())?
-        {
+                .is_ok();
+        let has_b_stale_leg = if cert_current {
+            Self::has_b_stale_leg(&account.as_view())?
+        } else {
+            true
+        };
+        if V16Core::kernel_position_action_reuses_current_certificate(
+            account_stale,
+            account_b_stale,
+            cert_current,
+            has_b_stale_leg,
+        ) {
             return account.header.health_cert.try_to_runtime();
         }
         match self.refresh_account_and_certify_not_atomic(account, None, 0, false)? {
             AccountRefreshCertOutcomeV16::Certified(cert) => Ok(cert),
+            AccountRefreshCertOutcomeV16::LegSettled { .. } => Err(V16Error::Stale),
             AccountRefreshCertOutcomeV16::BChunk(_) => Err(V16Error::BStale),
+            AccountRefreshCertOutcomeV16::SourceBackingExpired(_) => Err(V16Error::Stale),
         }
     }
 
@@ -13769,6 +15568,27 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             account.header.fee_credits.get(),
             cert.certified_initial_req,
         )
+    }
+
+    fn ensure_trade_final_margin_policy(
+        long_account: &PortfolioV16View<'_>,
+        short_account: &PortfolioV16View<'_>,
+        locked: bool,
+        risk_increasing: bool,
+    ) -> V16Result<()> {
+        let long_cert = long_account.header.health_cert.try_to_runtime()?;
+        let short_cert = short_account.header.health_cert.try_to_runtime()?;
+        let maintenance_healthy =
+            long_cert.certified_liq_deficit == 0 && short_cert.certified_liq_deficit == 0;
+        if risk_increasing || !maintenance_healthy {
+            Self::ensure_initial_margin(long_account)?;
+            Self::ensure_initial_margin(short_account)?;
+            if locked {
+                Self::ensure_no_positive_credit_initial_margin(long_account)?;
+                Self::ensure_no_positive_credit_initial_margin(short_account)?;
+            }
+        }
+        Ok(())
     }
 
     fn recertify_account_after_source_lien_change(
@@ -13993,12 +15813,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 self.create_initial_margin_source_lien_if_needed(short_account)?;
             }
         }
-        Self::ensure_initial_margin(&long_account.as_view())?;
-        Self::ensure_initial_margin(&short_account.as_view())?;
-        if locked {
-            Self::ensure_no_positive_credit_initial_margin(&long_account.as_view())?;
-            Self::ensure_no_positive_credit_initial_margin(&short_account.as_view())?;
-        }
+        // Initial margin admits new risk and remains mandatory for any liquidatable post-state.
+        // A maintenance-healthy matched reduction has already proved that neither absolute
+        // position grows. Requiring that reduction to restore IM in one fill can strand a large
+        // position when the opposite open interest is split across smaller portfolios.
+        Self::ensure_trade_final_margin_policy(
+            &long_account.as_view(),
+            &short_account.as_view(),
+            locked,
+            risk_increasing,
+        )?;
         self.validate_shape_audit_scan()?;
         self.validate_account_audit_scan(&long_account.as_view())?;
         self.validate_account_audit_scan(&short_account.as_view())?;
@@ -14191,7 +16015,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if account.header.pnl.get() >= 0 {
             return Ok(());
         }
-        self.header.bankruptcy_hlock_active = 1;
+        self.mark_unattributed_bankruptcy_hlock()?;
         self.set_account_pnl(account, 0)?;
         account.header.health_cert.valid = 0;
         Ok(())
@@ -14213,7 +16037,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return self.clear_resolved_unattributed_negative_pnl(account);
         };
 
-        self.header.bankruptcy_hlock_active = 1;
+        self.mark_attributed_bankruptcy_hlock(asset_index)?;
         let gross_residual = account.header.pnl.get().unsigned_abs();
         if !account.header.close_progress.try_to_runtime()?.active {
             self.begin_close_progress_ledger(
@@ -14286,7 +16110,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             pnl,
         )?;
         if paid == 0 {
-            self.header.bankruptcy_hlock_active = 1;
+            self.mark_bankruptcy_hlock_for_account(&account.as_view())?;
             return Ok(0);
         }
 
@@ -14296,7 +16120,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.set_account_pnl_after_principal_settlement(account, new_pnl)?;
         Self::record_account_residual_crystallized_loss(account, paid)?;
         if new_pnl < 0 {
-            self.header.bankruptcy_hlock_active = 1;
+            self.mark_bankruptcy_hlock_for_account(&account.as_view())?;
         }
         TokenValueFlowProofV16::account_capital_to_realized_loss(
             paid,
@@ -14450,8 +16274,19 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if decode_bool(account.header.resolved_payout_receipt.present)? {
             return Ok(());
         }
-        self.initialize_resolved_payout_ledger_if_needed()?;
         let terminal_positive_claim_face = account.header.pnl.get().max(0) as u128;
+        self.append_resolved_payout_receipt_face_not_atomic(account, terminal_positive_claim_face)
+    }
+
+    fn append_resolved_payout_receipt_face_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        terminal_positive_claim_face: u128,
+    ) -> V16Result<()> {
+        if terminal_positive_claim_face == 0 {
+            return Ok(());
+        }
+        self.initialize_resolved_payout_ledger_if_needed()?;
         let prior_bound_contribution_num =
             V16Core::bound_num_from_amount(terminal_positive_claim_face)?;
         let mut ledger = self.header.resolved_payout_ledger.try_to_runtime()?;
@@ -14475,15 +16310,25 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             )?)
             .ok_or(V16Error::ArithmeticOverflow)?;
         self.header.resolved_payout_ledger = ResolvedPayoutLedgerV16Account::from_runtime(&ledger);
+        let mut receipt = account.header.resolved_payout_receipt.try_to_runtime()?;
+        if !receipt.present {
+            if !receipt.is_empty() {
+                return Err(V16Error::InvalidLeg);
+            }
+            receipt.present = true;
+        }
+        receipt.prior_bound_contribution_num = receipt
+            .prior_bound_contribution_num
+            .checked_add(prior_bound_contribution_num)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        receipt.terminal_positive_claim_face = receipt
+            .terminal_positive_claim_face
+            .checked_add(terminal_positive_claim_face)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        receipt.finalized = receipt.paid_effective == receipt.terminal_positive_claim_face;
+        validate_resolved_payout_receipt_value(receipt)?;
         account.header.resolved_payout_receipt =
-            ResolvedPayoutReceiptV16Account::from_runtime(&ResolvedPayoutReceiptV16 {
-                present: true,
-                prior_bound_contribution_num,
-                live_released_face_at_receipt: 0,
-                terminal_positive_claim_face,
-                paid_effective: 0,
-                finalized: false,
-            });
+            ResolvedPayoutReceiptV16Account::from_runtime(&receipt);
         self.recompute_resolved_payout_rate()
     }
 
@@ -14981,9 +16826,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     }
 
     pub fn resolve_market_not_atomic(&mut self, resolved_slot: u64) -> V16Result<()> {
-        if decode_market_mode(self.header.mode)? == MarketModeV16::Recovery {
-            return Err(V16Error::LockActive);
-        }
+        decode_market_mode(self.header.mode)?;
         if resolved_slot < self.header.current_slot.get() {
             return Err(V16Error::Stale);
         }
@@ -15036,88 +16879,187 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
-    /// Terminal realization for a source-backed winner: realize the account's
-    /// outstanding source-credit claims against their domain backing at the
-    /// current credit rate (lien consumption -> capital credit) BEFORE the claim
-    /// face enters the junior receipt pool. A settlement-quality claim is
-    /// realizable at rate in Live (convert_released_pnl_to_capital); resolution
-    /// must not strip that entitlement -- without this step the wind-down
-    /// RELEASES the backing to the provider while the winner is haircut from a
-    /// residual pool that (correctly) excludes the very backing underwriting the
-    /// claim. Residual-neutral: capital/c_tot grow by exactly the consumed
-    /// backing atoms, so the payout snapshot does not depend on realization
-    /// order.
-    fn realize_source_backed_claims_for_resolved_close_not_atomic(
+    /// Perform at most one preparatory source-domain mutation before terminal
+    /// realization. Source claims cannot be removed piecemeal while their face
+    /// remains positive PnL: the persisted representation requires any nonempty
+    /// source roster to cover the account's full positive PnL. Lien release and
+    /// backing expiry preserve that invariant, so expose those as bounded
+    /// progress-only steps and leave claim settlement for a later call.
+    fn prepare_one_source_domain_for_resolved_close_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
-    ) -> V16Result<u128> {
-        if decode_bool(account.header.resolved_payout_receipt.present)? {
-            // The face is already frozen into the receipt pool.
-            return Ok(0);
-        }
+    ) -> V16Result<Option<usize>> {
         if !Self::account_has_source_claims(&account.as_view())? {
-            return Ok(0);
+            return Ok(None);
         }
-        let pos = account.header.pnl.get().max(0) as u128;
-        if pos == 0 {
-            return Ok(0);
-        }
-        // Release the account's persisted liens first (the terminal burn would do
-        // this anyway): the conversion consumes only UNLIENED claims, so a still-
-        // liened claim would make the realizable estimate exceed what consumption
-        // can deliver and dead-lock the close with LockActive. In the same sweep,
-        // expire any domain whose backing bucket has lapsed (status Fresh but
-        // expiry_slot <= current_slot): realization is best-effort, and querying
-        // realizable support against a past-expiry bucket would otherwise return
-        // Stale and strand the winner's close. Expiry forfeits the lapsed
-        // principal to the junior pool (the documented expiry semantics), drops
-        // the domain's credit rate to zero, and lets this step fall through to
-        // the junior receipt path instead of reverting.
+        account.compact_source_domains();
         let current_slot = self.header.current_slot.get();
-        let mut slot = 0usize;
-        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
-            let source = account.header.source_domains[slot];
-            if source.has_default_sparse_tag() && !source.is_occupied() {
-                break;
-            }
-            if source.is_occupied() {
-                let d = source.domain.get() as usize;
-                if source.source_claim_liened_num.get() != 0 {
-                    self.release_account_source_credit_lien_for_domain_not_atomic(account, d)?;
-                }
-                let bucket = self.backing_bucket_for_domain(d)?;
-                if bucket.status == BackingBucketStatusV16::Fresh
-                    && bucket.expiry_slot <= current_slot
-                {
-                    self.expire_source_backing_bucket_not_atomic(d, current_slot)?;
-                }
-            }
-            slot += 1;
+        let source = account.header.source_domains[0];
+        if !source.is_occupied() || source.source_claim_bound_num.get() == 0 {
+            return Err(V16Error::InvalidLeg);
         }
-        if self.account_source_realizable_support(&account.as_view(), pos)? == 0 {
-            return Ok(0);
+        let domain = source.domain.get() as usize;
+        self.domain_asset_side(domain)?;
+        let bucket = self.backing_bucket_for_domain(domain)?;
+        match V16Core::resolved_source_close_phase(
+            source.source_claim_liened_num.get(),
+            bucket.status,
+            bucket.expiry_slot,
+            current_slot,
+        ) {
+            ResolvedSourceClosePhaseV16::ReleaseLien => {
+                self.release_account_source_credit_lien_for_domain_not_atomic(account, domain)?;
+                account.header.health_cert.valid = 0;
+                self.validate_shape()?;
+                account.validate_with_market(&self.as_view())?;
+                Ok(Some(domain))
+            }
+            ResolvedSourceClosePhaseV16::ExpireBacking => {
+                self.expire_source_backing_bucket_not_atomic(domain, current_slot)?;
+                account.header.health_cert.valid = 0;
+                self.validate_shape()?;
+                account.validate_with_market(&self.as_view())?;
+                Ok(Some(domain))
+            }
+            ResolvedSourceClosePhaseV16::ProcessClaim => Ok(None),
         }
-        // Terminal: PnL reservations no longer gate realization.
-        account.header.reserved_pnl = V16PodU128::new(0);
-        let converted = self.convert_released_pnl_to_capital_core_not_atomic(account)?;
-        // If the payout snapshot was captured before this account realized (another
-        // winner closed first), the realized face is still counted in the ledger's
-        // unreceipted bound. Refine it out, or the stale bound dilutes the payout
-        // rate forever and blocks every remaining receipt from reaching the
-        // terminal rate (never finalized, never clearable).
-        if decode_bool(self.header.payout_snapshot_captured)? {
-            let pos_after = account.header.pnl.get().max(0) as u128;
-            let face_burned = pos
-                .checked_sub(pos_after)
+    }
+
+    /// Settle exactly one prepared source domain. Realizable source support
+    /// becomes capital; any remaining face moves into the exact resolved payout
+    /// receipt. PnL falls by the full processed face, so the remaining source
+    /// roster still covers all remaining positive PnL at every committed step.
+    fn process_one_source_claim_for_resolved_close_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+    ) -> V16Result<Option<usize>> {
+        if !Self::account_has_source_claims(&account.as_view())? {
+            return Ok(None);
+        }
+
+        account.compact_source_domains();
+        let source = account.header.source_domains[0];
+        if !source.is_occupied() || source.source_claim_bound_num.get() == 0 {
+            return Err(V16Error::InvalidLeg);
+        }
+        let domain = source.domain.get() as usize;
+        self.domain_asset_side(domain)?;
+        if source.source_claim_liened_num.get() != 0 {
+            return Err(V16Error::LockActive);
+        }
+
+        let pos_before = account.header.pnl.get().max(0) as u128;
+        let pos_bound_num = V16Core::bound_num_from_amount(pos_before)?;
+        let realizable_claim_num =
+            Self::source_claim_unliened_num(&account.as_view(), domain)?.min(pos_bound_num);
+        let source_credit = self.source_credit_for_domain(domain)?;
+        self.validate_source_domain_ledger_current(domain)?;
+        let credited_num = U256::from_u128(realizable_claim_num)
+            .checked_mul(U256::from_u128(source_credit.credit_rate_num))
+            .and_then(|v| v.checked_div(U256::from_u128(CREDIT_RATE_SCALE)))
+            .and_then(|v| v.try_into_u128())
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        let effective = (credited_num / BOUND_SCALE)
+            .min(self.source_credit_available_backing_num(domain)? / BOUND_SCALE)
+            .min(pos_before);
+
+        if effective != 0 {
+            account.header.reserved_pnl = V16PodU128::new(0);
+            let vault_before = self.header.vault.get();
+            let consumption =
+                self.consume_source_domain_credit_for_effective_not_atomic(domain, effective)?;
+            let face_burn = consumption.face_burn.min(pos_before);
+            let face_i128 = i128::try_from(face_burn).map_err(|_| V16Error::ArithmeticOverflow)?;
+            let new_pnl = account
+                .header
+                .pnl
+                .get()
+                .checked_sub(face_i128)
+                .ok_or(V16Error::ArithmeticOverflow)?;
+            self.set_account_pnl(account, new_pnl)?;
+            account.header.capital = V16PodU128::new(
+                account
+                    .header
+                    .capital
+                    .get()
+                    .checked_add(effective)
+                    .ok_or(V16Error::ArithmeticOverflow)?,
+            );
+            self.header.c_tot = V16PodU128::new(
+                self.header
+                    .c_tot
+                    .get()
+                    .checked_add(effective)
+                    .ok_or(V16Error::ArithmeticOverflow)?,
+            );
+            self.header.pnl_matured_pos_tot = V16PodU128::new(
+                self.header
+                    .pnl_matured_pos_tot
+                    .get()
+                    .saturating_sub(face_burn),
+            );
+            let protocol_surplus_consumed = effective
+                .checked_sub(consumption.counterparty_credit_consumed)
+                .and_then(|v| v.checked_sub(consumption.insurance_credit_consumed))
                 .ok_or(V16Error::CounterUnderflow)?;
-            let ledger = self.header.resolved_payout_ledger.try_to_runtime()?;
-            let decrease_num = V16Core::bound_num_from_amount(face_burned)?
-                .min(ledger.terminal_claim_bound_unreceipted_num);
-            if decrease_num != 0 {
-                self.refine_resolved_unreceipted_bound_not_atomic(decrease_num)?;
+            TokenValueFlowProofV16::support_to_account_capital(
+                effective,
+                consumption.counterparty_credit_consumed,
+                consumption.insurance_credit_consumed,
+                protocol_surplus_consumed,
+                vault_before,
+                self.header.vault.get(),
+            )?
+            .validate()?;
+
+            if decode_bool(self.header.payout_snapshot_captured)? {
+                let ledger = self.header.resolved_payout_ledger.try_to_runtime()?;
+                let decrease_num = V16Core::bound_num_from_amount(face_burn)?
+                    .min(ledger.terminal_claim_bound_unreceipted_num);
+                if decrease_num != 0 {
+                    self.refine_resolved_unreceipted_bound_not_atomic(decrease_num)?;
+                }
             }
         }
-        Ok(converted)
+
+        let pnl_after_source = account.header.pnl.get().max(0) as u128;
+        let remaining_domain_claim_num = account
+            .as_view()
+            .source_domain(domain)?
+            .source_claim_bound_num
+            .get();
+        let total_claim_num = Self::account_source_claim_bound_sum_num(&account.as_view())?;
+        let claims_after_domain_num = total_claim_num
+            .checked_sub(remaining_domain_claim_num)
+            .ok_or(V16Error::CounterUnderflow)?;
+        let target_pnl = if claims_after_domain_num == 0 {
+            0
+        } else {
+            pnl_after_source.min(claims_after_domain_num / BOUND_SCALE)
+        };
+        let junior_face = pnl_after_source
+            .checked_sub(target_pnl)
+            .ok_or(V16Error::CounterUnderflow)?;
+        if junior_face != 0 {
+            self.initialize_resolved_payout_ledger_if_needed()?;
+            let target_i128 =
+                i128::try_from(target_pnl).map_err(|_| V16Error::ArithmeticOverflow)?;
+            self.set_account_pnl(account, target_i128)?;
+        }
+        if let Some(slot) = account.source_domain_slot(domain)? {
+            let remainder_num = account.header.source_domains[slot]
+                .source_claim_bound_num
+                .get();
+            self.burn_account_source_claim_bound_num(account, remainder_num)?;
+        }
+        if junior_face != 0 {
+            self.append_resolved_payout_receipt_face_not_atomic(account, junior_face)?;
+        }
+
+        account.header.health_cert.valid = 0;
+        self.validate_shape()?;
+        account.validate_with_market(&self.as_view())?;
+        Ok(Some(domain))
     }
 
     fn claim_resolved_payout_topup_core_not_atomic(
@@ -15219,7 +17161,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if account.header.pnl.get() < 0 {
             self.settle_resolved_bankruptcy_negative_pnl(account)?;
         }
-        self.detach_solvent_active_legs_for_resolved_close(account)?;
+        if self.detach_one_solvent_active_leg_for_resolved_close(account)? {
+            self.validate_shape()?;
+            self.validate_account_audit_scan(&account.as_view())?;
+            return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
+        }
         if !active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get))
             || account.header.pnl.get() < 0
             || decode_bool(account.header.b_stale_state)?
@@ -15230,7 +17176,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if account.header.pnl.get() > 0 && !self.resolved_positive_payout_ready()? {
             return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
         }
-        self.realize_source_backed_claims_for_resolved_close_not_atomic(account)?;
+        if self
+            .prepare_one_source_domain_for_resolved_close_not_atomic(account)?
+            .is_some()
+        {
+            return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
+        }
+        if self
+            .process_one_source_claim_for_resolved_close_not_atomic(account)?
+            .is_some()
+        {
+            return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
+        }
         let mut payout_receipt = None;
         let pnl_payout = if account.header.pnl.get() > 0
             || decode_bool(account.header.resolved_payout_receipt.present)?
@@ -15244,14 +17201,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             0
         };
         let account_capital = account.header.capital.get();
-        let payout = account_capital
-            .checked_add(pnl_payout)
-            .ok_or(V16Error::ArithmeticOverflow)?
-            .min(self.header.vault.get());
-        let capital_paid = account_capital.min(payout);
-        let resolved_paid = payout
-            .checked_sub(capital_paid)
-            .ok_or(V16Error::CounterUnderflow)?;
+        let vault_before = self.header.vault.get();
+        let (payout, capital_paid, resolved_paid, vault_after, c_tot_after) =
+            V16Core::resolved_close_terminal_payout_delta(
+                account_capital,
+                pnl_payout,
+                vault_before,
+                self.header.c_tot.get(),
+            )?;
         if let Some(mut receipt) = payout_receipt {
             receipt = apply_resolved_payout_receipt_payment(receipt, resolved_paid)?;
             account.header.resolved_payout_receipt =
@@ -15261,20 +17218,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // (insolvency bad-debt shortfall is not an open obligation) so this close fully
         // settles instead of leaving the portfolio stuck present-but-unfinalized.
         self.clear_fully_diluted_resolved_receipt_if_terminal(account)?;
-        let vault_before = self.header.vault.get();
-        self.header.vault = V16PodU128::new(
-            self.header
-                .vault
-                .get()
-                .checked_sub(payout)
-                .ok_or(V16Error::CounterUnderflow)?,
-        );
-        self.header.c_tot = V16PodU128::new(
-            self.header
-                .c_tot
-                .get()
-                .saturating_sub(account_capital.min(self.header.c_tot.get())),
-        );
+        self.header.vault = V16PodU128::new(vault_after);
+        self.header.c_tot = V16PodU128::new(c_tot_after);
         self.set_account_pnl(account, 0)?;
         account.header.capital = V16PodU128::new(0);
         account.header.reserved_pnl = V16PodU128::new(0);
@@ -15293,10 +17238,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(ResolvedCloseOutcomeV16::Closed { payout })
     }
 
-    fn detach_solvent_active_legs_for_resolved_close(
+    fn detach_one_solvent_active_leg_for_resolved_close(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
-    ) -> V16Result<()> {
+    ) -> V16Result<bool> {
         if account.header.pnl.get() < 0
             || decode_bool(account.header.b_stale_state)?
             || decode_bool(account.header.stale_state)?
@@ -15306,44 +17251,36 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .try_to_runtime()?
                 .has_pending_residual()
         {
-            return Ok(());
+            return Ok(false);
         }
 
-        let configured_max = self.header.config.max_market_slots.get() as usize;
-        let mut slot = 0usize;
-        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
-            let leg = account.header.legs[slot].try_to_runtime()?;
-            if leg.active {
-                if leg.b_stale || leg.stale {
-                    return Ok(());
-                }
-                let asset_index = leg.asset_index as usize;
-                if asset_index >= configured_max {
-                    return Err(V16Error::InvalidLeg);
-                }
-                if self.has_pending_domain_loss_barrier(asset_index, leg.side)? {
-                    return Ok(());
-                }
-                let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;
-                if k_target != leg.k_snap || f_target != leg.f_snap {
-                    return Ok(());
-                }
-                if self.b_target_for_leg(asset_index, leg)? != leg.b_snap {
-                    return Ok(());
-                }
-            }
-            slot += 1;
+        let bitmap = account.header.active_bitmap.map(V16PodU64::get);
+        let Some(slot) = first_active_bitmap_slot(bitmap)? else {
+            return Ok(false);
+        };
+        let leg = account.header.legs[slot].try_to_runtime()?;
+        if !leg.active {
+            return Err(V16Error::HiddenLeg);
         }
-
-        let mut slot = 0usize;
-        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
-            let leg = account.header.legs[slot].try_to_runtime()?;
-            if leg.active {
-                self.clear_resolved_close_leg(account, leg.asset_index as usize)?;
-            }
-            slot += 1;
+        if leg.b_stale || leg.stale {
+            return Ok(false);
         }
-        Ok(())
+        let asset_index = leg.asset_index as usize;
+        if asset_index >= self.header.config.max_market_slots.get() as usize {
+            return Err(V16Error::InvalidLeg);
+        }
+        if self.has_pending_domain_loss_barrier(asset_index, leg.side)? {
+            return Ok(false);
+        }
+        let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;
+        if k_target != leg.k_snap || f_target != leg.f_snap {
+            return Ok(false);
+        }
+        if self.b_target_for_leg(asset_index, leg)? != leg.b_snap {
+            return Ok(false);
+        }
+        self.clear_resolved_close_leg(account, asset_index)?;
+        Ok(true)
     }
 
     pub fn deposit_not_atomic(
@@ -15478,6 +17415,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             )?;
 
         let slot = self.markets[asset_index].engine_slot_mut();
+        self.header
+            .clear_attributed_bankruptcy_asset_for_reuse(slot)?;
         *slot = Self::restarted_asset_slot_preserving_insurance_budget(
             slot,
             market_id,
@@ -15554,8 +17493,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         self.require_empty_asset_lifecycle_state(asset_index)?;
 
-        *self.markets[asset_index].engine_slot_mut() =
-            Self::canonical_retired_asset_slot(old_asset);
+        let slot = self.markets[asset_index].engine_slot_mut();
+        self.header
+            .clear_attributed_bankruptcy_asset_for_reuse(slot)?;
+        *slot = Self::canonical_retired_asset_slot(old_asset);
         self.validate_shape()
     }
 
@@ -15601,43 +17542,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Ok((0, 0, 0, 0));
         };
         let mut leg = account.header.legs[leg_slot].try_to_runtime()?;
-        let (k_now, f_now) = self.kf_target_for_leg(asset_index, leg)?;
-        let den = leg
-            .a_basis
-            .checked_mul(POS_SCALE)
-            .ok_or(V16Error::ArithmeticOverflow)?;
-        let k_delta = scaled_adl_delta_fast(
-            leg.basis_pos_q.unsigned_abs(),
-            leg.a_basis,
-            leg.k_snap,
-            k_now,
-        )
-        .unwrap_or_else(|| {
-            wide_signed_mul_div_floor_from_k_pair(
-                leg.basis_pos_q.unsigned_abs(),
-                leg.k_snap,
-                k_now,
-                den,
-            )
-        });
-        let f_delta = scaled_adl_delta_fast(
-            leg.basis_pos_q.unsigned_abs(),
-            leg.a_basis,
-            leg.f_snap,
-            f_now,
-        )
-        .unwrap_or_else(|| {
-            wide_signed_mul_div_floor_from_k_pair(
-                leg.basis_pos_q.unsigned_abs(),
-                leg.f_snap,
-                f_now,
-                den,
-            )
-        });
-        let net = k_delta
-            .checked_add(f_delta)
-            .ok_or(V16Error::ArithmeticOverflow)?;
-        validate_non_min_i128(net)?;
+        let asset = self.asset_state(asset_index)?;
+        let (k_now, f_now, _k_delta, f_delta, k_rem_num, f_rem_num, net) =
+            Self::leg_kf_delta_components_for_settlement_from_asset(asset, leg)?;
 
         let mut loss_settled = 0u128;
         let mut support_consumed = 0u128;
@@ -15655,6 +17562,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Self::record_account_funding_flow(account, leg.side, f_delta)?;
         leg.k_snap = k_now;
         leg.f_snap = f_now;
+        leg.k_rem_num = k_rem_num;
+        leg.f_rem_num = f_rem_num;
         account.header.legs[leg_slot] = PortfolioLegV16Account::from_runtime(&leg);
         account.header.health_cert.valid = 0;
         Ok((
@@ -15678,12 +17587,43 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         {
             return Err(V16Error::InvalidLeg);
         }
-        let leg = Self::active_leg_for_asset(&account.as_view(), asset_index)?;
+        let mut leg = Self::active_leg_for_asset(&account.as_view(), asset_index)?;
         if !leg.active {
             return Err(V16Error::InvalidLeg);
         }
         if !self.leg_is_dead_for_forfeit(asset_index, leg.side)? {
             return Err(V16Error::LockActive);
+        }
+        if Self::leg_has_exhausted_effective_oi(self.asset_state(asset_index)?, leg)
+            && !account
+                .header
+                .close_progress
+                .try_to_runtime()?
+                .has_pending_residual()
+            && !self.has_pending_domain_loss_barrier(asset_index, leg.side)?
+        {
+            // A matched Recovery close can consume the final effective OI while
+            // leaving an ADL-reduced account's larger stored basis behind. Move
+            // that terminal residue into the reset epoch before forfeit clears it.
+            self.begin_full_drain_reset_inner(asset_index, leg.side)?;
+            leg = Self::active_leg_for_asset(&account.as_view(), asset_index)?;
+        }
+
+        let existing_close = account.header.close_progress.try_to_runtime()?;
+        if existing_close.has_pending_residual() {
+            let (booking, detached) =
+                self.advance_asset_local_recovery_close_not_atomic(account, asset_index)?;
+            return Ok(DeadLegForfeitOutcomeV16 {
+                detached,
+                positive_pnl_forfeited: 0,
+                loss_settled: 0,
+                support_consumed: 0,
+                junior_face_burned: 0,
+                principal_used: 0,
+                insurance_used: 0,
+                residual_booked: booking.booked_loss,
+                explicit_loss: booking.explicit_loss,
+            });
         }
 
         let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;
@@ -15841,6 +17781,8 @@ pub struct PortfolioLegV16Account {
     pub a_basis: V16PodU128,
     pub k_snap: V16PodI128,
     pub f_snap: V16PodI128,
+    pub k_rem_num: V16PodU128,
+    pub f_rem_num: V16PodU128,
     pub epoch_snap: V16PodU64,
     pub loss_weight: V16PodU128,
     pub b_snap: V16PodU128,
@@ -15861,6 +17803,8 @@ impl PortfolioLegV16Account {
             a_basis: V16PodU128::new(value.a_basis),
             k_snap: V16PodI128::new(value.k_snap),
             f_snap: V16PodI128::new(value.f_snap),
+            k_rem_num: V16PodU128::new(value.k_rem_num),
+            f_rem_num: V16PodU128::new(value.f_rem_num),
             epoch_snap: V16PodU64::new(value.epoch_snap),
             loss_weight: V16PodU128::new(value.loss_weight),
             b_snap: V16PodU128::new(value.b_snap),
@@ -15881,6 +17825,8 @@ impl PortfolioLegV16Account {
             a_basis: self.a_basis.get(),
             k_snap: self.k_snap.get(),
             f_snap: self.f_snap.get(),
+            k_rem_num: self.k_rem_num.get(),
+            f_rem_num: self.f_rem_num.get(),
             epoch_snap: self.epoch_snap.get(),
             loss_weight: self.loss_weight.get(),
             b_snap: self.b_snap.get(),
@@ -16192,7 +18138,7 @@ pub struct PortfolioAccountV16Account {
 // Gated to non-kani: under `cfg(kani)` PORTFOLIO_SOURCE_DOMAIN_CAP is reduced for
 // proof tractability, so the production on-chain layout is the non-kani one.
 #[cfg(not(kani))]
-const _: () = assert!(core::mem::size_of::<PortfolioAccountV16Account>() == 9291);
+const _: () = assert!(core::mem::size_of::<PortfolioAccountV16Account>() == 9803);
 
 impl Default for PortfolioAccountV16Account {
     fn default() -> Self {
@@ -16278,7 +18224,9 @@ impl RiskScoreV16 {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PermissionlessProgressOutcomeV16 {
     AccountCurrent,
+    AccountLegSettled { asset_index: usize },
     AccountBChunk(AccountBSettlementChunkV16),
+    SourceBackingExpired { domain: usize },
     ResidualBooked(BResidualBookingOutcomeV16),
     RecoveryDeclared(PermissionlessRecoveryReasonV16),
 }
@@ -16453,6 +18401,44 @@ pub fn kani_trade_fee_atoms_per_side(
     checked_fee_bps(fee_notional, fee_bps)
 }
 
+/// Proof seam for the production close classifier and auto-crank selector. It
+/// keeps the full state-space theorem scalar while exercising the exact O(1)
+/// decision and priority kernel used by the public crank.
+#[cfg(kani)]
+pub fn kani_close_progress_auto_crank_plan(
+    close_active: bool,
+    residual_remaining: u128,
+    deadline_expired: bool,
+    asset_local_recovery: bool,
+    stale: bool,
+    b_stale: bool,
+    liquidatable: bool,
+) -> AutoCrankPlanV16 {
+    let close_outstanding = close_active && residual_remaining != 0;
+    let summary = ActionableSummaryV16 {
+        stale,
+        b_stale,
+        pending_close: close_outstanding && asset_local_recovery,
+        expired_close: V16Core::kernel_close_requires_global_recovery(
+            close_outstanding,
+            deadline_expired,
+            false,
+            asset_local_recovery,
+        ),
+        liquidatable,
+        recovery_eligible: false,
+        resolved_winner: false,
+    };
+    V16Core::select_auto_crank_plan(
+        summary,
+        7,
+        11,
+        13,
+        Some(13),
+        PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+    )
+}
+
 fn checked_i128_mul(a: i128, b: i128) -> V16Result<i128> {
     let out = a.checked_mul(b).ok_or(V16Error::ArithmeticOverflow)?;
     validate_non_min_i128(out)?;
@@ -16491,6 +18477,46 @@ fn decode_bool(value: u8) -> V16Result<bool> {
         1 => Ok(true),
         _ => Err(V16Error::InvalidConfig),
     }
+}
+
+pub fn bankruptcy_hlock_to_wire(active: bool, fully_attributed: bool) -> u8 {
+    if !active {
+        0
+    } else if fully_attributed {
+        2
+    } else {
+        1
+    }
+}
+
+pub fn bankruptcy_hlock_active_from_wire(value: u8) -> V16Result<bool> {
+    match value {
+        0 => Ok(false),
+        1 | 2 => Ok(true),
+        _ => Err(V16Error::InvalidConfig),
+    }
+}
+
+pub fn bankruptcy_hlock_fully_attributed_from_wire(value: u8) -> V16Result<bool> {
+    match value {
+        0 | 1 => Ok(false),
+        2 => Ok(true),
+        _ => Err(V16Error::InvalidConfig),
+    }
+}
+
+fn validate_bankruptcy_hlock_summary(value: u8, attributed_asset_count: u32) -> V16Result<()> {
+    match value {
+        0 if attributed_asset_count == 0 => Ok(()),
+        1 => Ok(()),
+        2 if attributed_asset_count != 0 => Ok(()),
+        0 | 2 => Err(V16Error::InvalidConfig),
+        _ => Err(V16Error::InvalidConfig),
+    }
+}
+
+pub fn bankruptcy_asset_slot_has_lock_state(slot: &EngineAssetSlotV16Account) -> V16Result<bool> {
+    decode_bool(slot.bankruptcy_hlock_active)
 }
 
 fn encode_side(value: SideV16) -> u8 {
@@ -16650,21 +18676,6 @@ fn fraction_ge(lhs_num: u128, lhs_den: u128, rhs_num: u128, rhs_den: u128) -> V1
     Ok(lhs >= rhs)
 }
 
-fn quarantine_remainder(remainder: &mut u128, dust: &mut u128) -> V16Result<()> {
-    if *remainder == 0 {
-        return Ok(());
-    }
-    let new_dust = dust
-        .checked_add(*remainder)
-        .ok_or(V16Error::ArithmeticOverflow)?;
-    if new_dust >= SOCIAL_LOSS_DEN {
-        return Err(V16Error::RecoveryRequired);
-    }
-    *dust = new_dust;
-    *remainder = 0;
-    Ok(())
-}
-
 fn validate_non_min_i128(v: i128) -> V16Result<()> {
     if v == i128::MIN {
         return Err(V16Error::ArithmeticOverflow);
@@ -16693,6 +18704,10 @@ fn validate_basis(basis_pos_q: i128) -> V16Result<()> {
 fn validate_active_leg(leg: PortfolioLegV16) -> V16Result<()> {
     validate_non_min_i128(leg.k_snap)?;
     validate_non_min_i128(leg.f_snap)?;
+    let kf_den = leg
+        .a_basis
+        .checked_mul(POS_SCALE)
+        .ok_or(V16Error::ArithmeticOverflow)?;
     let current_loss_weight = if leg.basis_pos_q == 0 {
         0
     } else {
@@ -16703,6 +18718,8 @@ fn validate_active_leg(leg: PortfolioLegV16) -> V16Result<()> {
         || leg.loss_weight == 0
         || leg.loss_weight < current_loss_weight
         || leg.loss_weight > SOCIAL_LOSS_DEN
+        || leg.k_rem_num >= kf_den
+        || leg.f_rem_num >= kf_den
         || leg.b_rem >= SOCIAL_LOSS_DEN
         || leg.b_epoch_snap != leg.epoch_snap
     {
@@ -16773,11 +18790,22 @@ fn loss_weight_for_basis(abs_basis_q: u128, a_basis: u128) -> V16Result<u128> {
     .ok_or(V16Error::ArithmeticOverflow)
 }
 
+#[cfg(any(kani, feature = "fuzz"))]
 fn scaled_adl_delta_fast(abs_basis_q: u128, a_basis: u128, then: i128, now: i128) -> Option<i128> {
+    scaled_adl_delta_with_carry_fast(abs_basis_q, a_basis, then, now, 0).map(|(q, _)| q)
+}
+
+fn scaled_adl_delta_with_carry_fast(
+    abs_basis_q: u128,
+    a_basis: u128,
+    then: i128,
+    now: i128,
+    carry: u128,
+) -> Option<(i128, u128)> {
     if abs_basis_q == 0 {
-        return Some(0);
+        return Some((0, carry));
     }
-    if a_basis != ADL_ONE {
+    if a_basis != ADL_ONE || carry % ADL_ONE != 0 {
         return None;
     }
     let adl_one_i = i128::try_from(ADL_ONE).ok()?;
@@ -16788,7 +18816,21 @@ fn scaled_adl_delta_fast(abs_basis_q: u128, a_basis: u128, then: i128, now: i128
     let scaled_delta = delta / adl_one_i;
     let basis_i = i128::try_from(abs_basis_q).ok()?;
     let numerator = scaled_delta.checked_mul(basis_i)?;
-    Some(floor_div_signed_conservative_i128(numerator, POS_SCALE))
+    let reduced_carry = i128::try_from(carry / ADL_ONE).ok()?;
+    let total = numerator.checked_add(reduced_carry)?;
+    let quotient = floor_div_signed_conservative_i128(total, POS_SCALE);
+    let reduced_remainder = if total >= 0 {
+        (total as u128) % POS_SCALE
+    } else {
+        let rem = total.unsigned_abs() % POS_SCALE;
+        if rem == 0 {
+            0
+        } else {
+            POS_SCALE - rem
+        }
+    };
+    let remainder = reduced_remainder.checked_mul(ADL_ONE)?;
+    Some((quotient, remainder))
 }
 
 // Non-production Kani proof harnesses (contract + closure layers) live in

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -9,6 +9,134 @@
 use super::*;
 use crate::wide_math::U256;
 
+pub fn kani_resolved_source_close_phase(
+    source_claim_liened_num: u128,
+    bucket_status: BackingBucketStatusV16,
+    bucket_expiry_slot: u64,
+    current_slot: u64,
+) -> u8 {
+    match V16Core::resolved_source_close_phase(
+        source_claim_liened_num,
+        bucket_status,
+        bucket_expiry_slot,
+        current_slot,
+    ) {
+        ResolvedSourceClosePhaseV16::ReleaseLien => 0,
+        ResolvedSourceClosePhaseV16::ExpireBacking => 1,
+        ResolvedSourceClosePhaseV16::ProcessClaim => 2,
+    }
+}
+
+pub fn kani_commit_declared_liquidation_recovery(
+    error: V16Error,
+    mode: MarketModeV16,
+    reason: Option<PermissionlessRecoveryReasonV16>,
+) -> V16Result<PermissionlessProgressOutcomeV16> {
+    V16Core::kernel_commit_declared_liquidation_recovery(error, mode, reason)
+}
+
+pub fn kani_clear_resolved_leg(
+    leg: PortfolioLegV16,
+    asset: AssetStateV16,
+) -> V16Result<AssetStateV16> {
+    V16Core::kernel_clear_resolved_leg(leg, asset)
+}
+
+pub fn kani_auto_crank_lifecycle_dispatchable(lifecycle: AssetLifecycleV16) -> bool {
+    V16Core::kernel_auto_crank_lifecycle_dispatchable(lifecycle)
+}
+
+pub fn kani_auto_crank_leg_flags(
+    active: bool,
+    lifecycle: AssetLifecycleV16,
+    basis_pos_q: i128,
+    side_oi_q: u128,
+    side_mode: SideModeV16,
+    asset_epoch: u64,
+    leg_epoch_snap: u64,
+    leg_b_stale: bool,
+) -> (bool, bool, bool, bool) {
+    V16Core::kernel_auto_crank_leg_flags(
+        active,
+        lifecycle,
+        basis_pos_q,
+        side_oi_q,
+        side_mode,
+        asset_epoch,
+        leg_epoch_snap,
+        leg_b_stale,
+    )
+}
+
+pub fn kani_should_clear_prior_reset_obligation(
+    already_cleared: bool,
+    prior_reset_obligation: bool,
+    pending_close_residual: bool,
+) -> bool {
+    V16Core::kernel_should_clear_prior_reset_obligation(
+        already_cleared,
+        prior_reset_obligation,
+        pending_close_residual,
+    )
+}
+
+pub fn kani_auto_crank_liquidatable(
+    live: bool,
+    cert_current: bool,
+    certified_liq_deficit: u128,
+    dispatchable_asset: Option<usize>,
+) -> bool {
+    V16Core::kernel_auto_crank_liquidatable(
+        live,
+        cert_current,
+        certified_liq_deficit,
+        dispatchable_asset,
+    )
+}
+
+pub fn kani_first_actionable_slot(flags: [bool; V16_MAX_PORTFOLIO_ASSETS_N]) -> Option<usize> {
+    V16Core::first_actionable_slot(flags)
+}
+
+pub fn kani_permissionless_kf_settlement_commits_step(
+    allow_b_chunk: bool,
+    source_domain_count: usize,
+    has_pending_kf: bool,
+    leg_kf_pending: bool,
+) -> bool {
+    V16Core::kernel_permissionless_kf_settlement_commits_step(
+        allow_b_chunk,
+        source_domain_count,
+        has_pending_kf,
+        leg_kf_pending,
+    )
+}
+
+pub fn kani_select_auto_crank_plan(
+    summary: ActionableSummaryV16,
+    pending_close_slot: usize,
+    b_stale_slot: usize,
+    liq_slot: usize,
+    refresh_asset: Option<usize>,
+    recovery_reason: PermissionlessRecoveryReasonV16,
+) -> AutoCrankPlanV16 {
+    V16Core::select_auto_crank_plan(
+        summary,
+        pending_close_slot,
+        b_stale_slot,
+        liq_slot,
+        refresh_asset,
+        recovery_reason,
+    )
+}
+
+pub fn kani_auto_crank_skip_post_action_accrual(
+    observations_preaccrued: bool,
+    selected_observation_supplied: bool,
+) -> bool {
+    auto_crank_skip_post_action_accrual(observations_preaccrued, selected_observation_supplied)
+}
+
 pub fn kani_apply_backing_utilization_fee_charge(
     account_capital: u128,
     group_c_tot: u128,
@@ -58,11 +186,54 @@ pub fn kani_cert_is_current(
     )
 }
 
+pub fn kani_position_action_reuses_current_certificate(
+    account_stale: bool,
+    account_b_stale: bool,
+    cert_current: bool,
+    has_b_stale_leg: bool,
+) -> bool {
+    V16Core::kernel_position_action_reuses_current_certificate(
+        account_stale,
+        account_b_stale,
+        cert_current,
+        has_b_stale_leg,
+    )
+}
+
 pub fn kani_active_bitmap_set(
     bitmap: &mut V16ActiveBitmap,
     leg_slot_index: usize,
 ) -> V16Result<()> {
     active_bitmap_set(bitmap, leg_slot_index)
+}
+
+pub fn kani_active_bitmap_with_cleared(
+    bitmap: V16ActiveBitmap,
+    leg_slot_index: usize,
+) -> V16Result<V16ActiveBitmap> {
+    active_bitmap_with_cleared(bitmap, leg_slot_index)
+}
+
+pub fn kani_first_active_bitmap_slot(bitmap: V16ActiveBitmap) -> V16Result<Option<usize>> {
+    first_active_bitmap_slot(bitmap)
+}
+
+pub fn kani_build_resolved_close_rank(
+    b_stale: bool,
+    pnl: i128,
+    active_bitmap: V16ActiveBitmap,
+    capital: u128,
+    receipt_present: bool,
+    recovery_required: bool,
+) -> ResolvedCloseRankV16 {
+    V16Core::build_resolved_close_rank(
+        b_stale,
+        pnl,
+        active_bitmap,
+        capital,
+        receipt_present,
+        recovery_required,
+    )
 }
 
 pub fn kani_liquidation_close_would_leave_uncovered_loss_with_open_risk(
@@ -451,9 +622,59 @@ impl MarketGroupV16HeaderAccount {
     ) -> V16Result<()> {
         self.validate_dynamic_market_slot_shape_at(slot_index, slot)
     }
+
+    pub fn kani_clear_attributed_bankruptcy_asset_for_reuse(
+        &mut self,
+        slot: &mut EngineAssetSlotV16Account,
+    ) -> V16Result<()> {
+        self.clear_attributed_bankruptcy_asset_for_reuse(slot)
+    }
 }
 
 impl<'a, T> MarketGroupV16ViewMut<'a, T> {
+    pub fn kani_kernel_unilateral_close_capacity(
+        stored_abs: u128,
+        oi_eff_long_q: u128,
+        oi_eff_short_q: u128,
+    ) -> u128 {
+        V16Core::kernel_unilateral_close_capacity(stored_abs, oi_eff_long_q, oi_eff_short_q)
+    }
+
+    pub fn kani_kernel_reduce_position_delta(
+        pre_basis_signed: i128,
+        side: SideV16,
+        requested: u128,
+    ) -> V16Result<(u128, i128)> {
+        V16Core::kernel_reduce_position_delta(pre_basis_signed, side, requested)
+    }
+
+    pub fn kani_kernel_begin_full_drain_reset(
+        asset: AssetStateV16,
+        side: SideV16,
+    ) -> V16Result<AssetStateV16> {
+        V16Core::kernel_begin_full_drain_reset(asset, side)
+    }
+
+    pub fn kani_kernel_clear_leg(
+        leg: PortfolioLegV16,
+        asset: AssetStateV16,
+    ) -> V16Result<AssetStateV16> {
+        V16Core::kernel_clear_leg(leg, asset)
+    }
+
+    pub fn kani_leg_has_exhausted_effective_oi(asset: AssetStateV16, leg: PortfolioLegV16) -> bool {
+        Self::leg_has_exhausted_effective_oi(asset, leg)
+    }
+
+    pub fn kani_reduce_matching_open_interest_for_unilateral_close(
+        &mut self,
+        asset_index: usize,
+        closed_side: SideV16,
+        close_q: u128,
+    ) -> V16Result<()> {
+        self.reduce_matching_open_interest_for_unilateral_close(asset_index, closed_side, close_q)
+    }
+
     pub fn kani_clear_leg(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
@@ -636,6 +857,30 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         )
     }
 
+    pub fn kani_apply_insurance_source_credit_lien_delta(
+        source: &mut PortfolioSourceDomainV16Account,
+        required_face_num: u128,
+        required_backing_num: u128,
+        effective_credit: u128,
+        current_slot: u64,
+    ) -> V16Result<()> {
+        Self::apply_account_source_credit_lien_delta(
+            source,
+            SourceCreditBackingSourceV16::Insurance,
+            required_face_num,
+            required_backing_num,
+            effective_credit,
+            current_slot,
+        )
+    }
+
+    pub fn kani_validate_account_source_credit_lien_entry(
+        source: PortfolioSourceDomainV16Account,
+        domain: usize,
+    ) -> V16Result<()> {
+        PortfolioV16View::source_credit_lien_aggregate_proof(source, domain)?.validate()
+    }
+
     pub fn kani_prepare_counterparty_lien_create_delta(
         bucket: BackingBucketV16,
         source: SourceCreditStateV16,
@@ -685,11 +930,129 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         V16Core::prepare_counterparty_backing_withdraw_delta(bucket, source, amount)
     }
 
+    pub fn kani_prepare_counterparty_backing_expiry_delta(
+        bucket: BackingBucketV16,
+        source: SourceCreditStateV16,
+        now_slot: u64,
+    ) -> V16Result<(BackingBucketV16, SourceCreditStateV16)> {
+        V16Core::prepare_counterparty_backing_expiry_delta(bucket, source, now_slot)
+    }
+
+    pub fn kani_lapsed_source_backing_scan_step(
+        selected: Option<usize>,
+        sparse_tail: bool,
+        occupied: bool,
+        domain: usize,
+        bucket_status: BackingBucketStatusV16,
+        expiry_slot: u64,
+        current_slot: u64,
+    ) -> (Option<usize>, bool) {
+        V16Core::kernel_lapsed_source_backing_scan_step(
+            selected,
+            sparse_tail,
+            occupied,
+            domain,
+            bucket_status,
+            expiry_slot,
+            current_slot,
+        )
+    }
+
     pub fn kani_source_credit_lien_amounts_for_effective(
         effective_credit: u128,
         credit_rate_num: u128,
     ) -> V16Result<(u128, u128)> {
         V16Core::source_credit_lien_amounts_for_effective(effective_credit, credit_rate_num)
+    }
+
+    pub fn kani_source_lien_backing_release_for_face_burn(
+        face_locked_num: u128,
+        backing_reserved_num: u128,
+        face_burn_num: u128,
+    ) -> V16Result<u128> {
+        V16Core::source_lien_backing_release_for_face_burn(
+            face_locked_num,
+            backing_reserved_num,
+            face_burn_num,
+        )
+    }
+
+    pub fn kani_source_lien_fee_after_backing_release(
+        fee_revenue: u128,
+        backing_before: u128,
+        backing_after: u128,
+    ) -> V16Result<u128> {
+        V16Core::source_lien_fee_after_backing_release(fee_revenue, backing_before, backing_after)
+    }
+
+    pub fn kani_source_lien_face_burn_plan(
+        counterparty_face_num: u128,
+        insurance_face_num: u128,
+        counterparty_backing_num: u128,
+        insurance_backing_num: u128,
+        face_burn_num: u128,
+    ) -> V16Result<(u128, u128, u128, u128, u128)> {
+        V16Core::source_lien_face_burn_plan(
+            counterparty_face_num,
+            insurance_face_num,
+            counterparty_backing_num,
+            insurance_backing_num,
+            face_burn_num,
+        )
+    }
+
+    pub fn kani_source_lien_face_burn_partition(
+        counterparty_face_num: u128,
+        insurance_face_num: u128,
+        face_burn_num: u128,
+    ) -> V16Result<(u128, u128)> {
+        V16Core::source_lien_face_burn_partition(
+            counterparty_face_num,
+            insurance_face_num,
+            face_burn_num,
+        )
+    }
+
+    pub fn kani_prepare_account_counterparty_lien_impairment(
+        source: PortfolioSourceDomainV16Account,
+    ) -> V16Result<(PortfolioSourceDomainV16Account, u128)> {
+        V16Core::prepare_account_counterparty_lien_impairment(source)
+    }
+
+    pub fn kani_live_source_backing_reconcile_scan_step(
+        selected: Option<(usize, bool, bool)>,
+        sparse_tail: bool,
+        occupied: bool,
+        domain: usize,
+        counterparty_backing_num: u128,
+        bucket_status: BackingBucketStatusV16,
+        expiry_slot: u64,
+        current_slot: u64,
+    ) -> (Option<(usize, bool, bool)>, bool) {
+        V16Core::kernel_live_source_backing_reconcile_scan_step(
+            selected,
+            sparse_tail,
+            occupied,
+            domain,
+            counterparty_backing_num,
+            bucket_status,
+            expiry_slot,
+            current_slot,
+        )
+    }
+
+    pub fn kani_source_credit_lien_allocation_take(
+        remaining: u128,
+        unliened_face_num: u128,
+        available_backing_num: u128,
+        credit_rate_num: u128,
+    ) -> V16Result<u128> {
+        V16Core::source_credit_lien_allocation_take(
+            remaining,
+            unliened_face_num,
+            available_backing_num,
+            credit_rate_num,
+        )
     }
 
     pub fn kani_counterparty_cure_atoms_from_scaled_backing(amount: u128) -> V16Result<u128> {
@@ -832,6 +1195,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Self::canonical_retired_asset_slot(old_asset)
     }
 
+    pub fn kani_asset_has_empty_lifecycle_blocker(asset: AssetStateV16) -> bool {
+        Self::asset_has_empty_lifecycle_blocker(asset)
+    }
+
     pub fn kani_convert_source_claim_exposure_guard(
         &self,
         account: &PortfolioV16View<'_>,
@@ -862,6 +1229,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         instruction_bankruptcy_candidate: bool,
     ) -> V16Result<HLockLaneV16> {
         self.h_lock_lane(account, instruction_bankruptcy_candidate)
+    }
+
+    pub fn kani_bankruptcy_hlock_is_only_unrelated_to_account(
+        &self,
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<bool> {
+        self.bankruptcy_hlock_is_only_unrelated_to_account(account)
+    }
+
+    pub fn kani_mark_attributed_bankruptcy_hlock(&mut self, asset_index: usize) -> V16Result<()> {
+        self.mark_attributed_bankruptcy_hlock(asset_index)
     }
 
     pub fn kani_can_ignore_unrelated_loss_stale_for_trade(
@@ -936,6 +1314,15 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &PortfolioV16View<'_>,
     ) -> V16Result<()> {
         Self::ensure_no_positive_credit_initial_margin(account)
+    }
+
+    pub fn kani_ensure_trade_final_margin_policy(
+        long_account: &PortfolioV16View<'_>,
+        short_account: &PortfolioV16View<'_>,
+        locked: bool,
+        risk_increasing: bool,
+    ) -> V16Result<()> {
+        Self::ensure_trade_final_margin_policy(long_account, short_account, locked, risk_increasing)
     }
 
     pub fn kani_apply_trade_after_refresh_not_atomic(
@@ -1018,11 +1405,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Self::resolved_receipt_claimable_against_ledger(receipt, ledger)
     }
 
-    pub fn kani_realize_source_backed_claims_for_resolved_close_not_atomic(
+    pub fn kani_prepare_one_source_domain_for_resolved_close_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
-    ) -> V16Result<u128> {
-        self.realize_source_backed_claims_for_resolved_close_not_atomic(account)
+    ) -> V16Result<Option<usize>> {
+        self.prepare_one_source_domain_for_resolved_close_not_atomic(account)
+    }
+
+    pub fn kani_process_one_source_claim_for_resolved_close_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+    ) -> V16Result<Option<usize>> {
+        self.process_one_source_claim_for_resolved_close_not_atomic(account)
     }
 
     pub fn kani_create_resolved_payout_receipt_if_needed(
@@ -1030,6 +1424,20 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
     ) -> V16Result<()> {
         self.create_resolved_payout_receipt_if_needed(account)
+    }
+
+    pub fn kani_resolved_close_terminal_payout_delta(
+        account_capital: u128,
+        resolved_claimable: u128,
+        vault: u128,
+        c_tot: u128,
+    ) -> V16Result<(u128, u128, u128, u128, u128)> {
+        V16Core::resolved_close_terminal_payout_delta(
+            account_capital,
+            resolved_claimable,
+            vault,
+            c_tot,
+        )
     }
 
     pub fn kani_claim_resolved_payout_topup_core_not_atomic(
@@ -1179,6 +1587,7 @@ pub fn kani_eq_market_group_v16_header_account(
         && a.funding_epoch.get() == b.funding_epoch.get()
         && a.slot_last.get() == b.slot_last.get()
         && a.current_slot.get() == b.current_slot.get()
+        && a.bankruptcy_hlock_asset_count.get() == b.bankruptcy_hlock_asset_count.get()
         && a.bankruptcy_hlock_active == b.bankruptcy_hlock_active
         && a.threshold_stress_active == b.threshold_stress_active
         && a.loss_stale_active == b.loss_stale_active
@@ -1292,6 +1701,7 @@ pub fn kani_eq_engine_asset_slot_v16_account(
         && a.insurance_domain_spent_short.get() == b.insurance_domain_spent_short.get()
         && a.pending_domain_loss_barrier_long.get() == b.pending_domain_loss_barrier_long.get()
         && a.pending_domain_loss_barrier_short.get() == b.pending_domain_loss_barrier_short.get()
+        && a.bankruptcy_hlock_active == b.bankruptcy_hlock_active
         && kani_eq_source_credit_state_v16_account(&a.source_credit_long, &b.source_credit_long)
         && kani_eq_source_credit_state_v16_account(&a.source_credit_short, &b.source_credit_short)
         && kani_eq_backing_bucket_v16_account(&a.backing_long, &b.backing_long)
@@ -1350,6 +1760,8 @@ pub fn kani_eq_portfolio_leg_v16_account(
         && a.a_basis.get() == b.a_basis.get()
         && a.k_snap.get() == b.k_snap.get()
         && a.f_snap.get() == b.f_snap.get()
+        && a.k_rem_num.get() == b.k_rem_num.get()
+        && a.f_rem_num.get() == b.f_rem_num.get()
         && a.epoch_snap.get() == b.epoch_snap.get()
         && a.loss_weight.get() == b.loss_weight.get()
         && a.b_snap.get() == b.b_snap.get()
@@ -1649,7 +2061,7 @@ pub enum TradeRejectReasonV16 {
 pub struct ResolvedCloseRankV16 {
     pub b_stale: bool,           // outstanding B settlement
     pub negative_pnl: bool,      // unsettled negative PnL
-    pub active_leg: bool,        // an open leg remains
+    pub active_leg_count: u32,   // exact number of open legs remaining
     pub receipt_claim: bool,     // an unpaid resolved receipt claim
     pub capital: bool,           // residual capital to disburse
     pub recovery_required: bool, // the explicit recovery predicate holds
@@ -1658,7 +2070,11 @@ pub struct ResolvedCloseRankV16 {
 impl ResolvedCloseRankV16 {
     #[cfg_attr(not(kani), allow(dead_code))] // PROOF-ONLY: used by kernel_resolved_close_progress (fidelity model)
     pub fn has_pending(self) -> bool {
-        self.b_stale || self.negative_pnl || self.active_leg || self.receipt_claim || self.capital
+        self.b_stale
+            || self.negative_pnl
+            || self.active_leg_count != 0
+            || self.receipt_claim
+            || self.capital
     }
 }
 
@@ -1683,9 +2099,9 @@ pub enum ResolvedCloseStepV16 {
 )]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ProgressContinuationV16 {
-    DeclareRecovery, // A4 expired close / A6 recovery-eligible: terminal recovery
+    DeclareRecovery, // A4 expired non-isolated close / A6 recovery-eligible
     CloseResolved,   // A7 resolved winner: terminal realization
-    AdvanceClose,    // A3 pending close residual: close-ledger rank step
+    AdvanceClose,    // A3 frozen recovery-asset residual: close-ledger rank step
     SettleBChunk,    // A2 b-stale leg: B-advance rank step
     Liquidate,       // A5 liquidatable: risk-reduction
     RefreshAccount,  // A1 stale account: protective accrual segment
@@ -1901,14 +2317,14 @@ impl V16Core {
     /// PRODUCTION FIDELITY BUILDER (roadmap 3C step 3, A7 close-rank): map the
     /// real resolved-close per-component signals to the compact rank summary that
     /// kernel_resolved_close_progress classifies. Each rank flag is EXACTLY its
-    /// production predicate — b-stale bit, negative PnL, a live leg (non-empty
-    /// active bitmap), residual capital, an open receipt, and the explicit
+    /// production predicate — b-stale bit, negative PnL, the exact active-bitmap
+    /// population count, residual capital, an open receipt, and the explicit
     /// recovery predicate — so the close-rank summary faithfully represents the
     /// real account/market state (no hidden pending component outside it). Pure.
     #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|r: &ResolvedCloseRankV16| {
         r.b_stale == b_stale
             && r.negative_pnl == (pnl < 0)
-            && r.active_leg == !active_bitmap_is_empty(active_bitmap)
+            && r.active_leg_count == active_bitmap_count_ones(active_bitmap)
             && r.capital == (capital > 0)
             && r.receipt_claim == receipt_present
             && r.recovery_required == recovery_required
@@ -1925,7 +2341,7 @@ impl V16Core {
         ResolvedCloseRankV16 {
             b_stale,
             negative_pnl: pnl < 0,
-            active_leg: !active_bitmap_is_empty(active_bitmap),
+            active_leg_count: active_bitmap_count_ones(active_bitmap),
             capital: capital > 0,
             receipt_claim: receipt_present,
             recovery_required,
@@ -1944,5 +2360,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         request: PermissionlessCrankRequestV16,
     ) -> V16Result<PermissionlessProgressOutcomeV16> {
         self.permissionless_crank_not_atomic(account, request)
+    }
+
+    pub fn kani_permissionless_crank_with_skip_post_action_accrual(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        request: PermissionlessCrankRequestV16,
+        skip_post_action_accrual: bool,
+    ) -> V16Result<PermissionlessProgressOutcomeV16> {
+        self.permissionless_crank_impl_not_atomic(account, request, skip_post_action_accrual)
     }
 }

--- a/src/v16_proofs.rs
+++ b/src/v16_proofs.rs
@@ -47,6 +47,23 @@ use crate::{BOUND_SCALE, MAX_VAULT_TVL, V16_TOKEN_VALUE_CLASS_COUNT};
 // with the standalone suite proofs, which fix the operands concretely.
 
 #[cfg(all(kani, feature = "contracts"))]
+#[kani::proof_for_contract(V16Core::kernel_commit_declared_liquidation_recovery)]
+#[kani::unwind(4)]
+#[kani::solver(cadical)]
+fn contract_check_kernel_commit_declared_liquidation_recovery() {
+    let error: V16Error = kani::any();
+    let mode_tag: u8 = kani::any();
+    kani::assume(mode_tag < 3);
+    let mode = match mode_tag {
+        0 => MarketModeV16::Live,
+        1 => MarketModeV16::Resolved,
+        _ => MarketModeV16::Recovery,
+    };
+    let reason: Option<PermissionlessRecoveryReasonV16> = kani::any();
+    let _ = V16Core::kernel_commit_declared_liquidation_recovery(error, mode, reason);
+}
+
+#[cfg(all(kani, feature = "contracts"))]
 #[kani::proof_for_contract(V16Core::prepare_counterparty_lien_consume_delta)]
 #[kani::unwind(8)]
 #[kani::solver(cadical)]
@@ -1400,6 +1417,8 @@ fn contract_check_kernel_resize_leg_same_side() {
         a_basis: kani::any(),
         k_snap: kani::any(),
         f_snap: kani::any(),
+        k_rem_num: kani::any(),
+        f_rem_num: kani::any(),
         epoch_snap: kani::any(),
         loss_weight: kani::any(),
         b_snap: kani::any(),
@@ -1548,6 +1567,143 @@ fn contract_check_kernel_attach_leg() {
 }
 
 #[cfg(all(kani, feature = "contracts"))]
+#[kani::proof_for_contract(V16Core::kernel_fold_social_loss_dust)]
+#[kani::unwind(4)]
+#[kani::solver(cadical)]
+fn contract_check_kernel_fold_social_loss_dust() {
+    let current_dust: u128 = kani::any();
+    let leg_remainder: u128 = kani::any();
+    kani::assume(current_dust < SOCIAL_LOSS_DEN);
+    kani::assume(leg_remainder < SOCIAL_LOSS_DEN);
+    let result = V16Core::kernel_fold_social_loss_dust(current_dust, leg_remainder);
+    kani::cover!(
+        current_dust + leg_remainder < SOCIAL_LOSS_DEN
+            && result == Ok((current_dust + leg_remainder, 0)),
+        "canonical fractions can fold without a carry"
+    );
+    kani::cover!(
+        current_dust + leg_remainder >= SOCIAL_LOSS_DEN
+            && result == Ok((current_dust + leg_remainder - SOCIAL_LOSS_DEN, 1)),
+        "canonical fractions can fold one whole-atom carry"
+    );
+}
+
+#[cfg(all(kani, feature = "contracts"))]
+#[kani::proof_for_contract(V16Core::kernel_quarantine_social_loss_remainder)]
+#[kani::unwind(4)]
+#[kani::solver(cadical)]
+fn contract_check_kernel_quarantine_social_loss_remainder() {
+    let social_remainder: u128 = kani::any();
+    let current_dust: u128 = kani::any();
+    let explicit_before: u128 = kani::any();
+    kani::assume(social_remainder < SOCIAL_LOSS_DEN);
+    kani::assume(current_dust < SOCIAL_LOSS_DEN);
+    kani::assume(explicit_before < u128::MAX);
+    let result = V16Core::kernel_quarantine_social_loss_remainder(
+        social_remainder,
+        current_dust,
+        explicit_before,
+    );
+    kani::cover!(
+        current_dust + social_remainder < SOCIAL_LOSS_DEN
+            && result == Ok((current_dust + social_remainder, explicit_before)),
+        "canonical reset remainder can fold without a carry"
+    );
+    kani::cover!(
+        current_dust + social_remainder >= SOCIAL_LOSS_DEN
+            && result
+                == Ok((
+                    current_dust + social_remainder - SOCIAL_LOSS_DEN,
+                    explicit_before + 1,
+                )),
+        "canonical reset remainder can quarantine one explicit loss atom"
+    );
+}
+
+#[cfg(all(kani, feature = "contracts"))]
+#[kani::proof_for_contract(V16Core::kernel_side_needs_full_drain_reset)]
+#[kani::unwind(2)]
+#[kani::solver(cadical)]
+fn contract_check_kernel_side_needs_full_drain_reset() {
+    let effective_oi: u128 = kani::any();
+    let stored_position_count: u64 = kani::any();
+    let pending_obligation_count: u64 = kani::any();
+    let mode = match kani::any::<u8>() % 3 {
+        0 => SideModeV16::Normal,
+        1 => SideModeV16::DrainOnly,
+        _ => SideModeV16::ResetPending,
+    };
+    let reset = V16Core::kernel_side_needs_full_drain_reset(
+        effective_oi,
+        stored_position_count,
+        pending_obligation_count,
+        mode,
+    );
+    kani::cover!(reset, "zero OI with stored positions requires reset");
+    kani::cover!(!reset, "a non-reset state remains unchanged");
+}
+
+// Exercise the production unilateral-close mutation for both orientations,
+// proving that each zero-OI side enters its bounded old-epoch exit route.
+#[cfg(all(kani, feature = "contracts"))]
+#[kani::proof]
+#[kani::unwind(20)]
+#[kani::solver(cadical)]
+fn composition_unilateral_close_resets_both_zero_oi_sides() {
+    let cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic([1u8; 32], cfg, 1, 0).unwrap();
+    let mut markets = [Market::new(0u64, EngineAssetSlotV16Account::default())];
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        market.activate_empty_market_not_atomic(0, 100, 1).unwrap();
+    }
+
+    let closed_side = if kani::any() {
+        SideV16::Long
+    } else {
+        SideV16::Short
+    };
+    let stored_position_count = u64::from(kani::any::<u8>()).saturating_add(1);
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    match closed_side {
+        SideV16::Long => {
+            asset.oi_eff_long_q = 0;
+            asset.stored_pos_count_long = stored_position_count;
+            asset.oi_eff_short_q = 1;
+            asset.stored_pos_count_short = 1;
+        }
+        SideV16::Short => {
+            asset.oi_eff_short_q = 0;
+            asset.stored_pos_count_short = stored_position_count;
+            asset.oi_eff_long_q = 1;
+            asset.stored_pos_count_long = 1;
+        }
+    }
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        market
+            .kani_reduce_matching_open_interest_for_unilateral_close(0, closed_side, 1)
+            .unwrap();
+    }
+
+    let after = markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(after.oi_eff_long_q, 0);
+    assert_eq!(after.oi_eff_short_q, 0);
+    assert_eq!(after.mode_long, SideModeV16::ResetPending);
+    assert_eq!(after.mode_short, SideModeV16::ResetPending);
+    kani::cover!(
+        closed_side == SideV16::Long,
+        "long closed side enters reset"
+    );
+    kani::cover!(
+        closed_side == SideV16::Short,
+        "short closed side enters reset"
+    );
+}
+
+#[cfg(all(kani, feature = "contracts"))]
 #[kani::proof_for_contract(V16Core::kernel_clear_leg)]
 #[kani::unwind(8)]
 #[kani::solver(cadical)]
@@ -1565,6 +1721,8 @@ fn contract_check_kernel_clear_leg() {
         a_basis: kani::any(),
         k_snap: kani::any(),
         f_snap: kani::any(),
+        k_rem_num: kani::any(),
+        f_rem_num: kani::any(),
         epoch_snap: kani::any(),
         loss_weight: kani::any(),
         b_snap: kani::any(),
@@ -1625,7 +1783,140 @@ fn contract_check_kernel_clear_leg() {
         },
     };
     kani::assume(leg.basis_pos_q > i128::MIN);
+    kani::assume(leg.b_rem < SOCIAL_LOSS_DEN);
+    kani::assume(asset.social_loss_dust_long_num < SOCIAL_LOSS_DEN);
+    kani::assume(asset.social_loss_dust_short_num < SOCIAL_LOSS_DEN);
     let _ = V16Core::kernel_clear_leg(leg, asset);
+}
+
+#[cfg(all(kani, feature = "contracts"))]
+#[kani::proof_for_contract(V16Core::kernel_clear_resolved_leg)]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn contract_check_kernel_clear_resolved_leg() {
+    let side = if kani::any() {
+        SideV16::Long
+    } else {
+        SideV16::Short
+    };
+    let basis_pos_q: i128 = kani::any();
+    kani::assume(basis_pos_q > i128::MIN);
+    let leg = PortfolioLegV16 {
+        active: true,
+        side,
+        basis_pos_q,
+        epoch_snap: kani::any(),
+        loss_weight: kani::any(),
+        b_rem: kani::any(),
+        ..PortfolioLegV16::EMPTY
+    };
+    let mut asset = AssetStateV16::default();
+    asset.oi_eff_long_q = kani::any();
+    asset.oi_eff_short_q = kani::any();
+    asset.stored_pos_count_long = kani::any();
+    asset.stored_pos_count_short = kani::any();
+    asset.pending_obligation_count_long = kani::any();
+    asset.pending_obligation_count_short = kani::any();
+    asset.loss_weight_sum_long = kani::any();
+    asset.loss_weight_sum_short = kani::any();
+    asset.social_loss_dust_long_num = kani::any();
+    asset.social_loss_dust_short_num = kani::any();
+    asset.epoch_long = kani::any();
+    asset.epoch_short = kani::any();
+    asset.mode_long = if kani::any() {
+        SideModeV16::Normal
+    } else {
+        SideModeV16::ResetPending
+    };
+    asset.mode_short = if kani::any() {
+        SideModeV16::Normal
+    } else {
+        SideModeV16::ResetPending
+    };
+    let _ = V16Core::kernel_clear_resolved_leg(leg, asset);
+}
+
+#[cfg(all(kani, feature = "closure"))]
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_clear_leg_canonical_dust_never_blocks_exit() {
+    let side = if kani::any() {
+        SideV16::Long
+    } else {
+        SideV16::Short
+    };
+    let current_dust: u128 = kani::any();
+    let leg_remainder: u128 = kani::any();
+    kani::assume(current_dust < SOCIAL_LOSS_DEN);
+    kani::assume(leg_remainder < SOCIAL_LOSS_DEN);
+
+    let basis_abs = POS_SCALE;
+    let basis_pos_q = match side {
+        SideV16::Long => basis_abs as i128,
+        SideV16::Short => -(basis_abs as i128),
+    };
+    let leg = PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: 1,
+        side,
+        basis_pos_q,
+        a_basis: POS_SCALE,
+        k_snap: 0,
+        f_snap: 0,
+        k_rem_num: 0,
+        f_rem_num: 0,
+        epoch_snap: 0,
+        loss_weight: 1,
+        b_snap: 0,
+        b_rem: leg_remainder,
+        b_epoch_snap: 0,
+        b_stale: false,
+        stale: false,
+    };
+    let mut asset = AssetStateV16::default();
+    asset.market_id = 1;
+    asset.lifecycle = AssetLifecycleV16::Active;
+    match side {
+        SideV16::Long => {
+            asset.oi_eff_long_q = basis_abs;
+            asset.stored_pos_count_long = 1;
+            asset.loss_weight_sum_long = 1;
+            asset.social_loss_dust_long_num = current_dust;
+        }
+        SideV16::Short => {
+            asset.oi_eff_short_q = basis_abs;
+            asset.stored_pos_count_short = 1;
+            asset.loss_weight_sum_short = 1;
+            asset.social_loss_dust_short_num = current_dust;
+        }
+    }
+
+    let cleared = V16Core::kernel_clear_leg(leg, asset).unwrap();
+    let expected_dust = (current_dust + leg_remainder) % SOCIAL_LOSS_DEN;
+    match side {
+        SideV16::Long => {
+            assert_eq!(cleared.oi_eff_long_q, 0);
+            assert_eq!(cleared.stored_pos_count_long, 0);
+            assert_eq!(cleared.loss_weight_sum_long, 0);
+            assert_eq!(cleared.social_loss_dust_long_num, expected_dust);
+        }
+        SideV16::Short => {
+            assert_eq!(cleared.oi_eff_short_q, 0);
+            assert_eq!(cleared.stored_pos_count_short, 0);
+            assert_eq!(cleared.loss_weight_sum_short, 0);
+            assert_eq!(cleared.social_loss_dust_short_num, expected_dust);
+        }
+    }
+    kani::cover!(
+        current_dust + leg_remainder < SOCIAL_LOSS_DEN,
+        "a no-carry exit clears"
+    );
+    kani::cover!(
+        current_dust + leg_remainder >= SOCIAL_LOSS_DEN,
+        "a whole-atom carry exit clears"
+    );
 }
 
 #[cfg(all(kani, feature = "contracts"))]
@@ -1646,6 +1937,8 @@ fn contract_check_kernel_advance_leg_b_snap() {
         a_basis: kani::any(),
         k_snap: kani::any(),
         f_snap: kani::any(),
+        k_rem_num: kani::any(),
+        f_rem_num: kani::any(),
         epoch_snap: kani::any(),
         loss_weight: kani::any(),
         b_snap: kani::any(),
@@ -2079,6 +2372,8 @@ fn liveness_b_stale_leg_has_advancing_chunk() {
         a_basis: kani::any(),
         k_snap: kani::any(),
         f_snap: kani::any(),
+        k_rem_num: kani::any(),
+        f_rem_num: kani::any(),
         epoch_snap: kani::any(),
         loss_weight: kani::any(),
         b_snap: kani::any(),
@@ -2488,8 +2783,8 @@ fn contract_check_kernel_cert_is_current() {
 
 // ROADMAP 3C step 3 (A7 close-rank fidelity): full-domain contract check that
 // build_resolved_close_rank maps each real per-component signal to its rank flag
-// (b-stale, negative PnL, live leg via non-empty bitmap, capital, receipt,
-// recovery). unwind(16): the active-bitmap is-empty scan / memcmp.
+// (b-stale, negative PnL, exact live-leg count, capital, receipt,
+// recovery). unwind(16): the active-bitmap population scan.
 #[cfg(all(kani, feature = "contracts"))]
 #[kani::proof_for_contract(V16Core::build_resolved_close_rank)]
 #[kani::unwind(16)]
@@ -2746,14 +3041,14 @@ fn contract_check_first_actionable_slot() {
 }
 
 // ENGINE.MD plan selector: totality (actionable -> non-NoAction), priority
-// determinism (recovery > resolved > b-stale > liquidate > refresh), and
-// selected-asset fidelity (SettleBChunk/Liquidate carry the engine-selected
-// slot). pending_close is classifier-unreachable (required absent).
+// determinism (recovery > resolved > recovery-close > b-stale > liquidate >
+// refresh), and selected-asset fidelity for every asset-scoped continuation.
 #[cfg(all(kani, feature = "contracts"))]
 #[kani::proof_for_contract(V16Core::select_auto_crank_plan)]
 #[kani::solver(cadical)]
 fn contract_check_select_auto_crank_plan() {
     let summary: ActionableSummaryV16 = kani::any();
+    let pending_close_slot: usize = kani::any();
     let b_stale_slot: usize = kani::any();
     let liq_slot: usize = kani::any();
     let refresh_asset: Option<usize> = if kani::any() {
@@ -2764,6 +3059,7 @@ fn contract_check_select_auto_crank_plan() {
     let recovery_reason: PermissionlessRecoveryReasonV16 = kani::any();
     let _ = V16Core::select_auto_crank_plan(
         summary,
+        pending_close_slot,
         b_stale_slot,
         liq_slot,
         refresh_asset,

--- a/src/wide_math.rs
+++ b/src/wide_math.rs
@@ -1633,7 +1633,26 @@ pub fn wide_signed_mul_div_floor_from_k_pair(
     k_now: i128,
     den: u128,
 ) -> i128 {
+    wide_signed_mul_div_floor_with_carry_from_k_pair(abs_basis, k_then, k_now, den, 0).0
+}
+
+/// Exact signed floor settlement with a persistent Euclidean remainder.
+///
+/// Computes `floor((carry + abs_basis * (k_now - k_then)) / den)` and returns
+/// the quotient plus the new remainder in `[0, den)`. Carrying that remainder
+/// makes any partition of the same K/F interval settle to the same total.
+pub fn wide_signed_mul_div_floor_with_carry_from_k_pair(
+    abs_basis: u128,
+    k_then: i128,
+    k_now: i128,
+    den: u128,
+    carry: u128,
+) -> (i128, u128) {
     assert!(den > 0, "wide_signed_mul_div_floor_from_k_pair: den == 0");
+    assert!(
+        carry < den,
+        "wide_signed_mul_div_floor_from_k_pair: carry >= den"
+    );
     // Compute d = k_now - k_then in wide signed to avoid i128 overflow (spec §4.8)
     let k_now_wide = I256::from_i128(k_now);
     let k_then_wide = I256::from_i128(k_then);
@@ -1641,7 +1660,7 @@ pub fn wide_signed_mul_div_floor_from_k_pair(
         .checked_sub(k_then_wide)
         .expect("K-diff overflow in wide");
     if d.is_zero() || abs_basis == 0 {
-        return 0i128;
+        return (0, carry);
     }
     let abs_d = d.abs_u256();
     let abs_basis_u256 = U256::from_u128(abs_basis);
@@ -1650,27 +1669,48 @@ pub fn wide_signed_mul_div_floor_from_k_pair(
     let p = abs_basis_u256
         .checked_mul(abs_d)
         .expect("wide product overflow");
-    let (q, rem) = div_rem_u256(p, den_u256);
+    let carry_u256 = U256::from_u128(carry);
     if d.is_negative() {
-        // mag = q + 1 if r != 0 else q
-        let mag = if !rem.is_zero() {
-            q.checked_add(U256::ONE).expect("mag overflow")
+        if p <= carry_u256 {
+            let rem = carry_u256
+                .checked_sub(p)
+                .expect("carry subtraction underflow")
+                .try_into_u128()
+                .expect("carry remainder exceeds u128");
+            return (0, rem);
+        }
+        let magnitude = p
+            .checked_sub(carry_u256)
+            .expect("negative magnitude underflow");
+        let (q, rem) = div_rem_u256(magnitude, den_u256);
+        // floor(-m/d) = -ceil(m/d), with a nonnegative Euclidean remainder.
+        let (mag, next_rem) = if !rem.is_zero() {
+            let mag = q.checked_add(U256::ONE).expect("mag overflow");
+            let rem_u128 = rem.try_into_u128().expect("remainder exceeds u128");
+            (mag, den - rem_u128)
         } else {
-            q
+            (q, 0)
         };
         let mag_u128 = mag.try_into_u128().expect("mag exceeds u128");
         assert!(
             mag_u128 <= i128::MAX as u128,
             "wide_signed_mul_div_floor_from_k_pair: mag > i128::MAX"
         );
-        -(mag_u128 as i128)
+        (-(mag_u128 as i128), next_rem)
     } else {
+        let total = p
+            .checked_add(carry_u256)
+            .expect("wide product + carry overflow");
+        let (q, rem) = div_rem_u256(total, den_u256);
         let q_u128 = q.try_into_u128().expect("quotient exceeds u128");
         assert!(
             q_u128 <= i128::MAX as u128,
             "wide_signed_mul_div_floor_from_k_pair: q > i128::MAX"
         );
-        q_u128 as i128
+        (
+            q_u128 as i128,
+            rem.try_into_u128().expect("remainder exceeds u128"),
+        )
     }
 }
 
@@ -2166,5 +2206,41 @@ mod tests {
             mul_div_floor_u256(U256::ONE, U256::ONE, U256::ONE),
             U256::ONE
         );
+    }
+
+    #[test]
+    fn signed_floor_carry_is_partition_invariant() {
+        for delta in [-1i128, 1i128] {
+            let mut carry = 0u128;
+            let mut fragmented_q = 0i128;
+            for _ in 0..10 {
+                let (q, next_carry) =
+                    wide_signed_mul_div_floor_with_carry_from_k_pair(1, 0, delta, 10, carry);
+                fragmented_q += q;
+                carry = next_carry;
+            }
+            let (delayed_q, delayed_carry) =
+                wide_signed_mul_div_floor_with_carry_from_k_pair(1, 0, delta * 10, 10, 0);
+            assert_eq!((fragmented_q, carry), (delayed_q, delayed_carry));
+        }
+    }
+
+    #[test]
+    fn signed_floor_carry_handles_sign_reversal_and_wide_difference() {
+        let (loss_q, loss_rem) = wide_signed_mul_div_floor_with_carry_from_k_pair(1, 0, -1, 10, 0);
+        assert_eq!((loss_q, loss_rem), (-1, 9));
+        let (recovery_q, recovery_rem) =
+            wide_signed_mul_div_floor_with_carry_from_k_pair(1, 0, 1, 10, loss_rem);
+        assert_eq!((recovery_q, recovery_rem), (1, 0));
+
+        let den = u128::MAX;
+        let (q, rem) = wide_signed_mul_div_floor_with_carry_from_k_pair(
+            1,
+            i128::MAX,
+            i128::MIN + 1,
+            den,
+            den - 1,
+        );
+        assert_eq!((q, rem), (0, 0));
     }
 }

--- a/tests/backing_double_claim_fuzz.rs
+++ b/tests/backing_double_claim_fuzz.rs
@@ -16,7 +16,7 @@ use percolator::{
     Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PortfolioAccountV16Account,
     PortfolioV16ViewMut, ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedCloseOutcomeV16,
     SourceCreditStateV16, SourceCreditStateV16Account, V16Config, V16PodI128, V16PodU128,
-    V16PodU32, V16PodU64, CREDIT_RATE_SCALE,
+    V16PodU32, V16PodU64, CREDIT_RATE_SCALE, PORTFOLIO_SOURCE_DOMAIN_CAP,
 };
 use proptest::prelude::*;
 
@@ -88,6 +88,23 @@ fn winner_account(capital: u128, pnl: u128) -> PortfolioAccountV16Account {
     account_header
 }
 
+fn close_resolved_to_completion(
+    market: &mut MarketGroupV16ViewMut<'_, u64>,
+    account: &mut PortfolioV16ViewMut<'_>,
+) -> (u128, usize) {
+    let max_progress_steps = 3 * PORTFOLIO_SOURCE_DOMAIN_CAP;
+    for progress_steps in 0..=max_progress_steps {
+        match market
+            .close_resolved_account_not_atomic(account, 0)
+            .expect("resolved close step must not revert")
+        {
+            ResolvedCloseOutcomeV16::ProgressOnly => {}
+            ResolvedCloseOutcomeV16::Closed { payout } => return (payout, progress_steps),
+        }
+    }
+    panic!("resolved close exceeded its bounded source-domain progress rank")
+}
+
 /// Close the winner, then (optionally first) withdraw the provider principal.
 /// Returns (winner_payout, vault_after_everything).
 fn run_order(
@@ -110,11 +127,7 @@ fn run_order(
             .withdraw_fresh_counterparty_backing_not_atomic(0, backing)
             .expect("provider principal must be withdrawable before the winner closes");
     }
-    let outcome = market
-        .close_resolved_account_not_atomic(&mut account, 0)
-        .expect("winner close must not revert");
-    let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { .. });
-    assert!(closed, "winner did not fully close");
+    close_resolved_to_completion(&mut market, &mut account);
     if !provider_first {
         market
             .withdraw_fresh_counterparty_backing_not_atomic(0, backing)
@@ -230,11 +243,8 @@ proptest! {
         prop_assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
 
         let vault_before = market.header.vault.get();
-        let outcome = market
-            .close_resolved_account_not_atomic(&mut account, 0)
-            .expect("backed winner close must not revert");
-        let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { payout: _ });
-        prop_assert!(closed, "backed winner did not fully close");
+        let (_, progress_steps) = close_resolved_to_completion(&mut market, &mut account);
+        prop_assert!(progress_steps >= 1);
         let paid = vault_before - market.header.vault.get();
 
         // The Live-realizable portion of the claim must reach the winner...
@@ -325,11 +335,8 @@ proptest! {
         prop_assume!(account.validate_with_market(&market.as_view()) == Ok(()));
 
         let vault_before = market.header.vault.get();
-        let outcome = market
-            .close_resolved_account_not_atomic(&mut account, 0)
-            .expect("liened backed winner close must not revert");
-        let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { payout: _ });
-        prop_assert!(closed, "liened backed winner did not fully close");
+        let (_, progress_steps) = close_resolved_to_completion(&mut market, &mut account);
+        prop_assert!(progress_steps >= 2);
         let paid = vault_before - market.header.vault.get();
 
         // Fully backed claim realizes in full after the terminal lien release.
@@ -406,7 +413,8 @@ fn realization_after_snapshot_refines_unreceipted_bound() {
 
     // B realizes against its backing at terminal close.
     let vault_before_b = market.header.vault.get();
-    market.close_resolved_account_not_atomic(&mut b, 0).unwrap();
+    let (_, progress_steps) = close_resolved_to_completion(&mut market, &mut b);
+    assert!(progress_steps >= 1);
     assert_eq!(vault_before_b - market.header.vault.get(), pnl_b);
     assert_eq!(b.header.pnl.get(), 0);
     assert_eq!(b.header.capital.get(), 0);
@@ -457,11 +465,8 @@ fn terminal_close_with_expired_backing_does_not_strand() {
     assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
 
     let vault_before = market.header.vault.get();
-    let outcome = market
-        .close_resolved_account_not_atomic(&mut account, 0)
-        .expect("expired-backing winner close must not revert (liveness)");
-    let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { payout: _ });
-    assert!(closed, "expired-backing winner did not fully close");
+    let (_, progress_steps) = close_resolved_to_completion(&mut market, &mut account);
+    assert!(progress_steps >= 2);
     let paid = vault_before - market.header.vault.get();
 
     // Expiry forfeits the lapsed principal to the junior pool: the winner is
@@ -481,6 +486,91 @@ fn terminal_close_with_expired_backing_does_not_strand() {
     assert!(market
         .withdraw_fresh_counterparty_backing_not_atomic(0, backing)
         .is_err());
+    assert_eq!(market.validate_shape(), Ok(()));
+}
+
+#[test]
+fn resolved_close_receipts_two_source_domains_one_bounded_step_at_a_time() {
+    let claim_per_domain = 10u128;
+    let total_claim = 2 * claim_per_domain;
+    let cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_id(), cfg, 1, 0).unwrap();
+    let mut markets = [Market::new(0u64, EngineAssetSlotV16Account::default())];
+    header
+        .activate_empty_asset_slot_not_atomic(0, &mut markets[0].engine, 100, 1)
+        .unwrap();
+    header.mode = 1;
+    header.resolved_slot = V16PodU64::new(1);
+    header.current_slot = V16PodU64::new(1);
+    header.vault = V16PodU128::new(total_claim);
+    header.pnl_pos_tot = V16PodU128::new(total_claim);
+    header.pnl_matured_pos_tot = V16PodU128::new(total_claim);
+    header.pnl_pos_bound_tot = V16PodU128::new(total_claim);
+    header.pnl_pos_bound_tot_num = V16PodU128::new(total_claim * BOUND_SCALE);
+    header.source_claim_bound_total_num = V16PodU128::new(total_claim * BOUND_SCALE);
+
+    let domain_claim_num = claim_per_domain * BOUND_SCALE;
+    let source = SourceCreditStateV16 {
+        positive_claim_bound_num: domain_claim_num,
+        exact_positive_claim_num: domain_claim_num,
+        credit_rate_num: 0,
+        ..SourceCreditStateV16::EMPTY
+    };
+    markets[0].engine.source_credit_long = SourceCreditStateV16Account::from_runtime(&source);
+    markets[0].engine.source_credit_short = SourceCreditStateV16Account::from_runtime(&source);
+
+    let engine_market_id = markets[0].engine.asset.market_id.get();
+    let mut account_header = winner_account(0, total_claim);
+    for domain in 0..2usize {
+        account_header.source_domains[domain].domain = V16PodU32::new(domain as u32);
+        account_header.source_domains[domain].source_claim_market_id =
+            V16PodU64::new(engine_market_id);
+        account_header.source_domains[domain].source_claim_bound_num =
+            V16PodU128::new(domain_claim_num);
+    }
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    assert_eq!(market.validate_shape(), Ok(()));
+    assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
+
+    for remaining_domains in [1usize, 0usize] {
+        assert_eq!(
+            market.close_resolved_account_not_atomic(&mut account, 0),
+            Ok(ResolvedCloseOutcomeV16::ProgressOnly),
+        );
+        let occupied = account
+            .header
+            .source_domains
+            .iter()
+            .filter(|source| source.source_claim_bound_num.get() != 0)
+            .count();
+        assert_eq!(occupied, remaining_domains);
+        assert_eq!(
+            account.header.pnl.get(),
+            (remaining_domains as i128) * (claim_per_domain as i128),
+        );
+        let receipt = account
+            .header
+            .resolved_payout_receipt
+            .try_to_runtime()
+            .unwrap();
+        assert_eq!(
+            receipt.terminal_positive_claim_face,
+            (2 - remaining_domains as u128) * claim_per_domain,
+        );
+        assert_eq!(market.validate_shape(), Ok(()));
+        assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
+    }
+
+    assert_eq!(
+        market.close_resolved_account_not_atomic(&mut account, 0),
+        Ok(ResolvedCloseOutcomeV16::Closed {
+            payout: total_claim,
+        }),
+    );
+    assert_eq!(market.header.vault.get(), 0);
+    assert_eq!(account.header.pnl.get(), 0);
     assert_eq!(market.validate_shape(), Ok(()));
 }
 
@@ -511,12 +601,8 @@ proptest! {
         prop_assume!(account.validate_with_market(&market.as_view()) == Ok(()));
 
         let vault_before = market.header.vault.get();
-        let outcome = market
-            .close_resolved_account_not_atomic(&mut account, 0)
-            .expect("backed winner close must not revert at any backing level (no DoS)");
-        // No DoS: the close fully settles rather than stalling.
-        let closed = matches!(outcome, ResolvedCloseOutcomeV16::Closed { payout: _ });
-        prop_assert!(closed, "close did not finalize at backing={}", backing);
+        let (_, progress_steps) = close_resolved_to_completion(&mut market, &mut account);
+        prop_assert!(progress_steps >= 1);
         let paid = vault_before - market.header.vault.get();
 
         // No LoF: value conserved (paid out of the vault, nothing minted),

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -2,28 +2,37 @@
 
 use percolator::v16::{
     active_bitmap_count_ones, active_bitmap_get, active_bitmap_is_empty,
-    backing_domain_fee_split_for_lien_delta_num, kani_active_bitmap_set as active_bitmap_set,
-    kani_add_open_interest_for_new_position, kani_apply_backing_provider_earnings_withdraw,
-    kani_apply_backing_utilization_fee_charge, kani_apply_resolved_payout_receipt_payment,
-    kani_available_backing_num_for_source_credit_state,
+    backing_domain_fee_split_for_lien_delta_num, bankruptcy_asset_slot_has_lock_state,
+    bankruptcy_hlock_to_wire, kani_active_bitmap_set as active_bitmap_set,
+    kani_active_bitmap_with_cleared, kani_add_open_interest_for_new_position,
+    kani_apply_backing_provider_earnings_withdraw, kani_apply_backing_utilization_fee_charge,
+    kani_apply_resolved_payout_receipt_payment, kani_auto_crank_leg_flags,
+    kani_auto_crank_lifecycle_dispatchable, kani_auto_crank_liquidatable,
+    kani_auto_crank_skip_post_action_accrual, kani_available_backing_num_for_source_credit_state,
     kani_backing_utilization_fee_quote_atoms_for_lien,
-    kani_backing_utilization_rate_e9_for_source_state, kani_cert_is_current,
-    kani_expected_source_credit_rate_num_for_state, kani_health_cert_after_capital_debit,
-    kani_health_requirements_from_base_and_target_lag,
+    kani_backing_utilization_rate_e9_for_source_state, kani_build_resolved_close_rank,
+    kani_cert_is_current, kani_clear_resolved_leg, kani_close_progress_auto_crank_plan,
+    kani_commit_declared_liquidation_recovery, kani_expected_source_credit_rate_num_for_state,
+    kani_first_actionable_slot, kani_first_active_bitmap_slot,
+    kani_health_cert_after_capital_debit, kani_health_requirements_from_base_and_target_lag,
     kani_liquidation_close_would_leave_uncovered_loss_with_open_risk,
     kani_liquidation_engine_close_request_q, kani_liquidation_fee_from_raw_fee,
     kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
-    kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
-    kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
-    kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
-    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
-    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
+    kani_pending_domain_loss_barrier_blocks_position_change,
+    kani_permissionless_kf_settlement_commits_step,
+    kani_position_action_reuses_current_certificate, kani_position_delta_increases_risk,
+    kani_prepare_asset_recovery_transition, kani_resolved_source_close_phase,
+    kani_select_auto_crank_plan, kani_should_clear_prior_reset_obligation,
+    kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
+    kani_trade_preexisting_oi_reduction_gate, kani_trade_preflight_risk_gate,
+    kani_validate_positive_pnl_source_attribution, ActionableSummaryV16, AssetLifecycleV16,
+    AssetStateV16, AssetStateV16Account, AutoCrankPlanV16, BackingBucketStatusV16,
     BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
     CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
     HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
-    Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
-    PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
+    Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, MarketModeV16,
+    PermissionlessCrankActionV16, PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
     ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedCloseOutcomeV16,
@@ -40,7 +49,7 @@ use percolator::v16::{
     kani_eq_portfolio_account_v16_account,
 };
 use percolator::{
-    ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, MAX_ACCOUNT_NOTIONAL, MAX_MARGIN_BPS,
+    ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, MAX_ACCOUNT_NOTIONAL, MAX_MARGIN_BPS, MAX_OI_SIDE_Q,
     MAX_ORACLE_PRICE, MAX_POSITION_ABS_Q, MAX_TRADE_SIZE_Q, MAX_VAULT_TVL, POS_SCALE,
     SOCIAL_LOSS_DEN, V16_ACTIVE_BITMAP_WORDS,
 };
@@ -79,11 +88,7 @@ fn one_market_view_fixture() -> (
     (header, markets, account_header)
 }
 
-fn two_market_view_fixture() -> (
-    MarketGroupV16HeaderAccount,
-    [Market<u64>; 2],
-    PortfolioAccountV16Account,
-) {
+fn two_market_only_fixture() -> (MarketGroupV16HeaderAccount, [Market<u64>; 2]) {
     let (market_id, _, _) = ids();
     let cfg = V16Config::public_user_fund_with_market_slots(2, 2, 0, 10);
     let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_id, cfg, 2, 0).unwrap();
@@ -96,6 +101,16 @@ fn two_market_view_fixture() -> (
         view.activate_empty_market_not_atomic(0, 100, 1).unwrap();
         view.activate_empty_market_not_atomic(1, 100, 2).unwrap();
     }
+    (header, markets)
+}
+
+fn two_market_view_fixture() -> (
+    MarketGroupV16HeaderAccount,
+    [Market<u64>; 2],
+    PortfolioAccountV16Account,
+) {
+    let (header, markets) = two_market_only_fixture();
+    let (market_id, _, _) = ids();
     let account_header = empty_account_fixture(market_id, 2);
     (header, markets, account_header)
 }
@@ -184,7 +199,7 @@ fn empty_recovery_slot_for_market(
 }
 
 #[kani::proof]
-#[kani::unwind(8)]
+#[kani::unwind(40)]
 #[kani::solver(cadical)]
 fn proof_v16_active_bitmap_set_get_count_is_exact_and_bounds_checked() {
     let slot_raw: u8 = kani::any();
@@ -235,6 +250,267 @@ fn proof_v16_active_bitmap_set_get_count_is_exact_and_bounds_checked() {
         assert!(!active_bitmap_get(bitmap, slot));
         assert_eq!(after_count, before_count);
     }
+}
+
+#[kani::proof]
+#[kani::unwind(17)]
+#[kani::solver(cadical)]
+fn proof_v16_resolved_leg_detach_exhausts_exact_rank_and_frames_other_obligations() {
+    assert_eq!(V16_ACTIVE_BITMAP_WORDS, 1);
+    assert!(V16_MAX_PORTFOLIO_ASSETS_N < 64);
+
+    let raw_bitmap: u64 = kani::any();
+    let valid_mask = (1u64 << V16_MAX_PORTFOLIO_ASSETS_N) - 1;
+    let mut bitmap = V16_EMPTY_ACTIVE_BITMAP;
+    bitmap[0] = raw_bitmap & valid_mask;
+
+    let b_stale: bool = kani::any();
+    let negative_pnl: bool = kani::any();
+    let capital_pending: bool = kani::any();
+    let receipt_present: bool = kani::any();
+    let recovery_required: bool = kani::any();
+    let pnl = if negative_pnl { -1 } else { 0 };
+    let capital = u128::from(capital_pending);
+    let initial_count = active_bitmap_count_ones(bitmap);
+    let mut steps = 0u32;
+
+    kani::cover!(
+        initial_count == 0,
+        "resolved account can begin without active legs"
+    );
+    kani::cover!(
+        initial_count == 1,
+        "resolved account can begin with one active leg"
+    );
+    kani::cover!(
+        initial_count == V16_MAX_PORTFOLIO_ASSETS_N as u32,
+        "resolved account can begin at the maximum active-leg shape"
+    );
+    kani::cover!(
+        initial_count >= 2 && bitmap[0] & 1 == 0,
+        "sparse active-leg sets require deterministic repeated teardown"
+    );
+    kani::cover!(
+        initial_count > 0
+            && b_stale
+            && negative_pnl
+            && capital_pending
+            && receipt_present
+            && recovery_required,
+        "leg teardown frames every unrelated resolved-close obligation"
+    );
+
+    loop {
+        let Some(slot) = kani_first_active_bitmap_slot(bitmap).unwrap() else {
+            break;
+        };
+        let before = kani_build_resolved_close_rank(
+            b_stale,
+            pnl,
+            bitmap,
+            capital,
+            receipt_present,
+            recovery_required,
+        );
+        assert_eq!(slot, bitmap[0].trailing_zeros() as usize);
+        assert!(active_bitmap_get(bitmap, slot));
+
+        let after_bitmap = kani_active_bitmap_with_cleared(bitmap, slot).unwrap();
+        let after = kani_build_resolved_close_rank(
+            b_stale,
+            pnl,
+            after_bitmap,
+            capital,
+            receipt_present,
+            recovery_required,
+        );
+
+        assert_eq!(after.active_leg_count + 1, before.active_leg_count);
+        assert_eq!(after.b_stale, before.b_stale);
+        assert_eq!(after.negative_pnl, before.negative_pnl);
+        assert_eq!(after.capital, before.capital);
+        assert_eq!(after.receipt_claim, before.receipt_claim);
+        assert_eq!(after.recovery_required, before.recovery_required);
+        assert_eq!(after_bitmap[0], bitmap[0] & !(1u64 << slot));
+        assert_eq!(
+            active_bitmap_count_ones(after_bitmap) + steps + 1,
+            initial_count
+        );
+
+        bitmap = after_bitmap;
+        steps += 1;
+    }
+
+    assert!(active_bitmap_is_empty(bitmap));
+    assert_eq!(steps, initial_count);
+    assert!(steps <= V16_MAX_PORTFOLIO_ASSETS_N as u32);
+}
+
+#[kani::proof]
+#[kani::unwind(17)]
+#[kani::solver(cadical)]
+fn proof_v16_permissionless_source_kf_refresh_exhausts_exact_pending_rank() {
+    assert!(V16_MAX_PORTFOLIO_ASSETS_N < 64);
+    let raw_pending: u64 = kani::any();
+    let valid_mask = (1u64 << V16_MAX_PORTFOLIO_ASSETS_N) - 1;
+    let mut pending = raw_pending & valid_mask;
+    let initial_count = pending.count_ones();
+    let source_domain_count = (kani::any::<u8>() as usize) % (PORTFOLIO_SOURCE_DOMAIN_CAP + 1);
+    let allow_b_chunk: bool = kani::any();
+    let chunked = allow_b_chunk && source_domain_count != 0;
+    let mut steps = 0u32;
+
+    kani::cover!(
+        chunked && initial_count == V16_MAX_PORTFOLIO_ASSETS_N as u32,
+        "permissionless source refresh covers the maximum stale-leg shape"
+    );
+    kani::cover!(
+        chunked && initial_count >= 2 && pending & 1 == 0,
+        "permissionless source refresh covers sparse stale-leg sets"
+    );
+    kani::cover!(
+        allow_b_chunk && source_domain_count == PORTFOLIO_SOURCE_DOMAIN_CAP,
+        "permissionless refresh covers the maximum source-domain shape"
+    );
+    kani::cover!(
+        !allow_b_chunk && source_domain_count != 0 && initial_count != 0,
+        "direct refresh remains unchunked despite source attribution"
+    );
+    kani::cover!(
+        allow_b_chunk && source_domain_count == 0 && initial_count != 0,
+        "source-free permissionless refresh remains unchunked"
+    );
+
+    loop {
+        let has_pending = pending != 0;
+        let mut selected = None;
+        let mut slot = 0usize;
+        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg_pending = pending & (1u64 << slot) != 0;
+            if kani_permissionless_kf_settlement_commits_step(
+                allow_b_chunk,
+                source_domain_count,
+                has_pending,
+                leg_pending,
+            ) {
+                selected = Some(slot);
+                break;
+            }
+            slot += 1;
+        }
+
+        if !chunked || pending == 0 {
+            assert!(selected.is_none());
+            break;
+        }
+
+        let selected = selected.unwrap();
+        assert_eq!(selected, pending.trailing_zeros() as usize);
+        let after = pending & !(1u64 << selected);
+        assert_eq!(after.count_ones() + 1, pending.count_ones());
+        assert_eq!(after.count_ones() + steps + 1, initial_count);
+        pending = after;
+        steps += 1;
+    }
+
+    if chunked {
+        assert_eq!(pending, 0);
+        assert_eq!(steps, initial_count);
+        assert!(steps <= V16_MAX_PORTFOLIO_ASSETS_N as u32);
+    } else {
+        assert_eq!(pending.count_ones(), initial_count);
+        assert_eq!(steps, 0);
+    }
+}
+
+#[kani::proof]
+#[kani::unwind(16)]
+#[kani::solver(cadical)]
+fn proof_v16_current_liquidatable_account_reuses_certificate_without_refresh() {
+    let cert = HealthCertV16 {
+        certified_equity: kani::any(),
+        certified_initial_req: kani::any(),
+        certified_maintenance_req: kani::any(),
+        certified_liq_deficit: kani::any(),
+        certified_worst_case_loss: kani::any(),
+        cert_oracle_epoch: kani::any(),
+        cert_funding_epoch: kani::any(),
+        cert_risk_epoch: kani::any(),
+        cert_asset_set_epoch: kani::any(),
+        active_bitmap_at_cert: kani::any(),
+        valid: kani::any(),
+    };
+    let oracle_epoch: u64 = kani::any();
+    let funding_epoch: u64 = kani::any();
+    let risk_epoch: u64 = kani::any();
+    let asset_set_epoch: u64 = kani::any();
+    let account_bitmap = kani::any();
+    let account_stale: bool = kani::any();
+    let account_b_stale: bool = kani::any();
+    let has_b_stale_leg: bool = kani::any();
+    let cert_current = kani_cert_is_current(
+        cert,
+        oracle_epoch,
+        funding_epoch,
+        risk_epoch,
+        asset_set_epoch,
+        account_bitmap,
+    );
+    let reuse = kani_position_action_reuses_current_certificate(
+        account_stale,
+        account_b_stale,
+        cert_current,
+        has_b_stale_leg,
+    );
+
+    kani::cover!(
+        reuse && cert.certified_liq_deficit > 0,
+        "a current liquidatable account takes the certificate fast path"
+    );
+    kani::cover!(
+        !reuse && cert_current,
+        "account or leg staleness blocks certificate reuse"
+    );
+    kani::cover!(
+        !reuse && !cert_current,
+        "an invalid or epoch-mismatched certificate forces refresh"
+    );
+
+    assert_eq!(
+        reuse,
+        !account_stale
+            && !account_b_stale
+            && cert.valid
+            && cert.cert_oracle_epoch == oracle_epoch
+            && cert.cert_funding_epoch == funding_epoch
+            && cert.cert_risk_epoch == risk_epoch
+            && cert.cert_asset_set_epoch == asset_set_epoch
+            && cert.active_bitmap_at_cert == account_bitmap
+            && !has_b_stale_leg
+    );
+
+    let mut alternate_liquidation_state = cert;
+    alternate_liquidation_state.certified_liq_deficit = if cert.certified_liq_deficit == 0 {
+        1
+    } else {
+        0
+    };
+    let alternate_current = kani_cert_is_current(
+        alternate_liquidation_state,
+        oracle_epoch,
+        funding_epoch,
+        risk_epoch,
+        asset_set_epoch,
+        account_bitmap,
+    );
+    let alternate_reuse = kani_position_action_reuses_current_certificate(
+        account_stale,
+        account_b_stale,
+        alternate_current,
+        has_b_stale_leg,
+    );
+    assert_eq!(alternate_current, cert_current);
+    assert_eq!(alternate_reuse, reuse);
 }
 
 #[kani::proof]
@@ -1761,6 +2037,9 @@ fn proof_v16_public_restart_empty_asset_zero_preserves_budgets_and_senior_value(
     let short_budget = short_budget_raw as u128;
     let budget_total = long_budget + short_budget;
     let insurance = budget_total + slack_raw as u128;
+    let [k_long, k_short, k_epoch_long, k_epoch_short] = [7, -11, 13, -17];
+    let [b_long, b_short, b_epoch_long, b_epoch_short] = [1; 4];
+    let [f_long, f_short, f_epoch_long, f_epoch_short] = [1, -1, 1, -1];
 
     let (market_group_id, _, _) = ids();
     let cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
@@ -1792,6 +2071,18 @@ fn proof_v16_public_restart_empty_asset_zero_preserves_budgets_and_senior_value(
     old_asset.fund_px_last = 100;
     old_asset.slot_last = current_slot;
     old_asset.retired_slot = if restart_retired { current_slot } else { 0 };
+    old_asset.k_long = k_long;
+    old_asset.k_short = k_short;
+    old_asset.k_epoch_start_long = k_epoch_long;
+    old_asset.k_epoch_start_short = k_epoch_short;
+    old_asset.b_long_num = b_long;
+    old_asset.b_short_num = b_short;
+    old_asset.b_epoch_start_long_num = b_epoch_long;
+    old_asset.b_epoch_start_short_num = b_epoch_short;
+    old_asset.f_long_num = f_long;
+    old_asset.f_short_num = f_short;
+    old_asset.f_epoch_start_long_num = f_epoch_long;
+    old_asset.f_epoch_start_short_num = f_epoch_short;
     markets[0].engine.asset = AssetStateV16Account::from_runtime(&old_asset);
     markets[0].engine.insurance_domain_budget_long = V16PodU128::new(long_budget);
     markets[0].engine.insurance_domain_budget_short = V16PodU128::new(short_budget);
@@ -1828,6 +2119,18 @@ fn proof_v16_public_restart_empty_asset_zero_preserves_budgets_and_senior_value(
     assert_eq!(restarted_asset.effective_price, price_raw as u64);
     assert_eq!(restarted_asset.fund_px_last, price_raw as u64);
     assert_eq!(restarted_asset.slot_last, now_slot);
+    assert_eq!(restarted_asset.k_long, 0);
+    assert_eq!(restarted_asset.k_short, 0);
+    assert_eq!(restarted_asset.k_epoch_start_long, 0);
+    assert_eq!(restarted_asset.k_epoch_start_short, 0);
+    assert_eq!(restarted_asset.b_long_num, 0);
+    assert_eq!(restarted_asset.b_short_num, 0);
+    assert_eq!(restarted_asset.b_epoch_start_long_num, 0);
+    assert_eq!(restarted_asset.b_epoch_start_short_num, 0);
+    assert_eq!(restarted_asset.f_long_num, 0);
+    assert_eq!(restarted_asset.f_short_num, 0);
+    assert_eq!(restarted_asset.f_epoch_start_long_num, 0);
+    assert_eq!(restarted_asset.f_epoch_start_short_num, 0);
     assert_eq!(restarted.insurance_domain_budget_long.get(), long_budget);
     assert_eq!(restarted.insurance_domain_budget_short.get(), short_budget);
     assert_eq!(restarted.insurance_domain_spent_long.get(), 0);
@@ -1927,6 +2230,10 @@ fn assert_v16_public_restart_two_slot_selected_only<const SELECTED_INDEX: usize>
     selected_asset.fund_px_last = 100;
     selected_asset.slot_last = current_slot;
     selected_asset.retired_slot = if restart_retired { current_slot } else { 0 };
+    selected_asset.k_long = 19;
+    selected_asset.k_short = -23;
+    selected_asset.k_epoch_start_long = 29;
+    selected_asset.k_epoch_start_short = -31;
     markets[selected_index].engine.asset = AssetStateV16Account::from_runtime(&selected_asset);
     markets[selected_index].engine.insurance_domain_budget_long =
         V16PodU128::new(selected_long_budget);
@@ -1995,6 +2302,10 @@ fn assert_v16_public_restart_two_slot_selected_only<const SELECTED_INDEX: usize>
     assert_eq!(restarted_asset.effective_price, price_raw as u64);
     assert_eq!(restarted_asset.fund_px_last, price_raw as u64);
     assert_eq!(restarted_asset.slot_last, now_slot);
+    assert_eq!(restarted_asset.k_long, 0);
+    assert_eq!(restarted_asset.k_short, 0);
+    assert_eq!(restarted_asset.k_epoch_start_long, 0);
+    assert_eq!(restarted_asset.k_epoch_start_short, 0);
     assert_eq!(
         restarted.insurance_domain_budget_long.get(),
         selected_budget_long_before
@@ -3175,6 +3486,7 @@ fn proof_v16_recovery_mode_blocks_fee_sync_and_pnl_conversion_before_mutation() 
 #[kani::unwind(32)]
 #[kani::solver(cadical)]
 fn proof_v16_public_resolve_market_is_value_neutral_and_clears_loss_stale() {
+    let start_in_recovery: bool = kani::any();
     let current_slot_raw: u8 = kani::any();
     let stale_lag_raw: u8 = kani::any();
     let resolved_delta_raw: u8 = kani::any();
@@ -3197,10 +3509,17 @@ fn proof_v16_public_resolve_market_is_value_neutral_and_clears_loss_stale() {
     header.loss_stale_active = if slot_last < current_slot { 1 } else { 0 };
     header.current_slot = V16PodU64::new(current_slot);
     header.slot_last = V16PodU64::new(slot_last);
+    if start_in_recovery {
+        header.mode = 2;
+        header.recovery_reason = V16OptionalRecoveryReasonAccount::from_runtime(Some(
+            PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+        ));
+    }
     let vault_before = header.vault;
     let c_tot_before = header.c_tot;
     let insurance_before = header.insurance;
     let slot_last_before = header.slot_last;
+    let recovery_reason_before = header.recovery_reason;
     let asset_before = markets[0].engine.asset;
     let long_budget_before = markets[0].engine.insurance_domain_budget_long;
     let short_budget_before = markets[0].engine.insurance_domain_budget_short;
@@ -3221,11 +3540,16 @@ fn proof_v16_public_resolve_market_is_value_neutral_and_clears_loss_stale() {
             && surplus > 255,
         "resolved market transition covers future authenticated slot over wide symbolic value state"
     );
+    kani::cover!(
+        start_in_recovery && c_tot > 255 && insurance > 255,
+        "permissionless Recovery-to-Resolved transition preserves nontrivial senior value"
+    );
     assert_eq!(market.header.mode, 1);
     assert_eq!(market.header.resolved_slot.get(), resolved_slot);
     assert_eq!(market.header.current_slot.get(), resolved_slot);
     assert_eq!(market.header.slot_last, slot_last_before);
     assert_eq!(market.header.loss_stale_active, 0);
+    assert_eq!(market.header.recovery_reason, recovery_reason_before);
     assert_eq!(market.header.vault, vault_before);
     assert_eq!(market.header.c_tot, c_tot_before);
     assert_eq!(market.header.insurance, insurance_before);
@@ -3537,6 +3861,296 @@ fn proof_v16_global_hlock_lane_selects_hmax_only_for_global_stress_or_candidate(
         "global h-lock lane covers same-instruction candidate h_max branch"
     );
     assert_eq!(lane, expected);
+}
+
+#[kani::proof]
+#[kani::unwind(32)]
+#[kani::solver(cadical)]
+fn proof_v16_bankruptcy_hlock_attribution_is_asset_local_and_fail_closed() {
+    let wire: u8 = kani::any();
+    let lock_0: bool = kani::any();
+    let lock_1: bool = kani::any();
+    let leg_0: bool = kani::any();
+    let leg_1: bool = kani::any();
+    let source_0: bool = kani::any();
+    let source_1: bool = kani::any();
+    let close_ref: u8 = kani::any();
+    kani::assume(wire <= 2);
+    kani::assume(close_ref <= 2);
+    kani::assume(wire != 0 || (!lock_0 && !lock_1));
+    kani::assume(wire != 2 || lock_0 || lock_1);
+
+    let (mut header, mut markets, mut account_header) = two_market_view_fixture();
+    header.bankruptcy_hlock_active = wire;
+    header.bankruptcy_hlock_asset_count = V16PodU32::new(lock_0 as u32 + lock_1 as u32);
+    markets[0].engine.bankruptcy_hlock_active = lock_0 as u8;
+    markets[1].engine.bankruptcy_hlock_active = lock_1 as u8;
+
+    let assets = [
+        markets[0].engine.asset.try_to_runtime().unwrap(),
+        markets[1].engine.asset.try_to_runtime().unwrap(),
+    ];
+    for (slot, active) in [leg_0, leg_1].into_iter().enumerate() {
+        if active {
+            let asset = assets[slot];
+            account_header.legs[slot] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+                active: true,
+                asset_index: slot as u32,
+                market_id: asset.market_id,
+                side: SideV16::Long,
+                basis_pos_q: POS_SCALE as i128,
+                a_basis: ADL_ONE,
+                k_snap: asset.k_long,
+                f_snap: asset.f_long_num,
+                k_rem_num: 0,
+                f_rem_num: 0,
+                epoch_snap: asset.epoch_long,
+                loss_weight: POS_SCALE,
+                b_snap: asset.b_long_num,
+                b_rem: 0,
+                b_epoch_snap: asset.epoch_long,
+                b_stale: false,
+                stale: false,
+            });
+            let word = slot / 64;
+            account_header.active_bitmap[word] =
+                V16PodU64::new(account_header.active_bitmap[word].get() | (1u64 << (slot % 64)));
+        }
+    }
+    let mut source_slot = 0usize;
+    for (asset_index, active) in [source_0, source_1].into_iter().enumerate() {
+        if active {
+            account_header.source_domains[source_slot].domain =
+                V16PodU32::new((asset_index * 2) as u32);
+            account_header.source_domains[source_slot].source_claim_market_id =
+                V16PodU64::new(assets[asset_index].market_id);
+            account_header.source_domains[source_slot].source_claim_bound_num = V16PodU128::new(1);
+            source_slot += 1;
+        }
+    }
+    if close_ref != 0 {
+        let asset_index = (close_ref - 1) as usize;
+        account_header.close_progress =
+            CloseProgressLedgerV16Account::from_runtime(&CloseProgressLedgerV16 {
+                active: true,
+                close_id: 1,
+                asset_index: asset_index as u32,
+                market_id: assets[asset_index].market_id,
+                domain_side: SideV16::Long,
+                gross_loss_at_close_start: 1,
+                residual_remaining: 1,
+                ..CloseProgressLedgerV16::EMPTY
+            });
+    }
+
+    let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let account = PortfolioV16View::new(&account_header);
+    let only_unrelated = market
+        .kani_bankruptcy_hlock_is_only_unrelated_to_account(&account)
+        .unwrap();
+
+    let references_0 = leg_0 || source_0 || close_ref == 1;
+    let references_1 = leg_1 || source_1 || close_ref == 2;
+    let references_locked_asset = (lock_0 && references_0) || (lock_1 && references_1);
+    let expected = wire == 2 && !references_locked_asset;
+
+    kani::cover!(
+        wire == 2 && lock_1 && references_0 && !references_1 && only_unrelated,
+        "an attributed bankruptcy on another asset does not freeze this account"
+    );
+    kani::cover!(
+        wire == 2 && lock_0 && leg_0 && !only_unrelated,
+        "an active leg on the bankrupt asset remains fail-closed"
+    );
+    kani::cover!(
+        wire == 2 && lock_0 && source_0 && !only_unrelated,
+        "a source claim on the bankrupt asset remains fail-closed"
+    );
+    kani::cover!(
+        wire == 2 && lock_0 && close_ref == 1 && !only_unrelated,
+        "an active close on the bankrupt asset remains fail-closed"
+    );
+    kani::cover!(
+        wire == 1 && !only_unrelated,
+        "an unattributed global bankruptcy lock remains fail-closed"
+    );
+    kani::cover!(
+        wire == 0 && !only_unrelated,
+        "an inactive lock is not ignored"
+    );
+    assert_eq!(only_unrelated, expected);
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_bankruptcy_asset_lock_is_durable_not_inferred_from_transient_state() {
+    let durable_lock: bool = kani::any();
+    let transient_mask: u8 = kani::any();
+    kani::assume(transient_mask <= 0x3f);
+    let mut slot = EngineAssetSlotV16Account::empty_for_market(1);
+    let mut asset = AssetStateV16 {
+        market_id: 1,
+        lifecycle: AssetLifecycleV16::Active,
+        ..AssetStateV16::default()
+    };
+    if transient_mask & 1 != 0 {
+        asset.mode_long = SideModeV16::DrainOnly;
+    }
+    if transient_mask & 2 != 0 {
+        asset.b_long_num = 1;
+    }
+    if transient_mask & 4 != 0 {
+        asset.social_loss_remainder_long_num = 1;
+    }
+    if transient_mask & 8 != 0 {
+        asset.explicit_unallocated_loss_long = 1;
+    }
+    if transient_mask & 16 != 0 {
+        slot.insurance_domain_spent_long = V16PodU128::new(1);
+    }
+    if transient_mask & 32 != 0 {
+        slot.pending_domain_loss_barrier_long = V16PodU64::new(1);
+    }
+    slot.asset = AssetStateV16Account::from_runtime(&asset);
+    slot.bankruptcy_hlock_active = durable_lock as u8;
+
+    let result = bankruptcy_asset_slot_has_lock_state(&slot).unwrap();
+    kani::cover!(
+        !durable_lock && transient_mask != 0 && !result,
+        "ordinary transient asset state never fabricates bankruptcy attribution"
+    );
+    kani::cover!(
+        durable_lock && transient_mask == 0 && result,
+        "bankruptcy attribution survives after transient state clears"
+    );
+    assert_eq!(result, durable_lock);
+}
+
+#[kani::proof]
+#[kani::unwind(40)]
+#[kani::solver(cadical)]
+fn proof_v16_mark_attributed_bankruptcy_is_exact_durable_and_idempotent() {
+    let lock_0: bool = kani::any();
+    let lock_1: bool = kani::any();
+    let prior_unattributed: bool = kani::any();
+    let target: bool = kani::any();
+    let (mut header, mut markets) = two_market_only_fixture();
+    let count_before = lock_0 as u32 + lock_1 as u32;
+    header.bankruptcy_hlock_asset_count = V16PodU32::new(count_before);
+    header.bankruptcy_hlock_active = if prior_unattributed {
+        bankruptcy_hlock_to_wire(true, false)
+    } else {
+        bankruptcy_hlock_to_wire(count_before != 0, true)
+    };
+    markets[0].engine.bankruptcy_hlock_active = lock_0 as u8;
+    markets[1].engine.bankruptcy_hlock_active = lock_1 as u8;
+    let target_index = target as usize;
+    let target_was_locked = [lock_0, lock_1][target_index];
+
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        market
+            .kani_mark_attributed_bankruptcy_hlock(target_index)
+            .unwrap();
+    }
+    let expected_count = count_before + u32::from(!target_was_locked);
+    assert_eq!(header.bankruptcy_hlock_asset_count.get(), expected_count);
+    assert_eq!(
+        header.bankruptcy_hlock_active,
+        if prior_unattributed { 1 } else { 2 }
+    );
+    assert_eq!(markets[target_index].engine.bankruptcy_hlock_active, 1);
+    assert_eq!(
+        markets[1 - target_index].engine.bankruptcy_hlock_active,
+        [lock_0, lock_1][1 - target_index] as u8
+    );
+
+    let header_after_first = header;
+    let markets_after_first = markets;
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        market
+            .kani_mark_attributed_bankruptcy_hlock(target_index)
+            .unwrap();
+    }
+    kani::cover!(
+        !target_was_locked && count_before != 0 && !prior_unattributed,
+        "a new affected asset extends an attributed lock exactly once"
+    );
+    kani::cover!(
+        target_was_locked,
+        "repeated bankruptcy attribution is idempotent"
+    );
+    kani::cover!(
+        prior_unattributed,
+        "an unattributed event remains globally fail-closed"
+    );
+    assert!(kani_eq_market_group_v16_header_account(
+        &header,
+        &header_after_first
+    ));
+    for i in 0..2 {
+        assert!(kani_eq_engine_asset_slot_v16_account(
+            &markets[i].engine,
+            &markets_after_first[i].engine
+        ));
+    }
+}
+
+#[kani::proof]
+#[kani::unwind(40)]
+#[kani::solver(cadical)]
+fn proof_v16_bankruptcy_asset_reuse_clears_exactly_one_attribution() {
+    let target_locked: bool = kani::any();
+    let other_locked: bool = kani::any();
+    let prior_unattributed: bool = kani::any();
+    let mut header = MarketGroupV16HeaderAccount::default();
+    let count_before = target_locked as u32 + other_locked as u32;
+    header.bankruptcy_hlock_asset_count = V16PodU32::new(count_before);
+    header.bankruptcy_hlock_active = if prior_unattributed {
+        bankruptcy_hlock_to_wire(true, false)
+    } else {
+        bankruptcy_hlock_to_wire(count_before != 0, true)
+    };
+    let mut slot = EngineAssetSlotV16Account::empty_for_market(1);
+    slot.bankruptcy_hlock_active = target_locked as u8;
+
+    header
+        .kani_clear_attributed_bankruptcy_asset_for_reuse(&mut slot)
+        .unwrap();
+    let expected_count = count_before - u32::from(target_locked);
+    let expected_wire = if prior_unattributed {
+        1
+    } else if other_locked {
+        2
+    } else {
+        0
+    };
+    kani::cover!(
+        target_locked && !other_locked && !prior_unattributed,
+        "reusing the final attributed asset releases the global lock"
+    );
+    kani::cover!(
+        target_locked && other_locked && !prior_unattributed,
+        "reusing one asset preserves another asset's lock"
+    );
+    kani::cover!(
+        target_locked && prior_unattributed,
+        "reusing an attributed asset never clears an unattributed event"
+    );
+    assert_eq!(slot.bankruptcy_hlock_active, 0);
+    assert_eq!(header.bankruptcy_hlock_asset_count.get(), expected_count);
+    assert_eq!(header.bankruptcy_hlock_active, expected_wire);
+
+    let header_after_first = header;
+    header
+        .kani_clear_attributed_bankruptcy_asset_for_reuse(&mut slot)
+        .unwrap();
+    assert!(kani_eq_market_group_v16_header_account(
+        &header,
+        &header_after_first
+    ));
 }
 
 #[kani::proof]
@@ -4218,6 +4832,142 @@ fn proof_v16_locked_trade_margin_gate_cannot_use_positive_pnl_credit() {
     if expected_certified_ok && !expected_locked_ok {
         assert_eq!(locked_result, Err(V16Error::LockActive));
     }
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_trade_final_margin_policy_preserves_exit_liveness_and_bankruptcy_gates() {
+    let long_capital_raw: u8 = kani::any();
+    let short_capital_raw: u8 = kani::any();
+    let long_pnl_raw: i8 = kani::any();
+    let short_pnl_raw: i8 = kani::any();
+    let long_fee_debt_raw: u8 = kani::any();
+    let short_fee_debt_raw: u8 = kani::any();
+    let long_equity_raw: i8 = kani::any();
+    let short_equity_raw: i8 = kani::any();
+    let long_req_raw: u8 = kani::any();
+    let short_req_raw: u8 = kani::any();
+    let long_liq_deficit_raw: u8 = kani::any();
+    let short_liq_deficit_raw: u8 = kani::any();
+    let long_cert_valid: bool = kani::any();
+    let short_cert_valid: bool = kani::any();
+    let risk_increasing: bool = kani::any();
+    let locked: bool = kani::any();
+
+    let account = |capital_raw: u8,
+                   pnl_raw: i8,
+                   fee_debt_raw: u8,
+                   equity_raw: i8,
+                   req_raw: u8,
+                   liq_deficit_raw: u8,
+                   valid: bool| {
+        let mut header = PortfolioAccountV16Account::default();
+        header.capital = V16PodU128::new(capital_raw as u128);
+        header.pnl = V16PodI128::new(pnl_raw as i128);
+        header.fee_credits = V16PodI128::new(-(fee_debt_raw as i128));
+        header.health_cert = HealthCertV16Account::from_runtime(&HealthCertV16 {
+            certified_equity: equity_raw as i128,
+            certified_initial_req: req_raw as u128,
+            certified_maintenance_req: req_raw as u128,
+            certified_liq_deficit: liq_deficit_raw as u128,
+            certified_worst_case_loss: req_raw as u128,
+            cert_oracle_epoch: 0,
+            cert_funding_epoch: 0,
+            cert_risk_epoch: 0,
+            cert_asset_set_epoch: 0,
+            active_bitmap_at_cert: V16_EMPTY_ACTIVE_BITMAP,
+            valid,
+        });
+        header
+    };
+    let long_header = account(
+        long_capital_raw,
+        long_pnl_raw,
+        long_fee_debt_raw,
+        long_equity_raw,
+        long_req_raw,
+        long_liq_deficit_raw,
+        long_cert_valid,
+    );
+    let short_header = account(
+        short_capital_raw,
+        short_pnl_raw,
+        short_fee_debt_raw,
+        short_equity_raw,
+        short_req_raw,
+        short_liq_deficit_raw,
+        short_cert_valid,
+    );
+    let long = PortfolioV16View::new(&long_header);
+    let short = PortfolioV16View::new(&short_header);
+
+    let certified_ok =
+        |equity: i8, req: u8, valid: bool| valid && equity >= 0 && (equity as u8) >= req;
+    let principal_only_ok = |capital: u8, pnl: i8, fee_debt: u8, req: u8| {
+        let equity = capital as i128 + (pnl as i128).min(0) - fee_debt as i128;
+        equity >= 0 && (equity as u128) >= req as u128
+    };
+    let long_certified_ok = certified_ok(long_equity_raw, long_req_raw, long_cert_valid);
+    let short_certified_ok = certified_ok(short_equity_raw, short_req_raw, short_cert_valid);
+    let long_principal_only_ok = principal_only_ok(
+        long_capital_raw,
+        long_pnl_raw,
+        long_fee_debt_raw,
+        long_req_raw,
+    );
+    let short_principal_only_ok = principal_only_ok(
+        short_capital_raw,
+        short_pnl_raw,
+        short_fee_debt_raw,
+        short_req_raw,
+    );
+    let margin_required =
+        risk_increasing || long_liq_deficit_raw != 0 || short_liq_deficit_raw != 0;
+    let expected_ok = !margin_required
+        || (long_certified_ok
+            && short_certified_ok
+            && (!locked || (long_principal_only_ok && short_principal_only_ok)));
+
+    let result = MarketGroupV16ViewMut::<u64>::kani_ensure_trade_final_margin_policy(
+        &long,
+        &short,
+        locked,
+        risk_increasing,
+    );
+
+    kani::cover!(
+        !margin_required && !long_certified_ok && !short_certified_ok,
+        "maintenance-healthy bilateral reductions progress below IM"
+    );
+    kani::cover!(
+        risk_increasing && !long_certified_ok && result.is_err(),
+        "risk increases cannot bypass certified initial margin"
+    );
+    kani::cover!(
+        !risk_increasing && long_liq_deficit_raw != 0 && !long_certified_ok && result.is_err(),
+        "liquidatable counterparties cannot use the reduction exemption"
+    );
+    kani::cover!(
+        margin_required
+            && locked
+            && long_certified_ok
+            && short_certified_ok
+            && !long_principal_only_ok
+            && result.is_err(),
+        "locked risk cannot satisfy IM using positive credit"
+    );
+    kani::cover!(
+        margin_required
+            && locked
+            && long_certified_ok
+            && short_certified_ok
+            && long_principal_only_ok
+            && short_principal_only_ok
+            && result.is_ok(),
+        "fully funded locked risk remains admissible"
+    );
+    assert_eq!(result.is_ok(), expected_ok);
 }
 
 #[kani::proof]
@@ -6494,6 +7244,227 @@ fn proof_v16_public_counterparty_backing_expiry_is_value_neutral_and_impairs_lie
 }
 
 #[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_counterparty_backing_expiry_reclassifies_principal_and_impairs_lien() {
+    let fresh_atoms: u128 = kani::any();
+    let liened_atoms: u128 = kani::any();
+    kani::assume(fresh_atoms <= MAX_VAULT_TVL);
+    kani::assume(liened_atoms <= MAX_VAULT_TVL - fresh_atoms);
+    let total_atoms = fresh_atoms + liened_atoms;
+    kani::assume(total_atoms > 0);
+    let fresh_num = fresh_atoms * BOUND_SCALE;
+    let liened_num = liened_atoms * BOUND_SCALE;
+    let bucket = BackingBucketV16 {
+        market_id: 1,
+        fresh_unliened_backing_num: fresh_num,
+        valid_liened_backing_num: liened_num,
+        expiry_slot: 5,
+        status: BackingBucketStatusV16::Fresh,
+        ..BackingBucketV16::EMPTY
+    };
+    let source = SourceCreditStateV16 {
+        fresh_reserved_backing_num: fresh_num + liened_num,
+        valid_liened_backing_num: liened_num,
+        credit_rate_num: CREDIT_RATE_SCALE,
+        ..SourceCreditStateV16::EMPTY
+    };
+    let (bucket_after, source_after) =
+        MarketGroupV16ViewMut::<u64>::kani_prepare_counterparty_backing_expiry_delta(
+            bucket, source, 10,
+        )
+        .unwrap();
+
+    kani::cover!(
+        fresh_atoms > 0 && liened_atoms == 0,
+        "expiry reclassifies fresh-only backing"
+    );
+    kani::cover!(liened_atoms > 0, "expiry impairs liened backing");
+    assert_eq!(bucket_after.fresh_unliened_backing_num, 0);
+    assert_eq!(bucket_after.valid_liened_backing_num, 0);
+    assert_eq!(bucket_after.impaired_liened_backing_num, liened_num);
+    assert_eq!(bucket_after.consumed_liened_backing_num, 0);
+    assert_eq!(source_after.fresh_reserved_backing_num, 0);
+    assert_eq!(source_after.valid_liened_backing_num, 0);
+    assert_eq!(source_after.impaired_liened_backing_num, liened_num);
+    assert_eq!(source_after.provider_receivable_num, 0);
+    assert_eq!(source_after.spent_backing_num, 0);
+    assert_eq!(source_after.credit_rate_num, CREDIT_RATE_SCALE);
+    assert_eq!(source_after.credit_epoch, source.credit_epoch);
+    assert_eq!(
+        source.fresh_reserved_backing_num - source_after.fresh_reserved_backing_num,
+        fresh_num + liened_num,
+        "all recoverable provider principal leaves the senior backing class"
+    );
+    if liened_num == 0 {
+        assert_eq!(bucket_after.status, BackingBucketStatusV16::Expired);
+    } else {
+        assert_eq!(bucket_after.status, BackingBucketStatusV16::Impaired);
+    }
+    assert_eq!(
+        bucket_after.impaired_liened_backing_num,
+        source_after.impaired_liened_backing_num
+    );
+
+    let other_senior: u128 = kani::any();
+    kani::assume(other_senior <= MAX_VAULT_TVL - total_atoms);
+    let junior_before: u128 = kani::any();
+    kani::assume(junior_before <= MAX_VAULT_TVL - total_atoms - other_senior);
+    let vault = other_senior + total_atoms + junior_before;
+    let junior_after = vault - other_senior;
+    kani::cover!(junior_before == 0, "expiry covers a tight senior vault");
+    kani::cover!(
+        junior_before > 0,
+        "expiry covers pre-existing junior surplus"
+    );
+    assert_eq!(junior_after, junior_before + total_atoms);
+    assert_eq!(
+        StockReconciliationProofV16 {
+            token_vault: vault,
+            senior_capital_total: other_senior,
+            insurance_capital: 0,
+            backing_provider_earnings: 0,
+            counterparty_backing_principal: total_atoms,
+            settlement_rounding_residue_total: 0,
+            unallocated_protocol_surplus: junior_before,
+        }
+        .validate(),
+        Ok(())
+    );
+    assert_eq!(
+        StockReconciliationProofV16 {
+            token_vault: vault,
+            senior_capital_total: other_senior,
+            insurance_capital: 0,
+            backing_provider_earnings: 0,
+            counterparty_backing_principal: 0,
+            settlement_rounding_residue_total: 0,
+            unallocated_protocol_surplus: junior_after,
+        }
+        .validate(),
+        Ok(())
+    );
+}
+
+// Permissionless expiry liveness over every lapsed/future ordering in the
+// Kani-sized source-domain roster. Each successful step removes exactly one
+// lapsed obligation while future and unrelated domains remain untouched.
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_live_source_backing_expiry_is_bounded_complete_and_isolated() {
+    assert_eq!(PORTFOLIO_SOURCE_DOMAIN_CAP, 4);
+    let roster_len: u8 = kani::any();
+    let lapsed_mask: u8 = kani::any();
+    let future_mask: u8 = kani::any();
+    kani::assume(roster_len as usize <= PORTFOLIO_SOURCE_DOMAIN_CAP);
+    let roster_mask = (1u8 << roster_len) - 1;
+    kani::assume(lapsed_mask & !roster_mask == 0);
+    kani::assume(future_mask & !roster_mask == 0);
+    kani::assume(lapsed_mask & future_mask == 0);
+
+    let now_slot = 10u64;
+    let mut remaining = lapsed_mask;
+    let mut calls = 0usize;
+    while calls <= PORTFOLIO_SOURCE_DOMAIN_CAP {
+        let rank_before = remaining.count_ones();
+        let mut expected = None;
+        let mut domain = 0usize;
+        while domain < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            if expected.is_none() && remaining & (1u8 << domain) != 0 {
+                expected = Some(domain);
+            }
+            domain += 1;
+        }
+
+        let mut selected = None;
+        let mut stopped = false;
+        domain = 0;
+        while domain < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            if !stopped {
+                let bit = 1u8 << domain;
+                let occupied = domain < roster_len as usize;
+                let sparse_tail = domain == roster_len as usize;
+                let fresh = remaining & bit != 0 || future_mask & bit != 0;
+                let bucket_status = if fresh {
+                    BackingBucketStatusV16::Fresh
+                } else {
+                    BackingBucketStatusV16::Empty
+                };
+                let expiry_slot = if remaining & bit != 0 {
+                    now_slot
+                } else {
+                    now_slot + 1
+                };
+                (selected, stopped) =
+                    MarketGroupV16ViewMut::<u64>::kani_lapsed_source_backing_scan_step(
+                        selected,
+                        sparse_tail,
+                        occupied,
+                        domain,
+                        bucket_status,
+                        expiry_slot,
+                        now_slot,
+                    );
+            }
+            domain += 1;
+        }
+        assert_eq!(selected, expected);
+
+        if let Some(selected_domain) = selected {
+            let selected_bit = 1u8 << selected_domain;
+            assert!(remaining & selected_bit != 0);
+            assert!(future_mask & selected_bit == 0);
+            remaining &= !selected_bit;
+            assert_eq!(remaining.count_ones() + 1, rank_before);
+            let bucket = BackingBucketV16 {
+                market_id: 1,
+                fresh_unliened_backing_num: BOUND_SCALE,
+                expiry_slot: now_slot,
+                status: BackingBucketStatusV16::Fresh,
+                ..BackingBucketV16::EMPTY
+            };
+            let source = SourceCreditStateV16 {
+                fresh_reserved_backing_num: BOUND_SCALE,
+                ..SourceCreditStateV16::EMPTY
+            };
+            let (expired, source_after) =
+                MarketGroupV16ViewMut::<u64>::kani_prepare_counterparty_backing_expiry_delta(
+                    bucket, source, now_slot,
+                )
+                .unwrap();
+            assert_eq!(expired.status, BackingBucketStatusV16::Expired);
+            assert_eq!(expired.fresh_unliened_backing_num, 0);
+            assert_eq!(source_after.fresh_reserved_backing_num, 0);
+        } else {
+            assert_eq!(rank_before, 0);
+        }
+        calls += 1;
+    }
+
+    assert_eq!(remaining, 0);
+
+    kani::cover!(lapsed_mask == 0, "clean roster is a no-op");
+    kani::cover!(
+        lapsed_mask.count_ones() == 1,
+        "single lapsed domain progresses"
+    );
+    kani::cover!(
+        lapsed_mask.count_ones() > 1,
+        "multiple lapsed domains drain"
+    );
+    kani::cover!(
+        lapsed_mask & 1 == 0 && lapsed_mask != 0,
+        "scan skips an earlier non-lapsed domain"
+    );
+    kani::cover!(future_mask != 0, "future backing remains isolated");
+    kani::cover!(
+        (roster_len as usize) < PORTFOLIO_SOURCE_DOMAIN_CAP,
+        "compact sparse tail terminates the scan"
+    );
+}
+
+#[kani::proof]
 #[kani::unwind(48)]
 #[kani::solver(cadical)]
 fn proof_v16_public_counterparty_backing_withdraw_debits_vault_and_scaled_source_state() {
@@ -7152,20 +8123,285 @@ fn proof_v16_retire_nonempty_asset_rejects() {
     assert_eq!(result, Err(V16Error::LockActive));
 }
 
+// K is price-settlement history once every claimant-bearing field is empty.
+// Prove magnitude and lane-pattern independence over all four i128 lanes.
+#[kani::proof]
+#[kani::unwind(48)]
+#[kani::solver(cadical)]
+fn proof_v16_empty_lifecycle_classifier_is_k_history_independent() {
+    let k_history: [i128; 4] = kani::any();
+    let zero_adl_epoch: bool = kani::any();
+    let mut asset = AssetStateV16::default();
+    if zero_adl_epoch {
+        asset.a_long = 0;
+        asset.a_short = 0;
+    }
+    asset.k_long = k_history[0];
+    asset.k_short = k_history[1];
+    asset.k_epoch_start_long = k_history[2];
+    asset.k_epoch_start_short = k_history[3];
+    let mut zero_k = asset;
+    zero_k.k_long = 0;
+    zero_k.k_short = 0;
+    zero_k.k_epoch_start_long = 0;
+    zero_k.k_epoch_start_short = 0;
+
+    let classified = MarketGroupV16ViewMut::<u64>::kani_asset_has_empty_lifecycle_blocker(asset);
+    let zero_classified =
+        MarketGroupV16ViewMut::<u64>::kani_asset_has_empty_lifecycle_blocker(zero_k);
+
+    kani::cover!(
+        k_history[0] == i128::MAX
+            && k_history[1] == i128::MIN + 1
+            && k_history[2] == 1
+            && k_history[3] == -1,
+        "mixed current and epoch-start K history is inert at valid extrema"
+    );
+    kani::cover!(
+        k_history[0] != 0
+            && k_history[1] != 0
+            && k_history[2] != 0
+            && k_history[3] != 0
+            && zero_adl_epoch,
+        "all K history lanes are inert in the zero ADL epoch"
+    );
+    assert_eq!(classified, zero_classified);
+    assert!(!classified);
+}
+
+// B is discharged history once every claimant-bearing field is empty. Prove
+// magnitude and lane-pattern independence over the full four-u128 domain.
+#[kani::proof]
+#[kani::unwind(48)]
+#[kani::solver(cadical)]
+fn proof_v16_empty_lifecycle_classifier_is_b_history_independent() {
+    let b_history: [u128; 4] = kani::any();
+    let zero_adl_epoch: bool = kani::any();
+    let mut asset = AssetStateV16::default();
+    if zero_adl_epoch {
+        asset.a_long = 0;
+        asset.a_short = 0;
+    }
+    asset.b_long_num = b_history[0];
+    asset.b_short_num = b_history[1];
+    asset.b_epoch_start_long_num = b_history[2];
+    asset.b_epoch_start_short_num = b_history[3];
+    let mut zero_b = asset;
+    zero_b.b_long_num = 0;
+    zero_b.b_short_num = 0;
+    zero_b.b_epoch_start_long_num = 0;
+    zero_b.b_epoch_start_short_num = 0;
+
+    let classified = MarketGroupV16ViewMut::<u64>::kani_asset_has_empty_lifecycle_blocker(asset);
+    let zero_classified =
+        MarketGroupV16ViewMut::<u64>::kani_asset_has_empty_lifecycle_blocker(zero_b);
+
+    kani::cover!(
+        b_history[0] == u128::MAX && b_history[1] == 0 && b_history[2] == 1 && b_history[3] > 1,
+        "mixed current and epoch-start B history is inert at full width"
+    );
+    kani::cover!(
+        b_history[0] != 0
+            && b_history[1] != 0
+            && b_history[2] != 0
+            && b_history[3] != 0
+            && zero_adl_epoch,
+        "all B history lanes are inert in the zero ADL epoch"
+    );
+    assert_eq!(classified, zero_classified);
+    assert!(!classified);
+}
+
+// Funding indices are settlement history once every claimant-bearing field is
+// empty. Prove magnitude and lane-pattern independence over all four i128 lanes.
+#[kani::proof]
+#[kani::unwind(48)]
+#[kani::solver(cadical)]
+fn proof_v16_empty_lifecycle_classifier_is_f_history_independent() {
+    let f_history: [i128; 4] = kani::any();
+    let zero_adl_epoch: bool = kani::any();
+    let mut asset = AssetStateV16::default();
+    if zero_adl_epoch {
+        asset.a_long = 0;
+        asset.a_short = 0;
+    }
+    asset.f_long_num = f_history[0];
+    asset.f_short_num = f_history[1];
+    asset.f_epoch_start_long_num = f_history[2];
+    asset.f_epoch_start_short_num = f_history[3];
+    let mut zero_f = asset;
+    zero_f.f_long_num = 0;
+    zero_f.f_short_num = 0;
+    zero_f.f_epoch_start_long_num = 0;
+    zero_f.f_epoch_start_short_num = 0;
+
+    let classified = MarketGroupV16ViewMut::<u64>::kani_asset_has_empty_lifecycle_blocker(asset);
+    let zero_classified =
+        MarketGroupV16ViewMut::<u64>::kani_asset_has_empty_lifecycle_blocker(zero_f);
+
+    kani::cover!(
+        f_history[0] == i128::MAX
+            && f_history[1] == i128::MIN + 1
+            && f_history[2] == 1
+            && f_history[3] == -1,
+        "mixed current and epoch-start F history is inert at valid extrema"
+    );
+    kani::cover!(
+        f_history[0] != 0
+            && f_history[1] != 0
+            && f_history[2] != 0
+            && f_history[3] != 0
+            && zero_adl_epoch,
+        "all F history lanes are inert in the zero ADL epoch"
+    );
+    assert_eq!(classified, zero_classified);
+    assert!(!classified);
+}
+
+// Complement the noninterference theorem: every asset-local field that still
+// owns risk, a claimant, or unsettled loss must independently block reuse.
+#[kani::proof]
+#[kani::solver(cadical)]
+fn proof_v16_empty_lifecycle_classifier_rejects_every_asset_claimant_and_loss_field() {
+    let blocker: u8 = kani::any();
+    let short_side: bool = kani::any();
+    kani::assume(blocker <= 9);
+    let mut asset = AssetStateV16 {
+        k_long: i128::MAX,
+        k_short: i128::MIN + 1,
+        k_epoch_start_long: 1,
+        k_epoch_start_short: -1,
+        b_long_num: u128::MAX,
+        b_short_num: 1,
+        b_epoch_start_long_num: u128::MAX,
+        b_epoch_start_short_num: 1,
+        f_long_num: i128::MAX,
+        f_short_num: i128::MIN + 1,
+        f_epoch_start_long_num: 1,
+        f_epoch_start_short_num: -1,
+        ..AssetStateV16::default()
+    };
+
+    match blocker {
+        0 => {
+            if short_side {
+                asset.mode_short = SideModeV16::DrainOnly;
+            } else {
+                asset.mode_long = SideModeV16::DrainOnly;
+            }
+        }
+        1 => {
+            if short_side {
+                asset.a_short = 0;
+            } else {
+                asset.a_long = 0;
+            }
+        }
+        2 => {
+            if short_side {
+                asset.oi_eff_short_q = 1;
+            } else {
+                asset.oi_eff_long_q = 1;
+            }
+        }
+        3 => {
+            if short_side {
+                asset.stored_pos_count_short = 1;
+            } else {
+                asset.stored_pos_count_long = 1;
+            }
+        }
+        4 => {
+            if short_side {
+                asset.stale_account_count_short = 1;
+            } else {
+                asset.stale_account_count_long = 1;
+            }
+        }
+        5 => {
+            if short_side {
+                asset.pending_obligation_count_short = 1;
+            } else {
+                asset.pending_obligation_count_long = 1;
+            }
+        }
+        6 => {
+            if short_side {
+                asset.loss_weight_sum_short = 1;
+            } else {
+                asset.loss_weight_sum_long = 1;
+            }
+        }
+        7 => {
+            if short_side {
+                asset.social_loss_remainder_short_num = 1;
+            } else {
+                asset.social_loss_remainder_long_num = 1;
+            }
+        }
+        8 => {
+            if short_side {
+                asset.social_loss_dust_short_num = 1;
+            } else {
+                asset.social_loss_dust_long_num = 1;
+            }
+        }
+        _ => {
+            if short_side {
+                asset.explicit_unallocated_loss_short = 1;
+            } else {
+                asset.explicit_unallocated_loss_long = 1;
+            }
+        }
+    }
+
+    kani::cover!(
+        blocker == 0 && !short_side,
+        "long mode blocker is reachable"
+    );
+    kani::cover!(
+        blocker == 2 && short_side,
+        "short open-interest blocker is reachable"
+    );
+    kani::cover!(
+        blocker == 9 && !short_side,
+        "long explicit-loss blocker is reachable"
+    );
+    assert!(MarketGroupV16ViewMut::<u64>::kani_asset_has_empty_lifecycle_blocker(asset));
+}
+
+// Bind the classifier theorems to the persisted zero-copy retirement path with
+// all K, F, and B lanes present; the separate theorems above discharge magnitude.
 #[kani::proof]
 #[kani::unwind(48)]
 #[kani::solver(cadical)]
 fn proof_v16_retire_empty_asset_is_value_neutral_and_epoch_scoped() {
     let with_senior_balances: bool = kani::any();
-    let retire_slot_raw: u8 = kani::any();
-    kani::assume((1..=10).contains(&retire_slot_raw));
+    let late_retirement: bool = kani::any();
     let c_tot = if with_senior_balances { 7 } else { 0 };
     let insurance = if with_senior_balances { 3 } else { 0 };
-    let retire_slot = retire_slot_raw as u64;
+    let retire_slot = if late_retirement { 10 } else { 1 };
+    let [k_long, k_short, k_epoch_long, k_epoch_short] = [7, -11, 13, -17];
+    let [b_long, b_short, b_epoch_long, b_epoch_short] = [1; 4];
+    let [f_long, f_short, f_epoch_long, f_epoch_short] = [1, -1, 1, -1];
     let (mut header, mut markets, _) = one_market_view_fixture();
     header.vault = V16PodU128::new(c_tot + insurance);
     header.c_tot = V16PodU128::new(c_tot);
     header.insurance = V16PodU128::new(insurance);
+    let mut historical_asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    historical_asset.k_long = k_long;
+    historical_asset.k_short = k_short;
+    historical_asset.k_epoch_start_long = k_epoch_long;
+    historical_asset.k_epoch_start_short = k_epoch_short;
+    historical_asset.b_long_num = b_long;
+    historical_asset.b_short_num = b_short;
+    historical_asset.b_epoch_start_long_num = b_epoch_long;
+    historical_asset.b_epoch_start_short_num = b_epoch_short;
+    historical_asset.f_long_num = f_long;
+    historical_asset.f_short_num = f_short;
+    historical_asset.f_epoch_start_long_num = f_epoch_long;
+    historical_asset.f_epoch_start_short_num = f_epoch_short;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&historical_asset);
     let vault_before = header.vault;
     let c_tot_before = header.c_tot;
     let insurance_before = header.insurance;
@@ -7179,11 +8415,28 @@ fn proof_v16_retire_empty_asset_is_value_neutral_and_epoch_scoped() {
     let asset = market.markets[0].engine.asset.try_to_runtime().unwrap();
 
     kani::cover!(
-        retire_slot > 1 && with_senior_balances && asset.lifecycle == AssetLifecycleV16::Retired,
-        "empty asset can retire without moving nonzero senior balances"
+        late_retirement
+            && with_senior_balances
+            && asset.lifecycle == AssetLifecycleV16::Retired
+            && asset.k_long != 0
+            && asset.f_long_num != 0
+            && asset.b_long_num != 0,
+        "empty asset with inert K/F/B history can retire without moving senior balances"
     );
     assert_eq!(asset.lifecycle, AssetLifecycleV16::Retired);
     assert_eq!(asset.retired_slot, retire_slot);
+    assert_eq!(asset.k_long, k_long);
+    assert_eq!(asset.k_short, k_short);
+    assert_eq!(asset.k_epoch_start_long, k_epoch_long);
+    assert_eq!(asset.k_epoch_start_short, k_epoch_short);
+    assert_eq!(asset.b_long_num, b_long);
+    assert_eq!(asset.b_short_num, b_short);
+    assert_eq!(asset.b_epoch_start_long_num, b_epoch_long);
+    assert_eq!(asset.b_epoch_start_short_num, b_epoch_short);
+    assert_eq!(asset.f_long_num, f_long);
+    assert_eq!(asset.f_short_num, f_short);
+    assert_eq!(asset.f_epoch_start_long_num, f_epoch_long);
+    assert_eq!(asset.f_epoch_start_short_num, f_epoch_short);
     assert_eq!(market.header.current_slot.get(), retire_slot);
     assert_eq!(market.header.vault, vault_before);
     assert_eq!(market.header.c_tot, c_tot_before);
@@ -7193,7 +8446,6 @@ fn proof_v16_retire_empty_asset_is_value_neutral_and_epoch_scoped() {
         asset_set_epoch_before + 1
     );
     assert_eq!(market.header.risk_epoch.get(), risk_epoch_before + 1);
-    assert_eq!(market.validate_shape(), Ok(()));
 }
 
 #[kani::proof]
@@ -8678,6 +9930,119 @@ fn proof_v16_public_resolved_close_flat_account_pays_only_capital_and_vault() {
 }
 
 #[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_resolved_close_terminal_payout_conserves_vault_and_value_classes() {
+    let account_capital = kani::any::<u64>() as u128;
+    let resolved_claimable = kani::any::<u64>() as u128;
+    let vault = kani::any::<u64>() as u128;
+    let c_tot = kani::any::<u64>() as u128;
+    kani::assume(account_capital <= MAX_VAULT_TVL);
+    kani::assume(resolved_claimable <= MAX_VAULT_TVL);
+    kani::assume(vault <= MAX_VAULT_TVL);
+    kani::assume(c_tot <= MAX_VAULT_TVL);
+    let (payout, capital_paid, resolved_paid, vault_after, c_tot_after) =
+        MarketGroupV16ViewMut::<u64>::kani_resolved_close_terminal_payout_delta(
+            account_capital,
+            resolved_claimable,
+            vault,
+            c_tot,
+        )
+        .unwrap();
+
+    kani::cover!(
+        vault < account_capital && vault > 0,
+        "scarce vault pays only part of account capital"
+    );
+    kani::cover!(
+        vault > account_capital && vault < account_capital + resolved_claimable,
+        "scarce vault pays capital plus part of the resolved claim"
+    );
+    kani::cover!(
+        vault >= account_capital + resolved_claimable
+            && account_capital > 0
+            && resolved_claimable > 0,
+        "funded vault pays both value classes in full"
+    );
+
+    assert_eq!(payout, (account_capital + resolved_claimable).min(vault));
+    assert_eq!(capital_paid + resolved_paid, payout);
+    assert!(capital_paid <= account_capital);
+    assert!(resolved_paid <= resolved_claimable);
+    assert_eq!(vault_after + payout, vault);
+    assert_eq!(c_tot_after + account_capital.min(c_tot), c_tot);
+    if vault >= account_capital + resolved_claimable {
+        assert_eq!(capital_paid, account_capital);
+        assert_eq!(resolved_paid, resolved_claimable);
+    }
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_resolved_source_close_phase_strictly_decreases_global_rank() {
+    let liened: bool = kani::any();
+    let status_raw: u8 = kani::any();
+    let expiry_slot: u8 = kani::any();
+    let current_slot: u8 = kani::any();
+    let remaining_domains: u8 = kani::any();
+    let tail_rank: u8 = kani::any();
+    kani::assume(status_raw <= 3);
+    kani::assume(remaining_domains >= 1);
+    kani::assume(remaining_domains as usize <= PORTFOLIO_SOURCE_DOMAIN_CAP);
+    let min_tail_rank = remaining_domains - 1;
+    let max_tail_rank = 3 * (remaining_domains - 1);
+    kani::assume(tail_rank >= min_tail_rank && tail_rank <= max_tail_rank);
+
+    let status = match status_raw {
+        0 => BackingBucketStatusV16::Empty,
+        1 => BackingBucketStatusV16::Fresh,
+        2 => BackingBucketStatusV16::Expired,
+        _ => BackingBucketStatusV16::Impaired,
+    };
+    let lapsed = status == BackingBucketStatusV16::Fresh && expiry_slot <= current_slot;
+    let phase = kani_resolved_source_close_phase(
+        if liened { BOUND_SCALE } else { 0 },
+        status,
+        expiry_slot as u64,
+        current_slot as u64,
+    );
+    let current_rank = 1u8 + u8::from(liened) + u8::from(lapsed);
+    let rank_before = tail_rank + current_rank;
+    let rank_after = match phase {
+        0 => tail_rank + 1 + u8::from(lapsed),
+        1 => tail_rank + 1,
+        2 => tail_rank,
+        _ => unreachable!(),
+    };
+
+    kani::cover!(
+        liened && lapsed && remaining_domains as usize == PORTFOLIO_SOURCE_DOMAIN_CAP,
+        "max-domain close releases a lien before retaining its pending expiry"
+    );
+    kani::cover!(
+        !liened && lapsed && remaining_domains > 1,
+        "an expired first domain progresses while a nonempty tail remains"
+    );
+    kani::cover!(
+        !liened && !lapsed && remaining_domains > 1 && tail_rank > min_tail_rank,
+        "a prepared claim is processed with nontrivial later obligations"
+    );
+    kani::cover!(
+        !liened && !lapsed && remaining_domains == 1 && tail_rank == 0,
+        "the final prepared claim reaches the zero-rank base case"
+    );
+
+    assert_eq!(phase == 0, liened);
+    assert_eq!(phase == 1, !liened && lapsed);
+    assert_eq!(phase == 2, !liened && !lapsed);
+    assert_eq!(rank_after + 1, rank_before);
+    assert!(rank_after < rank_before);
+    assert!(rank_before >= remaining_domains);
+    assert!(rank_before <= 3 * remaining_domains);
+}
+
+#[kani::proof]
 #[kani::unwind(40)]
 #[kani::solver(cadical)]
 fn proof_v16_resolved_two_active_legs_are_unattributed_for_bankruptcy() {
@@ -8839,6 +10204,63 @@ fn proof_v16_expired_close_progress_declares_recovery_without_value_mutation() {
     assert_eq!(market.header.vault, vault_before);
     assert_eq!(market.header.c_tot, c_tot_before);
     assert_eq!(market.header.insurance, insurance_before);
+}
+
+#[kani::proof]
+#[kani::unwind(48)]
+#[kani::solver(cadical)]
+fn proof_v16_expired_frozen_asset_close_routing_is_local_and_fail_closed() {
+    let close_active: bool = kani::any();
+    let residual_raw: u8 = kani::any();
+    let deadline_expired: bool = kani::any();
+    let asset_local_recovery: bool = kani::any();
+    let stale: bool = kani::any();
+    let b_stale: bool = kani::any();
+    let liquidatable: bool = kani::any();
+    let residual = residual_raw as u128;
+    let outstanding = close_active && residual != 0;
+
+    let plan = kani_close_progress_auto_crank_plan(
+        close_active,
+        residual,
+        deadline_expired,
+        asset_local_recovery,
+        stale,
+        b_stale,
+        liquidatable,
+    );
+
+    kani::cover!(
+        outstanding && deadline_expired && asset_local_recovery && stale && b_stale && liquidatable,
+        "asset-local close wins every overlapping ordinary continuation"
+    );
+    kani::cover!(
+        outstanding && deadline_expired && !asset_local_recovery,
+        "expired drifting close fails closed to global recovery"
+    );
+    kani::cover!(
+        outstanding && !deadline_expired && !asset_local_recovery && stale,
+        "nonexpired ordinary close does not invent global recovery"
+    );
+
+    if outstanding && asset_local_recovery {
+        assert_eq!(
+            plan,
+            AutoCrankPlanV16::AdvanceRecoveryClose { asset_index: 7 }
+        );
+    }
+    if outstanding && deadline_expired && !asset_local_recovery {
+        assert_eq!(
+            plan,
+            AutoCrankPlanV16::DeclareRecovery {
+                reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+            }
+        );
+    }
+    assert!(
+        !matches!(plan, AutoCrankPlanV16::DeclareRecovery { .. })
+            || (outstanding && deadline_expired && !asset_local_recovery)
+    );
 }
 
 #[kani::proof]
@@ -9180,6 +10602,42 @@ fn proof_v16_equity_active_accrual_requires_protective_progress_before_mutation(
     assert_eq!(market.header.current_slot, header_before.current_slot);
     assert_eq!(market.header.slot_last, header_before.slot_last);
     assert_eq!(market.header.oracle_epoch, header_before.oracle_epoch);
+    assert_eq!(market.markets[0].engine.asset, market_before.engine.asset);
+}
+
+#[kani::proof]
+#[kani::unwind(48)]
+#[kani::solver(cadical)]
+fn proof_v16_lagged_target_zero_delta_cannot_consume_accrual_segment() {
+    let target_delta_raw: u8 = kani::any();
+    kani::assume(target_delta_raw > 0);
+    let (mut header, mut markets, _) = one_market_view_fixture();
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.oi_eff_long_q = POS_SCALE;
+    asset.stored_pos_count_long = 1;
+    asset.raw_oracle_target_price = asset
+        .effective_price
+        .checked_add(target_delta_raw as u64)
+        .unwrap();
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    let header_before = header;
+    let market_before = markets[0];
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let result = market.accrue_asset_to_not_atomic(0, 2, asset.effective_price, 0, true);
+
+    kani::cover!(
+        target_delta_raw > 1,
+        "lagged-target proof covers a nontrivial target distance"
+    );
+    assert_eq!(result, Err(V16Error::NonProgress));
+    assert_eq!(market.header.current_slot, header_before.current_slot);
+    assert_eq!(market.header.slot_last, header_before.slot_last);
+    assert_eq!(market.header.oracle_epoch, header_before.oracle_epoch);
+    assert_eq!(market.header.funding_epoch, header_before.funding_epoch);
+    assert_eq!(market.header.vault, header_before.vault);
+    assert_eq!(market.header.c_tot, header_before.c_tot);
+    assert_eq!(market.header.insurance, header_before.insurance);
     assert_eq!(market.markets[0].engine.asset, market_before.engine.asset);
 }
 
@@ -10111,6 +11569,204 @@ fn proof_v16_view_initial_margin_source_lien_creation_is_backed() {
         backing_num
     );
     assert_eq!(source_domain.source_lien_fee_last_slot.get(), current_slot);
+}
+
+#[kani::proof]
+#[kani::unwind(16)]
+#[kani::solver(cadical)]
+fn proof_v16_source_lien_allocation_plan_is_complete_bounded_and_ordered() {
+    let claim_raw: [u8; PORTFOLIO_SOURCE_DOMAIN_CAP] = kani::any();
+    let backing_raw: [u8; PORTFOLIO_SOURCE_DOMAIN_CAP] = kani::any();
+    let rate_raw: [u8; PORTFOLIO_SOURCE_DOMAIN_CAP] = kani::any();
+    let request_raw: u8 = kani::any();
+    let request = (request_raw & 31) as u128;
+    let mut remaining = request;
+    let mut total_capacity = 0u128;
+    let mut domain = 0usize;
+    let mut touched = 0usize;
+    let mut used_fractional_rate = false;
+    while domain < PORTFOLIO_SOURCE_DOMAIN_CAP {
+        let claim = (claim_raw[domain] & 7) as u128;
+        let backing = (backing_raw[domain] & 7) as u128;
+        let rate_code = rate_raw[domain] & 3;
+        let rate = if rate_code == 3 {
+            0
+        } else {
+            CREDIT_RATE_SCALE >> rate_code
+        };
+        let claim_capacity = claim * rate / CREDIT_RATE_SCALE;
+        let capacity = claim_capacity.min(backing);
+        let take = MarketGroupV16ViewMut::<u64>::kani_source_credit_lien_allocation_take(
+            remaining,
+            claim * BOUND_SCALE,
+            backing * BOUND_SCALE,
+            rate,
+        )
+        .unwrap();
+        assert_eq!(take, remaining.min(capacity));
+        assert!(take <= remaining);
+        assert!(take <= claim);
+        assert!(take <= backing);
+        if remaining == 0 {
+            assert_eq!(take, 0);
+        }
+        if take != 0 {
+            touched += 1;
+            used_fractional_rate |= rate != CREDIT_RATE_SCALE;
+        }
+        remaining -= take;
+        total_capacity += capacity;
+        domain += 1;
+    }
+
+    let allocated = request - remaining;
+    kani::cover!(request == 0, "zero source-credit request is the identity");
+    kani::cover!(
+        request > total_capacity && total_capacity > 0,
+        "insufficient aggregate backing exhausts every source"
+    );
+    kani::cover!(
+        request < total_capacity && touched > 1,
+        "allocation crosses source boundaries and stops with surplus"
+    );
+    kani::cover!(
+        touched == PORTFOLIO_SOURCE_DOMAIN_CAP,
+        "allocation can consume every bounded source"
+    );
+    kani::cover!(
+        used_fractional_rate && touched > 1,
+        "allocation composes independently haircutted sources"
+    );
+    assert_eq!(allocated, request.min(total_capacity));
+    assert_eq!(remaining, request.saturating_sub(total_capacity));
+}
+
+#[kani::proof]
+#[kani::unwind(64)]
+#[kani::solver(cadical)]
+fn proof_v16_source_lien_entry_relabel_preserves_persisted_aggregate_invariant() {
+    let pre_effective = (kani::any::<u8>() & 7) as u128;
+    let added_effective = 1 + (kani::any::<u8>() & 3) as u128;
+    let claim_slack = (kani::any::<u8>() & 7) as u128;
+    let pre_counterparty: bool = kani::any();
+    let add_counterparty: bool = kani::any();
+    let current_slot = 2 + (kani::any::<u8>() & 7) as u64;
+    let pre_num = pre_effective * BOUND_SCALE;
+    let added_num = added_effective * BOUND_SCALE;
+    let claim_bound_num = (pre_effective + added_effective + claim_slack) * BOUND_SCALE;
+    let pre_counterparty_num = if pre_counterparty { pre_num } else { 0 };
+    let pre_insurance_num = if pre_counterparty { 0 } else { pre_num };
+    let prior_fee_slot = if pre_counterparty_num == 0 {
+        0
+    } else {
+        current_slot - 1
+    };
+    let mut source = PortfolioSourceDomainV16Account {
+        domain: V16PodU32::new(1),
+        source_claim_market_id: V16PodU64::new(9),
+        source_claim_bound_num: V16PodU128::new(claim_bound_num),
+        source_claim_liened_num: V16PodU128::new(pre_num),
+        source_claim_counterparty_liened_num: V16PodU128::new(pre_counterparty_num),
+        source_claim_insurance_liened_num: V16PodU128::new(pre_insurance_num),
+        source_lien_effective_reserved: V16PodU128::new(pre_effective),
+        source_lien_counterparty_backing_num: V16PodU128::new(pre_counterparty_num),
+        source_lien_insurance_backing_num: V16PodU128::new(pre_insurance_num),
+        source_lien_fee_last_slot: V16PodU64::new(prior_fee_slot),
+        ..PortfolioSourceDomainV16Account::default()
+    };
+    MarketGroupV16ViewMut::<u64>::kani_validate_account_source_credit_lien_entry(source, 1)
+        .unwrap();
+    let before = source;
+
+    if add_counterparty {
+        MarketGroupV16ViewMut::<u64>::kani_apply_counterparty_source_credit_lien_delta(
+            &mut source,
+            added_num,
+            added_num,
+            added_effective,
+            current_slot,
+        )
+        .unwrap();
+    } else {
+        MarketGroupV16ViewMut::<u64>::kani_apply_insurance_source_credit_lien_delta(
+            &mut source,
+            added_num,
+            added_num,
+            added_effective,
+            current_slot,
+        )
+        .unwrap();
+    }
+    MarketGroupV16ViewMut::<u64>::kani_validate_account_source_credit_lien_entry(source, 1)
+        .unwrap();
+
+    let added_counterparty_num = if add_counterparty { added_num } else { 0 };
+    let added_insurance_num = if add_counterparty { 0 } else { added_num };
+    kani::cover!(
+        pre_effective > 0 && pre_counterparty && add_counterparty,
+        "an existing counterparty lien can be extended"
+    );
+    kani::cover!(
+        pre_effective > 0 && !pre_counterparty && add_counterparty,
+        "a counterparty lien can be added beside an insurance lien"
+    );
+    kani::cover!(
+        pre_effective > 0 && pre_counterparty && !add_counterparty,
+        "an insurance lien can be added beside a counterparty lien"
+    );
+    kani::cover!(
+        pre_effective == 0 && claim_slack > 0,
+        "a first lien can reserve only part of a larger claim"
+    );
+    assert_eq!(source.domain, before.domain);
+    assert_eq!(source.source_claim_market_id, before.source_claim_market_id);
+    assert_eq!(source.source_claim_bound_num, before.source_claim_bound_num);
+    assert_eq!(source.source_claim_liened_num.get(), pre_num + added_num);
+    assert_eq!(
+        source.source_claim_counterparty_liened_num.get(),
+        pre_counterparty_num + added_counterparty_num
+    );
+    assert_eq!(
+        source.source_claim_insurance_liened_num.get(),
+        pre_insurance_num + added_insurance_num
+    );
+    assert_eq!(
+        source.source_lien_effective_reserved.get(),
+        pre_effective + added_effective
+    );
+    assert_eq!(
+        source.source_lien_counterparty_backing_num.get(),
+        pre_counterparty_num + added_counterparty_num
+    );
+    assert_eq!(
+        source.source_lien_insurance_backing_num.get(),
+        pre_insurance_num + added_insurance_num
+    );
+    assert_eq!(
+        source.source_lien_fee_last_slot.get(),
+        if add_counterparty && pre_counterparty_num == 0 {
+            current_slot
+        } else {
+            prior_fee_slot
+        }
+    );
+    assert_eq!(
+        source
+            .source_lien_counterparty_backing_num
+            .get()
+            .checked_add(source.source_lien_insurance_backing_num.get())
+            .unwrap(),
+        source.source_lien_effective_reserved.get() * BOUND_SCALE
+    );
+    assert!(source.source_claim_liened_num.get() <= source.source_claim_bound_num.get());
+    assert_eq!(
+        source.source_claim_impaired_num,
+        before.source_claim_impaired_num
+    );
+    assert_eq!(
+        source.source_lien_impaired_effective_reserved,
+        before.source_lien_impaired_effective_reserved
+    );
 }
 
 #[kani::proof]
@@ -12215,6 +13871,261 @@ fn proof_v16_source_credit_lien_face_and_backing_use_scaled_units() {
             previous_realized_scaled < required_backing_num,
             "source-credit lien face must be the minimal scaled face that realizes the required backing"
         );
+    }
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_source_lien_face_burn_releases_only_required_backing() {
+    let face_whole_raw: u8 = kani::any();
+    let effective_raw: u8 = kani::any();
+    let burn_whole_raw: u8 = kani::any();
+    let has_fractional_face: bool = kani::any();
+    let burn_full_face: bool = kani::any();
+    kani::assume(face_whole_raw <= 32);
+    kani::assume(burn_whole_raw <= face_whole_raw);
+    let face_whole = face_whole_raw as u128;
+    let fractional_face = if has_fractional_face {
+        BOUND_SCALE / 2
+    } else {
+        0
+    };
+    let face_num = face_whole * BOUND_SCALE + fractional_face;
+    let max_effective = face_whole + u128::from(has_fractional_face);
+    kani::assume((effective_raw as u128) <= max_effective);
+    let backing_num = (effective_raw as u128) * BOUND_SCALE;
+    let face_burn_num = if burn_full_face {
+        face_num
+    } else {
+        (burn_whole_raw as u128) * BOUND_SCALE
+    };
+
+    let release_num = MarketGroupV16ViewMut::<u64>::kani_source_lien_backing_release_for_face_burn(
+        face_num,
+        backing_num,
+        face_burn_num,
+    )
+    .unwrap();
+    let remaining_face = face_num - face_burn_num;
+    let remaining_face_ceiling =
+        remaining_face / BOUND_SCALE + u128::from(remaining_face % BOUND_SCALE != 0);
+    let remaining_effective = (backing_num - release_num) / BOUND_SCALE;
+    let expected_release_effective = (effective_raw as u128).saturating_sub(remaining_face_ceiling);
+
+    kani::cover!(
+        release_num == 0,
+        "remaining face can preserve the full lien"
+    );
+    kani::cover!(release_num != 0, "face burn can require backing release");
+    kani::cover!(
+        has_fractional_face && face_burn_num != face_num,
+        "fractional scaled face is covered"
+    );
+    assert_eq!(release_num % BOUND_SCALE, 0);
+    assert_eq!(release_num, expected_release_effective * BOUND_SCALE);
+    assert!(remaining_effective <= remaining_face_ceiling);
+    if release_num != 0 {
+        assert!(remaining_effective + 1 > remaining_face_ceiling);
+    }
+    if face_burn_num == face_num {
+        assert_eq!(release_num, backing_num);
+    }
+}
+
+// Live mark-reversal liveness and conservation across both source classes.
+// Full-width source partition: every valid liened-face burn is assigned exactly
+// once, counterparty-first, and the aggregate face rank decreases by the burn.
+#[kani::proof]
+#[kani::unwind(4)]
+#[kani::solver(cadical)]
+fn proof_v16_source_lien_face_burn_partition_is_total_disjoint_and_strict_progress() {
+    let counterparty_face: u128 = kani::any();
+    let insurance_face: u128 = kani::any();
+    kani::assume(counterparty_face <= u128::MAX - insurance_face);
+    let total_face = counterparty_face + insurance_face;
+    kani::assume(total_face > 0);
+    let face_burn: u128 = kani::any();
+    kani::assume(face_burn > 0 && face_burn <= total_face);
+
+    let (counterparty_burn, insurance_burn) =
+        MarketGroupV16ViewMut::<u64>::kani_source_lien_face_burn_partition(
+            counterparty_face,
+            insurance_face,
+            face_burn,
+        )
+        .unwrap();
+
+    assert_eq!(counterparty_burn, face_burn.min(counterparty_face));
+    assert_eq!(counterparty_burn + insurance_burn, face_burn);
+    assert!(counterparty_burn <= counterparty_face);
+    assert!(insurance_burn <= insurance_face);
+    assert_eq!(
+        (counterparty_face - counterparty_burn) + (insurance_face - insurance_burn),
+        total_face - face_burn
+    );
+    kani::cover!(
+        counterparty_burn > 0 && insurance_burn == 0,
+        "counterparty-only partition is reachable"
+    );
+    kani::cover!(
+        counterparty_burn == 0 && insurance_burn > 0,
+        "insurance-only partition is reachable"
+    );
+    kani::cover!(
+        counterparty_burn > 0 && insurance_burn > 0,
+        "one burn can cross both source classes"
+    );
+    kani::cover!(face_burn == total_face, "full face burn reaches rank zero");
+}
+
+// Bounded composition through the complete production plan. The separate
+// full-width partition theorem and fractional source-local release theorem
+// discharge the amount-independent algebra around this composition seam.
+// Any valid liened-face burn must admit a plan, reduce the face rank exactly,
+// release only the backing no longer supportable by remaining face, and leave
+// counterparty/insurance backing independently bounded by their own claims.
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_source_lien_face_burn_plan_is_total_minimal_and_source_isolated() {
+    let counterparty_whole: u8 = kani::any();
+    let insurance_whole: u8 = kani::any();
+    let burn_whole: u8 = kani::any();
+    kani::assume(counterparty_whole <= 8);
+    kani::assume(insurance_whole <= 8);
+    kani::assume(burn_whole <= 16);
+    let counterparty_face = (counterparty_whole as u128) * BOUND_SCALE;
+    let insurance_face = (insurance_whole as u128) * BOUND_SCALE;
+    let total_face = counterparty_face + insurance_face;
+    kani::assume(total_face > 0);
+
+    let counterparty_face_ceiling =
+        counterparty_face / BOUND_SCALE + u128::from(counterparty_face % BOUND_SCALE != 0);
+    let insurance_face_ceiling =
+        insurance_face / BOUND_SCALE + u128::from(insurance_face % BOUND_SCALE != 0);
+    let counterparty_effective: u8 = kani::any();
+    let insurance_effective: u8 = kani::any();
+    kani::assume((counterparty_effective as u128) <= counterparty_face_ceiling);
+    kani::assume((insurance_effective as u128) <= insurance_face_ceiling);
+    let counterparty_backing = (counterparty_effective as u128) * BOUND_SCALE;
+    let insurance_backing = (insurance_effective as u128) * BOUND_SCALE;
+    let face_burn = (burn_whole as u128) * BOUND_SCALE;
+    kani::assume(face_burn > 0 && face_burn <= total_face);
+
+    let (counterparty_burn, insurance_burn, counterparty_release, insurance_release, total_release) =
+        MarketGroupV16ViewMut::<u64>::kani_source_lien_face_burn_plan(
+            counterparty_face,
+            insurance_face,
+            counterparty_backing,
+            insurance_backing,
+            face_burn,
+        )
+        .unwrap();
+
+    assert_eq!(counterparty_burn, face_burn.min(counterparty_face));
+    assert_eq!(counterparty_burn + insurance_burn, face_burn);
+    assert!(counterparty_burn <= counterparty_face);
+    assert!(insurance_burn <= insurance_face);
+    assert_eq!(counterparty_release % BOUND_SCALE, 0);
+    assert_eq!(insurance_release % BOUND_SCALE, 0);
+    assert_eq!(total_release, counterparty_release + insurance_release);
+    assert!(counterparty_release <= counterparty_backing);
+    assert!(insurance_release <= insurance_backing);
+
+    let counterparty_face_after = counterparty_face - counterparty_burn;
+    let insurance_face_after = insurance_face - insurance_burn;
+    let counterparty_backing_after = counterparty_backing - counterparty_release;
+    let insurance_backing_after = insurance_backing - insurance_release;
+    let counterparty_ceiling_after = counterparty_face_after / BOUND_SCALE
+        + u128::from(counterparty_face_after % BOUND_SCALE != 0);
+    let insurance_ceiling_after =
+        insurance_face_after / BOUND_SCALE + u128::from(insurance_face_after % BOUND_SCALE != 0);
+
+    assert_eq!(
+        counterparty_face_after + insurance_face_after,
+        total_face - face_burn,
+        "every successful reversal strictly decreases the liened-face rank"
+    );
+    assert!(counterparty_backing_after / BOUND_SCALE <= counterparty_ceiling_after);
+    assert!(insurance_backing_after / BOUND_SCALE <= insurance_ceiling_after);
+    if counterparty_release != 0 {
+        assert_eq!(
+            counterparty_backing_after / BOUND_SCALE,
+            counterparty_ceiling_after
+        );
+    }
+    if insurance_release != 0 {
+        assert_eq!(
+            insurance_backing_after / BOUND_SCALE,
+            insurance_ceiling_after
+        );
+    }
+    if counterparty_burn == counterparty_face {
+        assert_eq!(counterparty_release, counterparty_backing);
+    }
+    if insurance_burn == insurance_face {
+        assert_eq!(insurance_release, insurance_backing);
+    }
+
+    kani::cover!(
+        counterparty_burn > 0 && insurance_burn == 0,
+        "counterparty-only face burn is reachable"
+    );
+    kani::cover!(
+        counterparty_burn == 0 && insurance_burn > 0,
+        "insurance-only face burn is reachable"
+    );
+    kani::cover!(
+        counterparty_burn > 0 && insurance_burn > 0,
+        "one burn can cross both source classes"
+    );
+    kani::cover!(
+        total_release == 0,
+        "face can shrink without over-releasing backing"
+    );
+    kani::cover!(total_release > 0, "face shrink can require backing release");
+    kani::cover!(
+        face_burn == total_face,
+        "full reversal releases the complete lien"
+    );
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_source_lien_fee_proration_tracks_remaining_backing() {
+    let fee_raw: u8 = kani::any();
+    let before_raw: u8 = kani::any();
+    let after_raw: u8 = kani::any();
+    kani::assume(fee_raw <= 32);
+    kani::assume((1..=16).contains(&before_raw));
+    kani::assume(after_raw <= before_raw);
+    let fee = fee_raw as u128;
+    let before = before_raw as u128 * BOUND_SCALE;
+    let after = after_raw as u128 * BOUND_SCALE;
+
+    let remaining = MarketGroupV16ViewMut::<u64>::kani_source_lien_fee_after_backing_release(
+        fee, before, after,
+    )
+    .unwrap();
+
+    kani::cover!(
+        after == before,
+        "unchanged backing preserves all fee history"
+    );
+    kani::cover!(after == 0, "full backing release clears live fee history");
+    kani::cover!(
+        after > 0 && after < before && fee > 0,
+        "partial backing release prorates nonzero fee history"
+    );
+    assert_eq!(remaining, fee * after / before);
+    assert!(remaining <= fee);
+    if after == before {
+        assert_eq!(remaining, fee);
+    }
+    if after == 0 {
+        assert_eq!(remaining, 0);
     }
 }
 
@@ -14647,9 +16558,16 @@ fn proof_v16_frame_earnings_withdraw_touches_only_declared_state() {
 #[kani::unwind(40)]
 #[kani::solver(cadical)]
 fn proof_v16_frame_resolve_market_touches_only_declared_state() {
+    let start_in_recovery: bool = kani::any();
     let delta_raw: u8 = kani::any();
     kani::assume(delta_raw >= 1 && delta_raw <= 8);
     let (mut header, mut markets, _) = one_market_view_fixture();
+    if start_in_recovery {
+        header.mode = 2;
+        header.recovery_reason = V16OptionalRecoveryReasonAccount::from_runtime(Some(
+            PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+        ));
+    }
     let resolved_slot = header.current_slot.get() + delta_raw as u64;
     let h0 = header;
     let s0 = markets[0].engine;
@@ -14657,7 +16575,7 @@ fn proof_v16_frame_resolve_market_touches_only_declared_state() {
         let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
         market.resolve_market_not_atomic(resolved_slot).unwrap();
     }
-    kani::cover!(true, "resolve frame reached");
+    kani::cover!(start_in_recovery, "Recovery-to-Resolved frame reached");
     let mut eh = h0;
     eh.mode = 1;
     eh.resolved_slot = V16PodU64::new(resolved_slot);
@@ -15253,7 +17171,7 @@ fn proof_v16_validator_sound_account_reserves() {
 // asset refresh and every other plan are dispatchable from committed state.
 // Pinning this truth table means a future arm that gates committed-state progress
 // on an observation contradicts a machine-checked theorem. Exhaustive over the
-// six AutoCrankPlanV16 variants; the spec matrix ties the predicate to the real
+// eight AutoCrankPlanV16 variants; the spec matrix ties the predicate to the real
 // dispatch for each reachable class.
 #[kani::proof]
 fn proof_v16_auto_crank_refresh_is_unique_observation_requiring_plan() {
@@ -15269,17 +17187,233 @@ fn proof_v16_auto_crank_refresh_is_unique_observation_requiring_plan() {
         asset_index: None
     }));
     // No other plan does — committed on-chain state suffices.
+    assert!(!needs_obs(&AutoCrankPlanV16::AdvanceRecoveryClose {
+        asset_index: i
+    }));
     assert!(!needs_obs(&AutoCrankPlanV16::SettleBChunk {
         asset_index: i
     }));
     assert!(!needs_obs(&AutoCrankPlanV16::Liquidate { asset_index: i }));
     assert!(!needs_obs(&AutoCrankPlanV16::NoAction));
+    assert!(!needs_obs(&AutoCrankPlanV16::FinalizeRecovery));
     assert!(!needs_obs(&AutoCrankPlanV16::CloseResolved));
     // The predicate matches DeclareRecovery { .. } regardless of reason, so a
     // concrete variant exercises the arm (the reason enum isn't Arbitrary here).
     assert!(!needs_obs(&AutoCrankPlanV16::DeclareRecovery {
         reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
     }));
+}
+
+// A liquidation error may cross the rollback boundary as successful progress
+// only when it is exactly RecoveryRequired and the same call left both pieces of
+// the durable Recovery marker. Exhaustive over every engine error, market mode,
+// recovery reason, and the missing-reason state.
+#[kani::proof]
+#[kani::unwind(4)]
+#[kani::solver(cadical)]
+fn proof_v16_liquidation_error_commits_only_fully_declared_recovery() {
+    let error_tag: u8 = kani::any();
+    let mode_tag: u8 = kani::any();
+    let reason_tag: u8 = kani::any();
+    kani::assume(error_tag < 12);
+    kani::assume(mode_tag < 3);
+    kani::assume(reason_tag <= 8);
+
+    let error = match error_tag {
+        0 => V16Error::InvalidConfig,
+        1 => V16Error::ArithmeticOverflow,
+        2 => V16Error::ProvenanceMismatch,
+        3 => V16Error::HiddenLeg,
+        4 => V16Error::InvalidLeg,
+        5 => V16Error::Stale,
+        6 => V16Error::BStale,
+        7 => V16Error::LockActive,
+        8 => V16Error::NonProgress,
+        9 => V16Error::RecoveryRequired,
+        10 => V16Error::CounterOverflow,
+        _ => V16Error::CounterUnderflow,
+    };
+    let mode = match mode_tag {
+        0 => MarketModeV16::Live,
+        1 => MarketModeV16::Resolved,
+        _ => MarketModeV16::Recovery,
+    };
+    let reason = match reason_tag {
+        0 => Some(PermissionlessRecoveryReasonV16::BelowProgressFloor),
+        1 => Some(PermissionlessRecoveryReasonV16::BlockedSegmentHeadroomOrRepresentability),
+        2 => Some(PermissionlessRecoveryReasonV16::AccountBSettlementCannotProgress),
+        3 => Some(PermissionlessRecoveryReasonV16::BIndexHeadroomExhausted),
+        4 => Some(PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress),
+        5 => Some(PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow),
+        6 => Some(PermissionlessRecoveryReasonV16::OracleOrTargetUnavailableByAuthenticatedPolicy),
+        7 => Some(PermissionlessRecoveryReasonV16::CounterOrEpochOverflowDeclaredRecovery),
+        _ => None,
+    };
+
+    let result = kani_commit_declared_liquidation_recovery(error, mode, reason);
+    let complete_declaration =
+        error == V16Error::RecoveryRequired && mode == MarketModeV16::Recovery && reason.is_some();
+    if complete_declaration {
+        assert_eq!(
+            result,
+            Ok(PermissionlessProgressOutcomeV16::RecoveryDeclared(
+                reason.unwrap()
+            ))
+        );
+    } else {
+        assert_eq!(result, Err(error));
+    }
+
+    kani::cover!(
+        complete_declaration
+            && reason == Some(PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress),
+        "a fully declared liquidation terminal commits successful recovery progress"
+    );
+    kani::cover!(
+        error == V16Error::RecoveryRequired && mode == MarketModeV16::Live,
+        "a bare recovery-required error is not swallowed"
+    );
+    kani::cover!(
+        error == V16Error::RecoveryRequired && mode == MarketModeV16::Recovery && reason.is_none(),
+        "an incomplete Recovery marker fails closed"
+    );
+    kani::cover!(
+        error != V16Error::RecoveryRequired && mode == MarketModeV16::Recovery && reason.is_some(),
+        "Recovery state cannot mask an unrelated engine error"
+    );
+}
+
+#[kani::proof]
+fn proof_v16_auto_crank_accrual_requires_selected_observation_and_no_preaccrual() {
+    let observations_preaccrued: bool = kani::any();
+    let selected_observation_supplied: bool = kani::any();
+    let skip = kani_auto_crank_skip_post_action_accrual(
+        observations_preaccrued,
+        selected_observation_supplied,
+    );
+
+    kani::cover!(
+        !observations_preaccrued && !selected_observation_supplied && skip,
+        "committed-price fallback cannot authorize accrual"
+    );
+    kani::cover!(
+        !observations_preaccrued && selected_observation_supplied && !skip,
+        "fresh selected observation authorizes one accrual segment"
+    );
+    kani::cover!(
+        observations_preaccrued && selected_observation_supplied && skip,
+        "pre-accrued selected observation cannot apply a second segment"
+    );
+    kani::cover!(
+        observations_preaccrued && !selected_observation_supplied && skip,
+        "pre-accrued work remains single-segment when the observation list is consumed"
+    );
+    assert_eq!(
+        !skip,
+        selected_observation_supplied && !observations_preaccrued
+    );
+}
+
+fn assert_v16_crank_observation_authorization<const OBSERVATION_SUPPLIED: bool>(
+    long_segment: bool,
+) {
+    let now_slot = if long_segment { 4 } else { 2 };
+    let (mut header, mut markets, mut account_header) = one_market_view_fixture();
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        market
+            .set_asset_raw_oracle_target_not_atomic(0, 101)
+            .unwrap();
+    }
+    let slot_before = markets[0].engine;
+    let slot_last_before = slot_before.asset.slot_last.get();
+    let max_accrual_dt_slots = header.config.max_accrual_dt_slots.get();
+    let vault_before = header.vault;
+    let c_tot_before = header.c_tot;
+    let insurance_before = header.insurance;
+    assert!(!account_header.health_cert.try_to_runtime().unwrap().valid);
+
+    let skip_post_action_accrual =
+        kani_auto_crank_skip_post_action_accrual(false, OBSERVATION_SUPPLIED);
+    let effective_price = if OBSERVATION_SUPPLIED {
+        101
+    } else {
+        slot_before.asset.effective_price.get()
+    };
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let outcome = market.kani_permissionless_crank_with_skip_post_action_accrual(
+        &mut account,
+        PermissionlessCrankRequestV16 {
+            now_slot,
+            asset_index: 0,
+            effective_price,
+            funding_rate_e9: 0,
+            action: PermissionlessCrankActionV16::Refresh,
+        },
+        skip_post_action_accrual,
+    );
+
+    assert_eq!(
+        outcome,
+        Ok(PermissionlessProgressOutcomeV16::AccountCurrent)
+    );
+    assert!(account.header.health_cert.try_to_runtime().unwrap().valid);
+    assert_eq!(market.header.vault, vault_before);
+    assert_eq!(market.header.c_tot, c_tot_before);
+    assert_eq!(market.header.insurance, insurance_before);
+    if OBSERVATION_SUPPLIED {
+        let asset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+        let expected_dt = (now_slot - slot_last_before).min(max_accrual_dt_slots);
+        assert!(expected_dt > 0);
+        assert_eq!(asset.slot_last, slot_last_before + expected_dt);
+        assert_eq!(
+            market.header.loss_stale_active != 0,
+            asset.slot_last < now_slot
+        );
+        assert_eq!(asset.effective_price, 101);
+        assert!(!kani_eq_engine_asset_slot_v16_account(
+            &slot_before,
+            &market.markets[0].engine
+        ));
+    } else {
+        assert!(kani_eq_engine_asset_slot_v16_account(
+            &slot_before,
+            &market.markets[0].engine
+        ));
+    }
+}
+
+#[kani::proof]
+#[kani::unwind(64)]
+#[kani::solver(cadical)]
+fn proof_v16_observation_free_crank_preserves_asset_while_account_progresses() {
+    let long_segment: bool = kani::any();
+    kani::cover!(
+        !long_segment,
+        "short elapsed segment cannot be consumed by committed-price fallback"
+    );
+    kani::cover!(
+        long_segment,
+        "long elapsed segment cannot be consumed by committed-price fallback"
+    );
+    assert_v16_crank_observation_authorization::<false>(long_segment);
+}
+
+#[kani::proof]
+#[kani::unwind(64)]
+#[kani::solver(cadical)]
+fn proof_v16_observed_crank_accrues_asset_while_preserving_value() {
+    let long_segment: bool = kani::any();
+    kani::cover!(
+        !long_segment,
+        "short elapsed segment accrues with a selected observation"
+    );
+    kani::cover!(
+        long_segment,
+        "long elapsed segment accrues with a selected observation"
+    );
+    assert_v16_crank_observation_authorization::<true>(long_segment);
 }
 
 // LoF — no free open interest: a risk-increasing fill with nonzero size, nonzero
@@ -15401,4 +17535,996 @@ fn proof_v16_backing_utilization_zero_fee_carries_accrual_forward() {
     assert_eq!(market.header.c_tot.get(), c_tot_before);
     assert_eq!(market.header.vault.get(), vault_before);
     assert_eq!(market.header.insurance.get(), insurance_before);
+}
+
+// Mixed-lifecycle liveness over every ordering and multiplicity in the full
+// 16-leg shape. Recovery obligations cannot become ordinary refresh/liquidation
+// targets or starve later Active/DrainOnly work.
+#[kani::proof]
+#[kani::unwind(18)]
+#[kani::solver(cadical)]
+fn proof_v16_recovery_legs_cannot_starve_dispatchable_auto_crank_work() {
+    let recovery_mask: u16 = kani::any();
+    let active_mask: u16 = kani::any();
+    let drain_only_mask: u16 = kani::any();
+    kani::assume(recovery_mask != 0);
+    kani::assume(recovery_mask & active_mask == 0);
+    kani::assume(recovery_mask & drain_only_mask == 0);
+    kani::assume(active_mask & drain_only_mask == 0);
+
+    let dispatchable_mask = active_mask | drain_only_mask;
+    let mut dispatchable_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+    let mut slot = 0usize;
+    while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+        let bit = 1u16 << slot;
+        let lifecycle = if recovery_mask & bit != 0 {
+            AssetLifecycleV16::Recovery
+        } else if active_mask & bit != 0 {
+            AssetLifecycleV16::Active
+        } else if drain_only_mask & bit != 0 {
+            AssetLifecycleV16::DrainOnly
+        } else {
+            AssetLifecycleV16::Retired
+        };
+        let dispatchable = kani_auto_crank_lifecycle_dispatchable(lifecycle);
+        assert_eq!(dispatchable, dispatchable_mask & bit != 0);
+        dispatchable_flags[slot] = dispatchable;
+        slot += 1;
+    }
+
+    let selected = kani_first_actionable_slot(dispatchable_flags);
+    let liquidatable = kani_auto_crank_liquidatable(true, true, 1, selected);
+    assert_eq!(liquidatable, dispatchable_mask != 0);
+    let mut recovery_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+    slot = 0;
+    while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+        recovery_flags[slot] = recovery_mask & (1u16 << slot) != 0;
+        slot += 1;
+    }
+    let first_recovery = kani_first_actionable_slot(recovery_flags).unwrap();
+
+    if dispatchable_mask == 0 {
+        assert!(selected.is_none());
+        let plan = kani_select_auto_crank_plan(
+            ActionableSummaryV16 {
+                stale: false,
+                b_stale: false,
+                pending_close: false,
+                expired_close: false,
+                liquidatable,
+                recovery_eligible: false,
+                resolved_winner: false,
+            },
+            0,
+            0,
+            0,
+            None,
+            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+        );
+        assert_eq!(plan, AutoCrankPlanV16::NoAction);
+    } else {
+        let selected = selected.unwrap();
+        let selected_bit = 1u16 << selected;
+        assert!(dispatchable_mask & selected_bit != 0);
+        assert!(recovery_mask & selected_bit == 0);
+        slot = 0;
+        while slot < selected {
+            assert!(dispatchable_mask & (1u16 << slot) == 0);
+            slot += 1;
+        }
+
+        let refresh = kani_select_auto_crank_plan(
+            ActionableSummaryV16 {
+                stale: true,
+                b_stale: false,
+                pending_close: false,
+                expired_close: false,
+                liquidatable: false,
+                recovery_eligible: false,
+                resolved_winner: false,
+            },
+            0,
+            0,
+            selected,
+            Some(selected),
+            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+        );
+        assert_eq!(
+            refresh,
+            AutoCrankPlanV16::RefreshAccount {
+                asset_index: Some(selected)
+            }
+        );
+        let liquidate = kani_select_auto_crank_plan(
+            ActionableSummaryV16 {
+                stale: false,
+                b_stale: false,
+                pending_close: false,
+                expired_close: false,
+                liquidatable,
+                recovery_eligible: false,
+                resolved_winner: false,
+            },
+            0,
+            0,
+            selected,
+            Some(selected),
+            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+        );
+        assert_eq!(
+            liquidate,
+            AutoCrankPlanV16::Liquidate {
+                asset_index: selected
+            }
+        );
+
+        kani::cover!(
+            first_recovery < selected,
+            "Recovery obligation can precede dispatchable work"
+        );
+        kani::cover!(
+            selected < first_recovery,
+            "dispatchable work can precede Recovery obligation"
+        );
+        kani::cover!(
+            active_mask & selected_bit != 0,
+            "Active candidate is selected"
+        );
+        kani::cover!(
+            drain_only_mask & selected_bit != 0,
+            "DrainOnly candidate is selected"
+        );
+    }
+
+    kani::cover!(
+        dispatchable_mask == 0,
+        "Recovery-only account has no fake liquidation target"
+    );
+}
+
+// Permissionless liveness theorem for mixed prior-reset obligations and live
+// liquidation candidates. Each refresh removes exactly one prior-reset
+// obligation, so the rank reaches zero within the bounded portfolio shape;
+// prior-reset legs are never selected as liquidation work.
+#[kani::proof]
+#[kani::unwind(18)]
+#[kani::solver(cadical)]
+fn proof_v16_prior_reset_cleanup_cannot_starve_live_liquidation() {
+    let reset_mask: u16 = kani::any();
+    let live_mask: u16 = kani::any();
+    let drain_only_mask: u16 = kani::any();
+    let basis_abs: u128 = kani::any();
+    let live_oi_q: u128 = kani::any();
+    let reset_epoch: u64 = kani::any();
+    let negative_basis: bool = kani::any();
+    kani::assume(reset_mask != 0);
+    kani::assume(live_mask != 0);
+    kani::assume(reset_mask & live_mask == 0);
+    kani::assume((1..=MAX_POSITION_ABS_Q).contains(&basis_abs));
+    kani::assume((1..=MAX_OI_SIDE_Q).contains(&live_oi_q));
+    kani::assume(reset_epoch > 0);
+
+    let basis_pos_q = if negative_basis {
+        -(basis_abs as i128)
+    } else {
+        basis_abs as i128
+    };
+    let mut reset_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+    let mut liquidation_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+    let mut refresh_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+    let mut slot = 0usize;
+    while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+        let bit = 1u16 << slot;
+        let is_reset = reset_mask & bit != 0;
+        let is_live = live_mask & bit != 0;
+        let active = is_reset || is_live;
+        let lifecycle = if drain_only_mask & bit != 0 {
+            AssetLifecycleV16::DrainOnly
+        } else {
+            AssetLifecycleV16::Active
+        };
+        let side_mode = if is_reset {
+            SideModeV16::ResetPending
+        } else {
+            SideModeV16::Normal
+        };
+        let asset_epoch = if is_reset { reset_epoch } else { 0 };
+        let leg_epoch_snap = if is_reset { reset_epoch - 1 } else { 0 };
+        let side_oi_q = if is_live { live_oi_q } else { 0 };
+        let (b_stale, refresh, liquidatable, reset_obligation) = kani_auto_crank_leg_flags(
+            active,
+            lifecycle,
+            basis_pos_q,
+            side_oi_q,
+            side_mode,
+            asset_epoch,
+            leg_epoch_snap,
+            false,
+        );
+
+        assert!(!b_stale);
+        assert_eq!(refresh, active);
+        assert_eq!(liquidatable, is_live);
+        assert_eq!(reset_obligation, is_reset);
+        assert!(!(liquidatable && reset_obligation));
+        refresh_flags[slot] = refresh;
+        liquidation_flags[slot] = liquidatable;
+        reset_flags[slot] = reset_obligation;
+        slot += 1;
+    }
+
+    let initial_reset_count = reset_mask.count_ones();
+    let first_reset = kani_first_actionable_slot(reset_flags).unwrap();
+    let first_live = kani_first_actionable_slot(liquidation_flags).unwrap();
+    kani::cover!(
+        initial_reset_count == 1,
+        "single reset obligation is reachable"
+    );
+    kani::cover!(
+        initial_reset_count > 1,
+        "multiple reset obligations are reachable"
+    );
+    kani::cover!(first_reset < first_live, "reset can precede live risk");
+    kani::cover!(first_live < first_reset, "live risk can precede reset");
+    kani::cover!(
+        drain_only_mask & (reset_mask | live_mask) != 0,
+        "DrainOnly legs share the bounded progress classification"
+    );
+
+    let mut calls = 0usize;
+    while calls < V16_MAX_PORTFOLIO_ASSETS_N {
+        let mut pre_reset_count = 0u32;
+        slot = 0;
+        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+            pre_reset_count += reset_flags[slot] as u32;
+            slot += 1;
+        }
+        if pre_reset_count != 0 {
+            let selected_reset = kani_first_actionable_slot(reset_flags).unwrap();
+            let refresh_asset = kani_first_actionable_slot(refresh_flags);
+            let plan = kani_select_auto_crank_plan(
+                ActionableSummaryV16 {
+                    stale: true,
+                    b_stale: false,
+                    pending_close: false,
+                    expired_close: false,
+                    liquidatable: false,
+                    recovery_eligible: false,
+                    resolved_winner: false,
+                },
+                0,
+                0,
+                first_live,
+                refresh_asset,
+                PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+            );
+            assert_eq!(
+                plan,
+                AutoCrankPlanV16::RefreshAccount {
+                    asset_index: refresh_asset
+                }
+            );
+
+            let mut already_cleared = false;
+            slot = 0;
+            while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+                if kani_should_clear_prior_reset_obligation(
+                    already_cleared,
+                    reset_flags[slot],
+                    false,
+                ) {
+                    assert_eq!(slot, selected_reset);
+                    reset_flags[slot] = false;
+                    refresh_flags[slot] = false;
+                    already_cleared = true;
+                }
+                slot += 1;
+            }
+            assert!(already_cleared);
+
+            let mut post_reset_count = 0u32;
+            slot = 0;
+            while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+                post_reset_count += reset_flags[slot] as u32;
+                slot += 1;
+            }
+            assert_eq!(post_reset_count + 1, pre_reset_count);
+        }
+        calls += 1;
+    }
+
+    assert!(kani_first_actionable_slot(reset_flags).is_none());
+    let selected_live = kani_first_actionable_slot(liquidation_flags).unwrap();
+    assert_eq!(selected_live, first_live);
+    let final_plan = kani_select_auto_crank_plan(
+        ActionableSummaryV16 {
+            stale: false,
+            b_stale: false,
+            pending_close: false,
+            expired_close: false,
+            liquidatable: true,
+            recovery_eligible: false,
+            resolved_winner: false,
+        },
+        0,
+        0,
+        selected_live,
+        kani_first_actionable_slot(refresh_flags),
+        PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+    );
+    assert_eq!(
+        final_plan,
+        AutoCrankPlanV16::Liquidate {
+            asset_index: first_live
+        }
+    );
+
+    assert!(!kani_should_clear_prior_reset_obligation(false, true, true));
+    assert!(!kani_should_clear_prior_reset_obligation(true, true, false));
+}
+
+// Shared liquidation/rebalance theorem for partially ADL-reduced positions.
+// Stored basis may exceed matched effective OI; production capacity must prevent
+// underflow and make any zero-OI stored residue permissionlessly actionable.
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_unilateral_close_capacity_is_safe_progress_and_residue_complete() {
+    let side = if kani::any::<bool>() {
+        SideV16::Long
+    } else {
+        SideV16::Short
+    };
+    let stored_abs: u128 = kani::any();
+    let matched_oi: u128 = kani::any();
+    let request: u128 = kani::any();
+    kani::assume((1..=MAX_POSITION_ABS_Q).contains(&stored_abs));
+    kani::assume((1..=MAX_OI_SIDE_Q).contains(&matched_oi));
+    kani::assume(request > 0);
+
+    let capacity = MarketGroupV16ViewMut::<u64>::kani_kernel_unilateral_close_capacity(
+        stored_abs, matched_oi, matched_oi,
+    );
+    let work = request.min(capacity);
+    let pre_basis_signed = match side {
+        SideV16::Long => stored_abs as i128,
+        SideV16::Short => -(stored_abs as i128),
+    };
+    let (reduced_q, delta) = MarketGroupV16ViewMut::<u64>::kani_kernel_reduce_position_delta(
+        pre_basis_signed,
+        side,
+        work,
+    )
+    .unwrap();
+    let expected = request.min(stored_abs).min(matched_oi);
+    let post_basis_signed = pre_basis_signed.checked_add(delta).unwrap();
+    let long_oi_after = matched_oi.checked_sub(reduced_q).unwrap();
+    let short_oi_after = matched_oi.checked_sub(reduced_q).unwrap();
+
+    assert_eq!(capacity, stored_abs.min(matched_oi));
+    assert_eq!(reduced_q, expected);
+    assert!(reduced_q > 0);
+    assert!(reduced_q <= stored_abs);
+    assert!(reduced_q <= matched_oi);
+    assert_eq!(post_basis_signed.unsigned_abs(), stored_abs - reduced_q);
+    assert!(
+        post_basis_signed == 0 || post_basis_signed.signum() == pre_basis_signed.signum(),
+        "risk reduction cannot flip the user's side"
+    );
+
+    if request >= capacity && stored_abs > matched_oi {
+        assert_eq!(long_oi_after, 0);
+        assert_eq!(short_oi_after, 0);
+        assert_ne!(post_basis_signed, 0);
+        let mut asset = AssetStateV16::default();
+        asset.oi_eff_long_q = long_oi_after;
+        asset.oi_eff_short_q = short_oi_after;
+        match side {
+            SideV16::Long => asset.stored_pos_count_long = 1,
+            SideV16::Short => asset.stored_pos_count_short = 1,
+        }
+        let leg = PortfolioLegV16 {
+            active: true,
+            side,
+            basis_pos_q: post_basis_signed,
+            ..PortfolioLegV16::EMPTY
+        };
+        assert!(
+            MarketGroupV16ViewMut::<u64>::kani_leg_has_exhausted_effective_oi(asset, leg),
+            "a nonzero basis after matched OI exhaustion must remain crank-actionable"
+        );
+    }
+
+    kani::cover!(side == SideV16::Long, "capacity covers long reductions");
+    kani::cover!(side == SideV16::Short, "capacity covers short reductions");
+    kani::cover!(request < capacity, "capacity covers partial requested work");
+    kani::cover!(
+        request >= capacity && stored_abs > matched_oi,
+        "capacity covers an ADL terminal residue"
+    );
+    kani::cover!(
+        request >= capacity && stored_abs <= matched_oi,
+        "capacity covers a full account close"
+    );
+}
+
+// Terminal ADL liveness theorem over the production clear kernel. A stored
+// settlement basis may exceed effective OI after quantity ADL; every record
+// still detaches without mutating the opposite side or double-debiting a
+// prior-reset side.
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_resolved_leg_clear_closes_every_adl_gap_without_cross_side_mutation() {
+    let side = if kani::any() {
+        SideV16::Long
+    } else {
+        SideV16::Short
+    };
+    let prior_reset: bool = kani::any();
+    let stored_raw: u16 = kani::any();
+    let effective_raw: u16 = kani::any();
+    let trailing_weight_raw: u16 = kani::any();
+    let count_raw: u8 = kani::any();
+    let epoch_raw: u8 = kani::any();
+    let b_rem_raw: u16 = kani::any();
+    kani::assume((1..=1024).contains(&stored_raw));
+    kani::assume(effective_raw < stored_raw);
+    kani::assume(count_raw > 0);
+    kani::assume(epoch_raw < u8::MAX);
+
+    let stored_q = stored_raw as u128 * POS_SCALE;
+    let effective_q = effective_raw as u128 * POS_SCALE;
+    let trailing_weight = trailing_weight_raw as u128 * POS_SCALE;
+    let basis = i128::try_from(stored_q).unwrap();
+    let leg = PortfolioLegV16 {
+        active: true,
+        side,
+        basis_pos_q: if side == SideV16::Long { basis } else { -basis },
+        epoch_snap: epoch_raw as u64,
+        loss_weight: stored_q,
+        b_rem: b_rem_raw as u128,
+        ..PortfolioLegV16::EMPTY
+    };
+    let mut asset = AssetStateV16::default();
+    asset.oi_eff_long_q = if side == SideV16::Long {
+        effective_q
+    } else {
+        7 * POS_SCALE
+    };
+    asset.oi_eff_short_q = if side == SideV16::Short {
+        effective_q
+    } else {
+        11 * POS_SCALE
+    };
+    asset.stored_pos_count_long = if side == SideV16::Long {
+        count_raw as u64
+    } else {
+        5
+    };
+    asset.stored_pos_count_short = if side == SideV16::Short {
+        count_raw as u64
+    } else {
+        3
+    };
+    asset.loss_weight_sum_long = if side == SideV16::Long {
+        stored_q + trailing_weight
+    } else {
+        13 * POS_SCALE
+    };
+    asset.loss_weight_sum_short = if side == SideV16::Short {
+        stored_q + trailing_weight
+    } else {
+        17 * POS_SCALE
+    };
+    if side == SideV16::Long {
+        asset.epoch_long = epoch_raw as u64 + u64::from(prior_reset);
+        asset.mode_long = if prior_reset {
+            SideModeV16::ResetPending
+        } else {
+            SideModeV16::Normal
+        };
+    } else {
+        asset.epoch_short = epoch_raw as u64 + u64::from(prior_reset);
+        asset.mode_short = if prior_reset {
+            SideModeV16::ResetPending
+        } else {
+            SideModeV16::Normal
+        };
+    }
+    let before = asset;
+
+    let after = kani_clear_resolved_leg(leg, asset).unwrap();
+
+    kani::cover!(
+        side == SideV16::Long && !prior_reset && effective_raw > 0 && b_rem_raw > 0,
+        "current-epoch long closes a strict ADL gap"
+    );
+    kani::cover!(
+        side == SideV16::Short && !prior_reset && effective_raw > 0,
+        "current-epoch short closes a strict ADL gap"
+    );
+    kani::cover!(
+        prior_reset && effective_raw > 0,
+        "prior-reset record detaches without a second aggregate debit"
+    );
+
+    match side {
+        SideV16::Long => {
+            assert_eq!(after.stored_pos_count_long, count_raw as u64 - 1);
+            assert_eq!(after.stored_pos_count_short, before.stored_pos_count_short);
+            assert_eq!(after.oi_eff_short_q, before.oi_eff_short_q);
+            assert_eq!(after.loss_weight_sum_short, before.loss_weight_sum_short);
+            if prior_reset {
+                assert_eq!(after.oi_eff_long_q, before.oi_eff_long_q);
+                assert_eq!(after.loss_weight_sum_long, before.loss_weight_sum_long);
+            } else {
+                assert_eq!(after.oi_eff_long_q, 0);
+                assert_eq!(after.loss_weight_sum_long, trailing_weight);
+            }
+        }
+        SideV16::Short => {
+            assert_eq!(after.stored_pos_count_short, count_raw as u64 - 1);
+            assert_eq!(after.stored_pos_count_long, before.stored_pos_count_long);
+            assert_eq!(after.oi_eff_long_q, before.oi_eff_long_q);
+            assert_eq!(after.loss_weight_sum_long, before.loss_weight_sum_long);
+            if prior_reset {
+                assert_eq!(after.oi_eff_short_q, before.oi_eff_short_q);
+                assert_eq!(after.loss_weight_sum_short, before.loss_weight_sum_short);
+            } else {
+                assert_eq!(after.oi_eff_short_q, 0);
+                assert_eq!(after.loss_weight_sum_short, trailing_weight);
+            }
+        }
+    }
+    assert_eq!(
+        after.social_loss_dust_long_num,
+        before.social_loss_dust_long_num
+    );
+    assert_eq!(
+        after.social_loss_dust_short_num,
+        before.social_loss_dust_short_num
+    );
+}
+
+// A partial ADL can leave stored basis after matched effective OI reaches zero.
+// Prove the production reset+clear composition: reset preserves the old K/F/B
+// epoch targets, quarantines fractional social loss, and the prior-epoch clear
+// cannot subtract basis or loss weight from the already-zero current epoch.
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_full_drain_reset_then_prior_epoch_clear_is_total_and_exact() {
+    let side = if kani::any::<bool>() {
+        SideV16::Long
+    } else {
+        SideV16::Short
+    };
+    let mode = if kani::any::<bool>() {
+        SideModeV16::Normal
+    } else {
+        SideModeV16::DrainOnly
+    };
+    let epoch: u64 = kani::any();
+    let stored_count: u64 = kani::any();
+    let basis_abs: u128 = kani::any();
+    let k: i128 = kani::any();
+    let f: i128 = kani::any();
+    let b: u128 = kani::any();
+    let loss_weight: u128 = kani::any();
+    let remainder: u128 = kani::any();
+    let dust: u128 = kani::any();
+    let explicit_before: u128 = kani::any();
+    kani::assume(epoch < u64::MAX);
+    kani::assume(stored_count > 0);
+    kani::assume((1..=MAX_POSITION_ABS_Q).contains(&basis_abs));
+    kani::assume(remainder < SOCIAL_LOSS_DEN);
+    kani::assume(dust < SOCIAL_LOSS_DEN);
+    kani::assume(explicit_before < u128::MAX);
+
+    let mut asset = AssetStateV16::default();
+    asset.lifecycle = AssetLifecycleV16::Recovery;
+    match side {
+        SideV16::Long => {
+            asset.a_long = ADL_ONE / 2;
+            asset.k_long = k;
+            asset.f_long_num = f;
+            asset.b_long_num = b;
+            asset.oi_eff_long_q = 0;
+            asset.stored_pos_count_long = stored_count;
+            asset.pending_obligation_count_long = 0;
+            asset.loss_weight_sum_long = loss_weight;
+            asset.social_loss_remainder_long_num = remainder;
+            asset.social_loss_dust_long_num = dust;
+            asset.explicit_unallocated_loss_long = explicit_before;
+            asset.epoch_long = epoch;
+            asset.mode_long = mode;
+        }
+        SideV16::Short => {
+            asset.a_short = ADL_ONE / 2;
+            asset.k_short = k;
+            asset.f_short_num = f;
+            asset.b_short_num = b;
+            asset.oi_eff_short_q = 0;
+            asset.stored_pos_count_short = stored_count;
+            asset.pending_obligation_count_short = 0;
+            asset.loss_weight_sum_short = loss_weight;
+            asset.social_loss_remainder_short_num = remainder;
+            asset.social_loss_dust_short_num = dust;
+            asset.explicit_unallocated_loss_short = explicit_before;
+            asset.epoch_short = epoch;
+            asset.mode_short = mode;
+        }
+    }
+    let before = asset;
+    let reset =
+        MarketGroupV16ViewMut::<u64>::kani_kernel_begin_full_drain_reset(asset, side).unwrap();
+    let total_fraction = dust.checked_add(remainder).unwrap();
+    let (expected_dust, carry) = if total_fraction >= SOCIAL_LOSS_DEN {
+        (total_fraction - SOCIAL_LOSS_DEN, 1)
+    } else {
+        (total_fraction, 0)
+    };
+    let expected_explicit = explicit_before.checked_add(carry).unwrap();
+    let mut expected_reset = before;
+    match side {
+        SideV16::Long => {
+            expected_reset.k_epoch_start_long = k;
+            expected_reset.f_epoch_start_long_num = f;
+            expected_reset.b_epoch_start_long_num = b;
+            expected_reset.k_long = 0;
+            expected_reset.f_long_num = 0;
+            expected_reset.b_long_num = 0;
+            expected_reset.loss_weight_sum_long = 0;
+            expected_reset.social_loss_remainder_long_num = 0;
+            expected_reset.social_loss_dust_long_num = expected_dust;
+            expected_reset.explicit_unallocated_loss_long = expected_explicit;
+            expected_reset.a_long = ADL_ONE;
+            expected_reset.epoch_long = epoch + 1;
+            expected_reset.mode_long = SideModeV16::ResetPending;
+        }
+        SideV16::Short => {
+            expected_reset.k_epoch_start_short = k;
+            expected_reset.f_epoch_start_short_num = f;
+            expected_reset.b_epoch_start_short_num = b;
+            expected_reset.k_short = 0;
+            expected_reset.f_short_num = 0;
+            expected_reset.b_short_num = 0;
+            expected_reset.loss_weight_sum_short = 0;
+            expected_reset.social_loss_remainder_short_num = 0;
+            expected_reset.social_loss_dust_short_num = expected_dust;
+            expected_reset.explicit_unallocated_loss_short = expected_explicit;
+            expected_reset.a_short = ADL_ONE;
+            expected_reset.epoch_short = epoch + 1;
+            expected_reset.mode_short = SideModeV16::ResetPending;
+        }
+    }
+    assert_eq!(reset, expected_reset);
+
+    let basis_pos_q = match side {
+        SideV16::Long => basis_abs as i128,
+        SideV16::Short => -(basis_abs as i128),
+    };
+    let leg = PortfolioLegV16 {
+        active: true,
+        side,
+        basis_pos_q,
+        epoch_snap: epoch,
+        loss_weight,
+        b_rem: remainder,
+        ..PortfolioLegV16::EMPTY
+    };
+    let cleared = MarketGroupV16ViewMut::<u64>::kani_kernel_clear_leg(leg, reset).unwrap();
+    let mut expected_clear = expected_reset;
+    match side {
+        SideV16::Long => expected_clear.stored_pos_count_long = stored_count - 1,
+        SideV16::Short => expected_clear.stored_pos_count_short = stored_count - 1,
+    }
+
+    kani::cover!(side == SideV16::Long, "reset+clear covers long residues");
+    kani::cover!(side == SideV16::Short, "reset+clear covers short residues");
+    kani::cover!(
+        mode == SideModeV16::DrainOnly,
+        "reset+clear covers DrainOnly"
+    );
+    kani::cover!(remainder > 0, "reset+clear quarantines nonzero remainder");
+    kani::cover!(
+        carry == 1,
+        "reset+clear records a whole-atom fractional carry"
+    );
+    kani::cover!(stored_count > 1, "reset+clear preserves sibling residues");
+    kani::cover!(
+        k != 0 && f != 0 && b != 0,
+        "reset+clear preserves nonzero K/F/B targets"
+    );
+    assert_eq!(cleared, expected_clear);
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_expired_counterparty_lien_impairment_is_exact_relabel() {
+    let counter_face_atoms: u8 = kani::any();
+    let counter_effective: u8 = kani::any();
+    let insurance_face_atoms: u8 = kani::any();
+    let insurance_effective: u8 = kani::any();
+    let prior_impaired_face_atoms: u8 = kani::any();
+    let prior_impaired_effective: u8 = kani::any();
+    let live_fee: u8 = kani::any();
+    let impaired_fee: u8 = kani::any();
+    kani::assume(counter_face_atoms > 0 && counter_face_atoms <= 8);
+    kani::assume(counter_effective > 0 && counter_effective <= counter_face_atoms);
+    kani::assume(insurance_face_atoms <= 8);
+    kani::assume(insurance_effective <= insurance_face_atoms);
+    kani::assume(prior_impaired_face_atoms <= 8);
+    kani::assume(prior_impaired_effective <= prior_impaired_face_atoms);
+
+    let counter_face = (counter_face_atoms as u128) * BOUND_SCALE;
+    let insurance_face = (insurance_face_atoms as u128) * BOUND_SCALE;
+    let prior_impaired_face = (prior_impaired_face_atoms as u128) * BOUND_SCALE;
+    let counter_backing = (counter_effective as u128) * BOUND_SCALE;
+    let insurance_backing = (insurance_effective as u128) * BOUND_SCALE;
+    let live_effective = counter_effective as u128 + insurance_effective as u128;
+    let source = PortfolioSourceDomainV16Account {
+        domain: V16PodU32::new(3),
+        source_claim_market_id: V16PodU64::new(9),
+        source_claim_bound_num: V16PodU128::new(
+            counter_face + insurance_face + prior_impaired_face + BOUND_SCALE,
+        ),
+        source_claim_liened_num: V16PodU128::new(counter_face + insurance_face),
+        source_claim_counterparty_liened_num: V16PodU128::new(counter_face),
+        source_claim_insurance_liened_num: V16PodU128::new(insurance_face),
+        source_lien_effective_reserved: V16PodU128::new(live_effective),
+        source_lien_counterparty_backing_num: V16PodU128::new(counter_backing),
+        source_lien_insurance_backing_num: V16PodU128::new(insurance_backing),
+        source_lien_fee_last_slot: V16PodU64::new(7),
+        source_claim_impaired_num: V16PodU128::new(prior_impaired_face),
+        source_lien_impaired_effective_reserved: V16PodU128::new(prior_impaired_effective as u128),
+        source_lien_capital_at_risk_fee_revenue: V16PodU128::new(live_fee as u128),
+        source_lien_impaired_capital_at_risk_fee_revenue: V16PodU128::new(impaired_fee as u128),
+    };
+
+    let (after, impaired_effective) =
+        MarketGroupV16ViewMut::<u64>::kani_prepare_account_counterparty_lien_impairment(source)
+            .unwrap();
+
+    kani::cover!(
+        insurance_face_atoms > 0,
+        "counterparty expiry preserves a mixed insurance-backed lien"
+    );
+    kani::cover!(
+        prior_impaired_face_atoms > 0,
+        "counterparty expiry composes with prior impaired face"
+    );
+    kani::cover!(
+        live_fee > 0 && insurance_effective > 0,
+        "counterparty expiry splits mixed-lien fee revenue"
+    );
+    assert_eq!(impaired_effective, counter_effective as u128);
+    assert_eq!(after.domain.get(), source.domain.get());
+    assert_eq!(
+        after.source_claim_market_id.get(),
+        source.source_claim_market_id.get()
+    );
+    assert_eq!(
+        after.source_claim_bound_num.get(),
+        source.source_claim_bound_num.get()
+    );
+    assert_eq!(after.source_claim_liened_num.get(), insurance_face);
+    assert_eq!(after.source_claim_counterparty_liened_num.get(), 0);
+    assert_eq!(
+        after.source_claim_insurance_liened_num.get(),
+        source.source_claim_insurance_liened_num.get()
+    );
+    assert_eq!(
+        after.source_claim_impaired_num.get(),
+        prior_impaired_face + counter_face
+    );
+    assert_eq!(
+        after.source_claim_liened_num.get() + after.source_claim_impaired_num.get(),
+        source.source_claim_liened_num.get() + source.source_claim_impaired_num.get()
+    );
+    assert_eq!(
+        after.source_lien_effective_reserved.get(),
+        insurance_effective as u128
+    );
+    assert_eq!(after.source_lien_counterparty_backing_num.get(), 0);
+    assert_eq!(
+        after.source_lien_insurance_backing_num.get(),
+        source.source_lien_insurance_backing_num.get()
+    );
+    assert_eq!(
+        after.source_lien_impaired_effective_reserved.get(),
+        prior_impaired_effective as u128 + counter_effective as u128
+    );
+    assert_eq!(
+        after.source_lien_effective_reserved.get()
+            + after.source_lien_impaired_effective_reserved.get(),
+        source.source_lien_effective_reserved.get()
+            + source.source_lien_impaired_effective_reserved.get()
+    );
+    assert_eq!(after.source_lien_fee_last_slot.get(), 0);
+    let expected_impaired_fee =
+        (live_fee as u128) * (counter_effective as u128) / (live_effective as u128);
+    assert_eq!(
+        after.source_lien_capital_at_risk_fee_revenue.get(),
+        live_fee as u128 - expected_impaired_fee
+    );
+    assert_eq!(
+        after.source_lien_impaired_capital_at_risk_fee_revenue.get(),
+        impaired_fee as u128 + expected_impaired_fee
+    );
+    assert_eq!(
+        after.source_lien_capital_at_risk_fee_revenue.get()
+            + after.source_lien_impaired_capital_at_risk_fee_revenue.get(),
+        live_fee as u128 + impaired_fee as u128
+    );
+}
+
+// Repeated production scan steps composed with the real expiry and account
+// impairment kernels form a finite rank-decreasing permissionless process.
+// This separates the amount-independent liveness theorem from the full-width
+// relabel theorem above, avoiding an artificial solver dependency on amounts.
+#[kani::proof]
+#[kani::unwind(12)]
+#[kani::solver(cadical)]
+fn proof_v16_live_source_backing_reconcile_is_bounded_progress() {
+    assert_eq!(PORTFOLIO_SOURCE_DOMAIN_CAP, 4);
+    let roster_len: u8 = kani::any();
+    let lapsed_mask: u8 = kani::any();
+    let lapsed_lien_mask: u8 = kani::any();
+    let impaired_lien_mask: u8 = kani::any();
+    let future_lien_mask: u8 = kani::any();
+    let foreign_impaired_mask: u8 = kani::any();
+    kani::assume(roster_len as usize <= PORTFOLIO_SOURCE_DOMAIN_CAP);
+    let roster_mask = (1u8 << roster_len) - 1;
+    kani::assume(lapsed_mask & !roster_mask == 0);
+    kani::assume(lapsed_lien_mask & !lapsed_mask == 0);
+    kani::assume(impaired_lien_mask & !roster_mask == 0);
+    kani::assume(future_lien_mask & !roster_mask == 0);
+    kani::assume(foreign_impaired_mask & !roster_mask == 0);
+    kani::assume(lapsed_mask & impaired_lien_mask == 0);
+    kani::assume(lapsed_mask & future_lien_mask == 0);
+    kani::assume(lapsed_mask & foreign_impaired_mask == 0);
+    kani::assume(impaired_lien_mask & future_lien_mask == 0);
+    kani::assume(impaired_lien_mask & foreign_impaired_mask == 0);
+    kani::assume(future_lien_mask & foreign_impaired_mask == 0);
+
+    let now_slot = 10u64;
+    let initial_actionable = lapsed_mask | impaired_lien_mask;
+    let mut remaining = initial_actionable;
+    let mut remaining_lapsed = lapsed_mask;
+    let mut account_lien_mask = lapsed_lien_mask | impaired_lien_mask | future_lien_mask;
+    let mut calls = 0usize;
+    while calls <= PORTFOLIO_SOURCE_DOMAIN_CAP {
+        let rank_before = remaining.count_ones();
+        let mut expected = None;
+        let mut selected = None;
+        let mut stopped = false;
+        let mut domain = 0usize;
+        while domain < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let bit = 1u8 << domain;
+            if expected.is_none() && remaining & bit != 0 {
+                expected = Some(domain);
+            }
+            if !stopped {
+                let occupied = domain < roster_len as usize;
+                let sparse_tail = domain == roster_len as usize;
+                let processed_lapsed_lien = lapsed_lien_mask & !remaining_lapsed & bit != 0;
+                let status = if remaining_lapsed & bit != 0 {
+                    BackingBucketStatusV16::Fresh
+                } else if (impaired_lien_mask | foreign_impaired_mask) & bit != 0
+                    || processed_lapsed_lien
+                {
+                    BackingBucketStatusV16::Impaired
+                } else if future_lien_mask & bit != 0 {
+                    BackingBucketStatusV16::Fresh
+                } else {
+                    BackingBucketStatusV16::Expired
+                };
+                let expiry_slot = if remaining_lapsed & bit != 0 {
+                    now_slot
+                } else {
+                    now_slot + 1
+                };
+                (selected, stopped) =
+                    MarketGroupV16ViewMut::<u64>::kani_live_source_backing_reconcile_scan_step(
+                        selected,
+                        sparse_tail,
+                        occupied,
+                        domain,
+                        if account_lien_mask & bit != 0 {
+                            BOUND_SCALE
+                        } else {
+                            0
+                        },
+                        status,
+                        expiry_slot,
+                        now_slot,
+                    );
+            }
+            domain += 1;
+        }
+        assert_eq!(selected.map(|action| action.0), expected);
+
+        if let Some((selected_domain, newly_lapsed, impair_account)) = selected {
+            let selected_bit = 1u8 << selected_domain;
+            assert!(remaining & selected_bit != 0);
+            assert_eq!(newly_lapsed, remaining_lapsed & selected_bit != 0);
+            assert_eq!(impair_account, account_lien_mask & selected_bit != 0);
+            if newly_lapsed {
+                let liened = lapsed_lien_mask & selected_bit != 0;
+                let bucket = BackingBucketV16 {
+                    market_id: 1,
+                    fresh_unliened_backing_num: if liened { 0 } else { BOUND_SCALE },
+                    valid_liened_backing_num: if liened { BOUND_SCALE } else { 0 },
+                    expiry_slot: now_slot,
+                    status: BackingBucketStatusV16::Fresh,
+                    ..BackingBucketV16::EMPTY
+                };
+                let source = SourceCreditStateV16 {
+                    fresh_reserved_backing_num: BOUND_SCALE,
+                    valid_liened_backing_num: bucket.valid_liened_backing_num,
+                    ..SourceCreditStateV16::EMPTY
+                };
+                let (bucket_after, source_after) =
+                    MarketGroupV16ViewMut::<u64>::kani_prepare_counterparty_backing_expiry_delta(
+                        bucket, source, now_slot,
+                    )
+                    .unwrap();
+                assert_eq!(source_after.fresh_reserved_backing_num, 0);
+                assert_ne!(bucket_after.status, BackingBucketStatusV16::Fresh);
+                remaining_lapsed &= !selected_bit;
+            }
+            if impair_account {
+                let source = PortfolioSourceDomainV16Account {
+                    domain: V16PodU32::new(selected_domain as u32),
+                    source_claim_bound_num: V16PodU128::new(2 * BOUND_SCALE),
+                    source_claim_liened_num: V16PodU128::new(BOUND_SCALE),
+                    source_claim_counterparty_liened_num: V16PodU128::new(BOUND_SCALE),
+                    source_lien_effective_reserved: V16PodU128::new(1),
+                    source_lien_counterparty_backing_num: V16PodU128::new(BOUND_SCALE),
+                    ..PortfolioSourceDomainV16Account::default()
+                };
+                let (source_after, impaired_effective) = MarketGroupV16ViewMut::<u64>::
+                    kani_prepare_account_counterparty_lien_impairment(source)
+                    .unwrap();
+                assert_eq!(impaired_effective, 1);
+                assert_eq!(source_after.source_lien_counterparty_backing_num.get(), 0);
+                account_lien_mask &= !selected_bit;
+            }
+            remaining &= !selected_bit;
+            assert_eq!(remaining.count_ones() + 1, rank_before);
+        } else {
+            assert_eq!(rank_before, 0);
+        }
+        assert_eq!(account_lien_mask & future_lien_mask, future_lien_mask);
+        assert_eq!(account_lien_mask & foreign_impaired_mask, 0);
+        calls += 1;
+    }
+
+    assert_eq!(remaining, 0);
+    kani::cover!(initial_actionable == 0, "clean roster is a fixed point");
+    kani::cover!(
+        initial_actionable.count_ones() > 1,
+        "multiple obligations drain in bounded calls"
+    );
+    kani::cover!(
+        lapsed_mask & !lapsed_lien_mask != 0,
+        "unliened lapsed backing progresses"
+    );
+    kani::cover!(lapsed_lien_mask != 0, "lapsed account liens progress");
+    kani::cover!(
+        impaired_lien_mask != 0,
+        "already-impaired account liens progress"
+    );
+    kani::cover!(future_lien_mask != 0, "future source liens stay live");
+    kani::cover!(
+        foreign_impaired_mask != 0,
+        "foreign impaired backing remains isolated"
+    );
+    kani::cover!(
+        initial_actionable & 1 == 0 && initial_actionable != 0,
+        "scan skips earlier non-actionable domains"
+    );
 }

--- a/tests/proofs_v16_arithmetic.rs
+++ b/tests/proofs_v16_arithmetic.rs
@@ -6,7 +6,8 @@ use percolator::v16::{
 use percolator::wide_math::{
     ceil_div_positive_checked, floor_div_signed_conservative_i128, mul_div_ceil_u256,
     mul_div_floor_u256, mul_div_floor_u256_with_rem, wide_signed_mul_div_floor,
-    wide_signed_mul_div_floor_from_k_pair, I256, U256,
+    wide_signed_mul_div_floor_from_k_pair, wide_signed_mul_div_floor_with_carry_from_k_pair, I256,
+    U256,
 };
 use percolator::{ADL_ONE, POS_SCALE};
 
@@ -19,6 +20,16 @@ fn small_signed_floor_reference(n: i128, d: u128) -> i128 {
         let r = abs % d;
         -((q + u128::from(r != 0)) as i128)
     }
+}
+
+fn cadence_div_rem_stub(num: U256, den: U256) -> (U256, U256) {
+    assert_eq!(num.hi(), 0);
+    assert_eq!(den.hi(), 0);
+    assert_ne!(den.lo(), 0);
+    (
+        U256::from_u128(num.lo() / den.lo()),
+        U256::from_u128(num.lo() % den.lo()),
+    )
 }
 
 #[kani::proof]
@@ -139,6 +150,7 @@ fn proof_v16_wide_signed_mul_div_floor_matches_small_reference() {
 #[kani::proof]
 #[kani::unwind(80)]
 #[kani::solver(cadical)]
+#[kani::stub(percolator::wide_math::div_rem_u256, cadence_div_rem_stub)]
 fn proof_v16_k_pair_mul_div_floor_matches_small_reference() {
     let abs_basis_raw: u8 = kani::any();
     let k_then_raw: i8 = kani::any();
@@ -159,6 +171,61 @@ fn proof_v16_k_pair_mul_div_floor_matches_small_reference() {
     kani::cover!(k_now < k_then, "negative K-diff pair branch");
     kani::cover!(k_now > k_then, "positive K-diff pair branch");
     assert_eq!(got, expected);
+}
+
+#[kani::proof]
+#[kani::unwind(80)]
+#[kani::solver(cadical)]
+#[kani::stub(percolator::wide_math::div_rem_u256, cadence_div_rem_stub)]
+fn proof_v16_k_pair_carry_is_reference_exact_and_partition_invariant() {
+    let abs_basis_raw: u8 = kani::any();
+    let first_delta_raw: i8 = kani::any();
+    let second_delta_raw: i8 = kani::any();
+    let den_raw: u8 = kani::any();
+    let carry_raw: u8 = kani::any();
+    kani::assume(abs_basis_raw <= 4);
+    kani::assume((-4..=4).contains(&first_delta_raw));
+    kani::assume((-4..=4).contains(&second_delta_raw));
+    kani::assume((1..=8).contains(&den_raw));
+    kani::assume(carry_raw < den_raw);
+
+    let abs_basis = u128::from(abs_basis_raw);
+    let first_delta = i128::from(first_delta_raw);
+    let second_delta = i128::from(second_delta_raw);
+    let k_mid = first_delta;
+    let k_end = first_delta + second_delta;
+    let den = u128::from(den_raw);
+    let carry = u128::from(carry_raw);
+
+    let (first_q, first_rem) =
+        wide_signed_mul_div_floor_with_carry_from_k_pair(abs_basis, 0, k_mid, den, carry);
+    let (second_q, fragmented_rem) =
+        wide_signed_mul_div_floor_with_carry_from_k_pair(abs_basis, k_mid, k_end, den, first_rem);
+    let (delayed_q, delayed_rem) =
+        wide_signed_mul_div_floor_with_carry_from_k_pair(abs_basis, 0, k_end, den, carry);
+
+    let exact_num = carry as i128 + abs_basis as i128 * k_end;
+    let expected_q = small_signed_floor_reference(exact_num, den);
+    let expected_rem = (exact_num - expected_q * den as i128) as u128;
+
+    kani::cover!(
+        first_delta > 0 && second_delta > 0 && first_rem != 0,
+        "positive fragmented accrual carries a fractional remainder"
+    );
+    kani::cover!(
+        first_delta < 0 && second_delta < 0 && first_rem != 0,
+        "negative fragmented accrual carries a fractional remainder"
+    );
+    kani::cover!(
+        first_delta.signum() == -second_delta.signum() && k_end != 0,
+        "fragmentation remains exact across an index direction reversal"
+    );
+    kani::cover!(carry > 0, "an existing settlement remainder is preserved");
+    assert_eq!(first_q + second_q, delayed_q);
+    assert_eq!(fragmented_rem, delayed_rem);
+    assert_eq!(delayed_q, expected_q);
+    assert_eq!(delayed_rem, expected_rem);
+    assert!(delayed_rem < den);
 }
 
 #[kani::proof]

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1,6 +1,6 @@
 use percolator::{
-    auto_crank_plan_requires_caller_observation, AutoCrankObservationV16, AutoCrankOutcomeV16,
-    AutoCrankPlanV16, AutoCrankWorkV16,
+    active_bitmap_is_empty, auto_crank_plan_requires_caller_observation, AutoCrankObservationV16,
+    AutoCrankOutcomeV16, AutoCrankPlanV16, AutoCrankWorkV16,
 };
 use percolator::{
     v16_domain_count_for_market_slots, AssetLifecycleV16, AssetStateV16Account,
@@ -10,12 +10,14 @@ use percolator::{
     PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
-    ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedPayoutLedgerV16,
-    ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16, ResolvedPayoutReceiptV16Account,
-    SideModeV16, SideV16, SourceCreditStateV16, SourceCreditStateV16Account, TradeRequestV16,
-    V16Config, V16Error, V16PodI128, V16PodU128, V16PodU32, V16PodU64, V16_EMPTY_ACTIVE_BITMAP,
+    ProvenanceHeaderV16, ProvenanceHeaderV16Account, RebalanceRequestV16, ResolvedCloseOutcomeV16,
+    ResolvedPayoutLedgerV16, ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16,
+    ResolvedPayoutReceiptV16Account, SideModeV16, SideV16, SourceCreditStateV16,
+    SourceCreditStateV16Account, TradeRequestV16, V16Config, V16Error,
+    V16OptionalRecoveryReasonAccount, V16PodI128, V16PodU128, V16PodU32, V16PodU64,
+    V16_EMPTY_ACTIVE_BITMAP,
 };
-use percolator::{ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, POS_SCALE};
+use percolator::{ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, FUNDING_DEN, POS_SCALE};
 
 const FUNDING_COUNTER_PRICE: u64 = 1_000_000;
 const FUNDING_COUNTER_RATE_E9: i128 = 10_000;
@@ -23,6 +25,223 @@ const FUNDING_COUNTER_ATOMS_PER_SLOT: u128 = 10;
 
 fn ids() -> ([u8; 32], [u8; 32], [u8; 32]) {
     ([1; 32], [2; 32], [3; 32])
+}
+
+#[test]
+fn v16_quantity_adl_blocks_fresh_basis_reissue_across_split_trades() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut long_header = account_fixture(1, 220);
+    let mut short_header = account_fixture(1, 221);
+    let mut successor_header = account_fixture(1, 222);
+    let open_q = 4 * POS_SCALE;
+
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        let mut successor = PortfolioV16ViewMut::new(&mut successor_header);
+        market.deposit_not_atomic(&mut long, 10_000).unwrap();
+        market.deposit_not_atomic(&mut short, 10_000).unwrap();
+        market.deposit_not_atomic(&mut successor, 10_000).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: signed_q(open_q),
+                    exec_price: 100,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+        market
+            .rebalance_reduce_position_not_atomic(
+                &mut long,
+                RebalanceRequestV16 {
+                    asset_index: 0,
+                    reduce_q: POS_SCALE,
+                },
+            )
+            .unwrap();
+    }
+
+    let asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(asset.oi_eff_long_q, 3 * POS_SCALE);
+    assert_eq!(asset.oi_eff_short_q, 3 * POS_SCALE);
+    assert_eq!(asset.a_short, ADL_ONE * 3 / 4);
+    assert_eq!(
+        short_header.legs[0]
+            .try_to_runtime()
+            .unwrap()
+            .basis_pos_q
+            .unsigned_abs(),
+        open_q
+    );
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    let mut successor = PortfolioV16ViewMut::new(&mut successor_header);
+    let result = market.execute_trade_with_fee_loss_stale_scoped_not_atomic(
+        &mut short,
+        &mut successor,
+        TradeRequestV16 {
+            asset_index: 0,
+            size_q: signed_q(open_q / 2),
+            exec_price: 100,
+            fee_bps: 0,
+        },
+    );
+
+    assert_eq!(result, Err(V16Error::LockActive));
+}
+
+#[test]
+fn v16_quantity_adl_price_and_funding_accrual_remain_zero_sum() {
+    let (mut header, mut markets) = funding_market_fixture(FUNDING_COUNTER_PRICE);
+    let mut long_header = account_fixture(1, 223);
+    let mut short_header = account_fixture(1, 224);
+    let open_q = 4 * POS_SCALE;
+
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market.deposit_not_atomic(&mut long, 100_000_000).unwrap();
+        market.deposit_not_atomic(&mut short, 100_000_000).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: signed_q(open_q),
+                    exec_price: FUNDING_COUNTER_PRICE,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+        market
+            .rebalance_reduce_position_not_atomic(
+                &mut long,
+                RebalanceRequestV16 {
+                    asset_index: 0,
+                    reduce_q: POS_SCALE,
+                },
+            )
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(
+                0,
+                2,
+                FUNDING_COUNTER_PRICE + 1,
+                FUNDING_COUNTER_RATE_E9,
+                true,
+            )
+            .unwrap();
+        market.markets[0].engine.asset.raw_oracle_target_price =
+            V16PodU64::new(FUNDING_COUNTER_PRICE + 1);
+    }
+
+    let asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    let scaled = (ADL_ONE * 3 / 4) as i128;
+    let funding_index_numerator = FUNDING_COUNTER_RATE_E9 * (FUNDING_COUNTER_PRICE as i128 + 1);
+    assert_eq!(asset.k_long, ADL_ONE as i128);
+    assert_eq!(asset.k_short, -scaled);
+    assert_eq!(
+        asset.f_long_num,
+        -(funding_index_numerator * (ADL_ONE / FUNDING_DEN) as i128)
+    );
+    assert_eq!(
+        asset.f_short_num,
+        funding_index_numerator * ((scaled as u128 / FUNDING_DEN) as i128)
+    );
+
+    let total_value = |long: &PortfolioAccountV16Account,
+                       short: &PortfolioAccountV16Account|
+     -> i128 {
+        long.capital.get() as i128 + long.pnl.get() + short.capital.get() as i128 + short.pnl.get()
+    };
+    let value_before = total_value(&long_header, &short_header);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: -signed_q(POS_SCALE),
+                    exec_price: FUNDING_COUNTER_PRICE + 1,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+    }
+    let value_delta = total_value(&long_header, &short_header) - value_before;
+    assert!(
+        (-1..=0).contains(&value_delta),
+        "post-ADL settlement must be neutral or conservatively rounded by one atom"
+    );
+}
+
+fn quantity_adl_funding_indices_after_cadence(fragmented: bool) -> (u128, i128, i128) {
+    let (mut header, mut markets) = funding_cadence_fixture();
+    let mut long_header = account_fixture(1, 225);
+    let mut short_header = account_fixture(1, 226);
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market.deposit_not_atomic(&mut long, 10_000_000).unwrap();
+    market.deposit_not_atomic(&mut short, 10_000_000).unwrap();
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: signed_q(3 * POS_SCALE),
+                exec_price: FUNDING_COUNTER_PRICE,
+                fee_bps: 0,
+            },
+        )
+        .unwrap();
+    market
+        .rebalance_reduce_position_not_atomic(
+            &mut long,
+            RebalanceRequestV16 {
+                asset_index: 0,
+                reduce_q: POS_SCALE,
+            },
+        )
+        .unwrap();
+
+    if fragmented {
+        for slot in 2..=11 {
+            market
+                .accrue_asset_to_not_atomic(0, slot, FUNDING_COUNTER_PRICE, 100, true)
+                .unwrap();
+        }
+    } else {
+        market
+            .accrue_asset_to_not_atomic(0, 11, FUNDING_COUNTER_PRICE, 100, true)
+            .unwrap();
+    }
+
+    let asset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    (asset.a_short, asset.f_long_num, asset.f_short_num)
+}
+
+#[test]
+fn v16_quantity_adl_funding_indices_preserve_cadence_invariance() {
+    let delayed = quantity_adl_funding_indices_after_cadence(false);
+    let fragmented = quantity_adl_funding_indices_after_cadence(true);
+
+    assert_ne!(delayed.0, ADL_ONE);
+    assert_ne!(delayed.0 % FUNDING_DEN, 0);
+    assert_eq!(fragmented, delayed);
 }
 
 fn market_fixture(
@@ -116,6 +335,129 @@ fn open_one_lot_pair(
             },
         )
         .unwrap();
+}
+
+fn funding_cadence_fixture() -> (MarketGroupV16HeaderAccount, Vec<Market<u64>>) {
+    let (market_id, _, _) = ids();
+    let mut cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
+    cfg.max_abs_funding_e9_per_slot = 100;
+    cfg.max_accrual_dt_slots = 10;
+    cfg.min_funding_lifetime_slots = 10;
+    cfg.max_price_move_bps_per_slot = 1;
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_id, cfg, 1, 0).unwrap();
+    let mut markets = vec![Market::new(0, EngineAssetSlotV16Account::default())];
+    header
+        .activate_empty_asset_slot_not_atomic(0, &mut markets[0].engine, FUNDING_COUNTER_PRICE, 1)
+        .unwrap();
+    (header, markets)
+}
+
+fn funding_after_cadence(fragmented: bool) -> (i128, i128, u64, u128, u128, u128) {
+    let (mut header, mut markets) = funding_cadence_fixture();
+    let mut long_header = account_fixture(1, 122);
+    let mut short_header = account_fixture(1, 123);
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    open_one_lot_pair(&mut market, &mut long, &mut short);
+
+    if fragmented {
+        for slot in 2..=11 {
+            market
+                .accrue_asset_to_not_atomic(0, slot, FUNDING_COUNTER_PRICE, 100, true)
+                .unwrap();
+            market.full_account_refresh_not_atomic(&mut long).unwrap();
+        }
+    } else {
+        market
+            .accrue_asset_to_not_atomic(0, 11, FUNDING_COUNTER_PRICE, 100, true)
+            .unwrap();
+        market.full_account_refresh_not_atomic(&mut long).unwrap();
+    }
+
+    let asset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    let leg = long.header.legs[0].try_to_runtime().unwrap();
+    (
+        asset.f_long_num,
+        asset.f_short_num,
+        market.header.funding_epoch.get(),
+        long.header.capital.get(),
+        leg.f_rem_num,
+        long.header.funding_long_paid_atoms_total.get(),
+    )
+}
+
+#[test]
+fn v16_funding_accrual_is_invariant_to_permissionless_crank_cadence() {
+    let delayed = funding_after_cadence(false);
+    let fragmented = funding_after_cadence(true);
+
+    assert_ne!(delayed.0, 0, "ten-slot control must accrue funding");
+    assert_eq!(fragmented.0, delayed.0);
+    assert_eq!(fragmented.1, delayed.1);
+    assert_eq!(fragmented.3, delayed.3);
+    assert_eq!(fragmented.4, delayed.4);
+    assert_eq!(fragmented.5, delayed.5);
+    assert_eq!(delayed.3, 9_999_999);
+    assert_eq!(delayed.4, 0);
+    assert_eq!(delayed.5, 1);
+}
+
+fn fractional_price_loss_after_cadence(fragmented: bool) -> (u128, i128, u128) {
+    const FRACTIONAL_LOT_Q: i128 = POS_SCALE as i128 / 1_000;
+
+    let (mut header, mut markets) = funding_cadence_fixture();
+    let mut long_header = account_fixture(1, 124);
+    let mut short_header = account_fixture(1, 125);
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market.deposit_not_atomic(&mut long, 10_000_000).unwrap();
+    market.deposit_not_atomic(&mut short, 10_000_000).unwrap();
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: FRACTIONAL_LOT_Q,
+                exec_price: FUNDING_COUNTER_PRICE,
+                fee_bps: 0,
+            },
+        )
+        .unwrap();
+
+    if fragmented {
+        for slot in 2..=11 {
+            let price = FUNDING_COUNTER_PRICE + (slot - 1) * 100;
+            market
+                .accrue_asset_to_not_atomic(0, slot, price, 0, true)
+                .unwrap();
+            market.full_account_refresh_not_atomic(&mut short).unwrap();
+        }
+    } else {
+        market
+            .accrue_asset_to_not_atomic(0, 11, FUNDING_COUNTER_PRICE + 1_000, 0, true)
+            .unwrap();
+        market.full_account_refresh_not_atomic(&mut short).unwrap();
+    }
+
+    let leg = short.header.legs[0].try_to_runtime().unwrap();
+    (
+        short.header.capital.get(),
+        short.header.pnl.get(),
+        leg.k_rem_num,
+    )
+}
+
+#[test]
+fn v16_fractional_k_settlement_is_invariant_to_permissionless_refresh_cadence() {
+    let delayed = fractional_price_loss_after_cadence(false);
+    let fragmented = fractional_price_loss_after_cadence(true);
+
+    assert_eq!(fragmented, delayed);
+    assert_eq!(delayed.0, 9_999_999);
+    assert_eq!(delayed.2, 0);
 }
 
 #[test]
@@ -700,6 +1042,88 @@ fn v16_trade_keeps_two_sided_risk_reduction_open_during_side_recovery() {
 }
 
 #[test]
+fn v16_two_sided_reduction_does_not_require_same_fill_im_recovery() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    header.config.maintenance_margin_bps = V16PodU64::new(5_000);
+    header.config.initial_margin_bps = V16PodU64::new(10_000);
+    header.config.max_price_move_bps_per_slot = V16PodU64::new(1_000);
+    let mut long_header = account_fixture(1, 20);
+    let mut short_header = account_fixture(1, 21);
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market.deposit_not_atomic(&mut long, 1_000).unwrap();
+    market.deposit_not_atomic(&mut short, 1_000).unwrap();
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: signed_q(10 * POS_SCALE),
+                exec_price: 100,
+                fee_bps: 0,
+            },
+        )
+        .unwrap();
+
+    assert_eq!(
+        market
+            .sync_account_fee_to_slot_not_atomic(&mut long, 1, 150)
+            .unwrap(),
+        150
+    );
+    assert_eq!(
+        market
+            .sync_account_fee_to_slot_not_atomic(&mut short, 1, 150)
+            .unwrap(),
+        150
+    );
+    assert_eq!(
+        long.header
+            .health_cert
+            .try_to_runtime()
+            .unwrap()
+            .certified_liq_deficit,
+        0
+    );
+    assert_eq!(
+        short
+            .header
+            .health_cert
+            .try_to_runtime()
+            .unwrap()
+            .certified_liq_deficit,
+        0
+    );
+
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: -signed_q(POS_SCALE),
+                exec_price: 100,
+                fee_bps: 0,
+            },
+        )
+        .expect("a matched reduction must progress even when one fill cannot restore IM");
+
+    let long_leg = long.header.legs[0].try_to_runtime().unwrap();
+    let short_leg = short.header.legs[0].try_to_runtime().unwrap();
+    assert_eq!(long_leg.basis_pos_q, signed_q(9 * POS_SCALE));
+    assert_eq!(short_leg.basis_pos_q, -signed_q(9 * POS_SCALE));
+    let long_cert = long.header.health_cert.try_to_runtime().unwrap();
+    let short_cert = short.header.health_cert.try_to_runtime().unwrap();
+    assert!((long_cert.certified_equity as u128) < long_cert.certified_initial_req);
+    assert!((short_cert.certified_equity as u128) < short_cert.certified_initial_req);
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+    short.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_crossed_trade_cannot_spend_same_call_addition_as_preexisting_oi() {
     const SURVIVOR_Q: u128 = 13 * POS_SCALE;
     const MATCHED_Q: u128 = 10 * POS_SCALE;
@@ -736,6 +1160,8 @@ fn v16_crossed_trade_cannot_spend_same_call_addition_as_preexisting_oi() {
         a_basis: ADL_ONE,
         k_snap: asset.k_long,
         f_snap: asset.f_long_num,
+        k_rem_num: 0,
+        f_rem_num: 0,
         epoch_snap: asset.epoch_long,
         loss_weight: SURVIVOR_Q,
         b_snap: asset.b_long_num,
@@ -755,6 +1181,8 @@ fn v16_crossed_trade_cannot_spend_same_call_addition_as_preexisting_oi() {
         a_basis: ADL_ONE,
         k_snap: asset.k_short,
         f_snap: asset.f_short_num,
+        k_rem_num: 0,
+        f_rem_num: 0,
         epoch_snap: asset.epoch_short,
         loss_weight: MATCHED_Q,
         b_snap: asset.b_short_num,
@@ -800,6 +1228,78 @@ fn v16_crossed_trade_cannot_spend_same_call_addition_as_preexisting_oi() {
         ),
         value_before
     );
+}
+
+#[test]
+fn v16_resolved_close_detaches_adl_basis_above_effective_oi() {
+    const STORED_Q: u128 = 13 * POS_SCALE;
+    const EFFECTIVE_Q: u128 = 10 * POS_SCALE;
+
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 22);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut account_header);
+        market.deposit_not_atomic(&mut account, 100).unwrap();
+        market.resolve_market_not_atomic(1).unwrap();
+    }
+
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.a_long = ADL_ONE * EFFECTIVE_Q / STORED_Q;
+    asset.oi_eff_long_q = EFFECTIVE_Q;
+    asset.oi_eff_short_q = 0;
+    asset.stored_pos_count_long = 1;
+    asset.loss_weight_sum_long = STORED_Q;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(1);
+
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Long,
+        basis_pos_q: signed_q(STORED_Q),
+        a_basis: ADL_ONE,
+        k_snap: asset.k_long,
+        f_snap: asset.f_long_num,
+        k_rem_num: 0,
+        f_rem_num: 0,
+        epoch_snap: asset.epoch_long,
+        loss_weight: STORED_Q,
+        b_snap: asset.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(1);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+
+    let progress = market
+        .close_resolved_account_not_atomic(&mut account, 0)
+        .expect("terminal close must saturate ADL-reduced effective OI");
+    assert_eq!(progress, ResolvedCloseOutcomeV16::ProgressOnly);
+    assert!(active_bitmap_is_empty(
+        account.header.active_bitmap.map(V16PodU64::get)
+    ));
+    assert_eq!(account.header.capital.get(), 100);
+    let outcome = market
+        .close_resolved_account_not_atomic(&mut account, 0)
+        .expect("the next bounded continuation must pay the detached account");
+    assert_eq!(outcome, ResolvedCloseOutcomeV16::Closed { payout: 100 });
+    assert_eq!(account.header.capital.get(), 0);
+    let asset_after = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(asset_after.oi_eff_long_q, 0);
+    assert_eq!(asset_after.stored_pos_count_long, 0);
+    assert_eq!(asset_after.loss_weight_sum_long, 0);
+    assert_eq!(market.header.vault.get(), 0);
+    assert_eq!(market.header.c_tot.get(), 0);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
 }
 
 #[test]
@@ -856,6 +1356,75 @@ fn v16_batch_trade_applies_multiple_fills_after_inline_refresh() {
     );
     market.validate_shape().unwrap();
     long.validate_with_market(&market.as_view()).unwrap();
+    short.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_resolved_close_detaches_one_active_leg_per_progress_step() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut long_header = account_fixture(2, 203);
+    let mut short_header = account_fixture(2, 204);
+    let requests = [
+        TradeRequestV16 {
+            asset_index: 0,
+            size_q: signed_q(POS_SCALE),
+            exec_price: 100,
+            fee_bps: 0,
+        },
+        TradeRequestV16 {
+            asset_index: 1,
+            size_q: signed_q(POS_SCALE),
+            exec_price: 100,
+            fee_bps: 0,
+        },
+    ];
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market.deposit_not_atomic(&mut long, 1_000).unwrap();
+    market.deposit_not_atomic(&mut short, 1_000).unwrap();
+    market
+        .execute_batch_with_fee_loss_stale_scoped_not_atomic(&mut long, &mut short, &requests)
+        .unwrap();
+    market.resolve_market_not_atomic(2).unwrap();
+
+    assert_eq!(
+        market
+            .close_resolved_account_not_atomic(&mut short, 0)
+            .unwrap(),
+        ResolvedCloseOutcomeV16::ProgressOnly,
+    );
+    assert_eq!(
+        short
+            .header
+            .active_bitmap
+            .iter()
+            .map(|word| word.get().count_ones())
+            .sum::<u32>(),
+        1,
+        "one successful close continuation must detach exactly one active leg",
+    );
+    assert_eq!(short.header.capital.get(), 1_000);
+
+    assert_eq!(
+        market
+            .close_resolved_account_not_atomic(&mut short, 0)
+            .unwrap(),
+        ResolvedCloseOutcomeV16::ProgressOnly,
+    );
+    assert!(active_bitmap_is_empty(
+        short.header.active_bitmap.map(V16PodU64::get)
+    ));
+    assert_eq!(short.header.capital.get(), 1_000);
+
+    assert_eq!(
+        market
+            .close_resolved_account_not_atomic(&mut short, 0)
+            .unwrap(),
+        ResolvedCloseOutcomeV16::Closed { payout: 1_000 },
+    );
+    market.validate_shape().unwrap();
     short.validate_with_market(&market.as_view()).unwrap();
 }
 
@@ -1318,6 +1887,51 @@ fn v16_public_raw_oracle_target_update_is_value_neutral_and_lifecycle_gated() {
 }
 
 #[test]
+fn v16_lagged_oracle_target_rejects_zero_delta_slot_consumption() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut long_header = account_fixture(1, 221);
+    let mut short_header = account_fixture(1, 222);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market.deposit_not_atomic(&mut long, 1_000).unwrap();
+        market.deposit_not_atomic(&mut short, 1_000).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: signed_q(POS_SCALE),
+                    exec_price: 100,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+        market
+            .set_asset_raw_oracle_target_not_atomic(0, 200)
+            .unwrap();
+    }
+
+    let header_before = header;
+    let slot_before = markets[0];
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let result = market.accrue_asset_to_not_atomic(0, 2, 100, 0, true);
+
+    assert_eq!(result, Err(V16Error::NonProgress));
+    assert_eq!(market.header, &header_before);
+    assert_eq!(market.markets[0], slot_before);
+
+    let progressed = market
+        .accrue_asset_to_not_atomic(0, 2, 101, 0, true)
+        .unwrap();
+    assert_eq!(progressed.dt, 1);
+    assert!(progressed.price_move_active);
+    assert_eq!(market.markets[0].engine.asset.effective_price.get(), 101);
+}
+
+#[test]
 fn v16_public_empty_asset_oracle_anchor_reset_rejects_any_group_position_state() {
     let (mut header, mut markets) = market_fixture(2, 100);
     let mut other_asset = markets[1].engine.asset.try_to_runtime().unwrap();
@@ -1395,6 +2009,51 @@ fn v16_public_force_asset_recovery_freezes_mark_and_is_idempotent() {
 }
 
 #[test]
+fn v16_price_moved_empty_asset_remains_retireable() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        market
+            .set_asset_raw_oracle_target_not_atomic(1, 101)
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(1, 3, 101, 0, false)
+            .unwrap();
+    }
+
+    let accrued = markets[1].engine.asset.try_to_runtime().unwrap();
+    assert_ne!(accrued.k_long, 0, "control: empty-asset accrual moved K");
+    assert_ne!(accrued.k_short, 0, "control: empty-asset accrual moved K");
+    assert_eq!(accrued.oi_eff_long_q, 0);
+    assert_eq!(accrued.oi_eff_short_q, 0);
+    assert_eq!(accrued.stored_pos_count_long, 0);
+    assert_eq!(accrued.stored_pos_count_short, 0);
+    assert_eq!(accrued.stale_account_count_long, 0);
+    assert_eq!(accrued.stale_account_count_short, 0);
+    assert_eq!(accrued.pending_obligation_count_long, 0);
+    assert_eq!(accrued.pending_obligation_count_short, 0);
+    assert_eq!(accrued.loss_weight_sum_long, 0);
+    assert_eq!(accrued.loss_weight_sum_short, 0);
+
+    let old_market_id = accrued.market_id;
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    market.retire_empty_asset_not_atomic(1, 4).unwrap();
+    market
+        .restart_empty_asset_preserving_insurance_budget_not_atomic(1, 102, 5)
+        .unwrap();
+    let restarted = market.markets[1].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(restarted.lifecycle, AssetLifecycleV16::Active);
+    assert_ne!(restarted.market_id, old_market_id);
+    assert_eq!(restarted.raw_oracle_target_price, 102);
+    assert_eq!(restarted.effective_price, 102);
+    assert_eq!(restarted.k_long, 0);
+    assert_eq!(restarted.k_short, 0);
+    assert_eq!(restarted.k_epoch_start_long, 0);
+    assert_eq!(restarted.k_epoch_start_short, 0);
+    market.validate_shape().unwrap();
+}
+
+#[test]
 fn v16_restart_empty_asset_preserves_domain_budget_for_nonzero_asset() {
     let (mut header, mut markets) = market_fixture(2, 100);
     {
@@ -1408,6 +2067,9 @@ fn v16_restart_empty_asset_preserves_domain_budget_for_nonzero_asset() {
     let vault_before = header.vault.get();
     let c_tot_before = header.c_tot.get();
     let insurance_before = header.insurance.get();
+    header.bankruptcy_hlock_active = 2;
+    header.bankruptcy_hlock_asset_count = V16PodU32::new(1);
+    markets[1].engine.bankruptcy_hlock_active = 1;
 
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
     market
@@ -1426,6 +2088,148 @@ fn v16_restart_empty_asset_preserves_domain_budget_for_nonzero_asset() {
         market.header.insurance_domain_budget_remaining_total.get(),
         budget_total_before
     );
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), c_tot_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
+    assert_eq!(market.header.bankruptcy_hlock_active, 0);
+    assert_eq!(market.header.bankruptcy_hlock_asset_count.get(), 0);
+    assert_eq!(market.markets[1].engine.bankruptcy_hlock_active, 0);
+    market.validate_shape().unwrap();
+}
+
+#[test]
+fn v16_funded_then_flat_asset_remains_retireable() {
+    let (mut header, mut markets) = funding_market_fixture(FUNDING_COUNTER_PRICE);
+    let mut long_header = account_fixture(1, 124);
+    let mut short_header = account_fixture(1, 125);
+
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market.deposit_not_atomic(&mut long, 1_000).unwrap();
+        market.deposit_not_atomic(&mut short, 1_000).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: 1,
+                    exec_price: FUNDING_COUNTER_PRICE,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(0, 2, FUNDING_COUNTER_PRICE, FUNDING_COUNTER_RATE_E9, true)
+            .unwrap();
+        market.full_account_refresh_not_atomic(&mut long).unwrap();
+        market.full_account_refresh_not_atomic(&mut short).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: -1,
+                    exec_price: FUNDING_COUNTER_PRICE,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+    }
+
+    let backing_amounts = [
+        markets[0]
+            .engine
+            .backing_long
+            .try_to_runtime()
+            .unwrap()
+            .fresh_unliened_backing_num,
+        markets[0]
+            .engine
+            .backing_short
+            .try_to_runtime()
+            .unwrap()
+            .fresh_unliened_backing_num,
+    ];
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    for (domain, backing_num) in backing_amounts.into_iter().enumerate() {
+        assert_eq!(backing_num % BOUND_SCALE, 0);
+        let amount = backing_num / BOUND_SCALE;
+        if amount != 0 {
+            market
+                .withdraw_fresh_counterparty_backing_not_atomic(domain, amount)
+                .unwrap();
+        }
+    }
+
+    let flat = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(flat.k_long, 0);
+    assert_eq!(flat.k_short, 0);
+    assert_ne!(flat.f_long_num, 0, "control: funding history advanced");
+    assert_ne!(flat.f_short_num, 0, "control: funding history advanced");
+    assert_eq!(flat.oi_eff_long_q, 0);
+    assert_eq!(flat.oi_eff_short_q, 0);
+    assert_eq!(flat.stored_pos_count_long, 0);
+    assert_eq!(flat.stored_pos_count_short, 0);
+    assert_eq!(flat.stale_account_count_long, 0);
+    assert_eq!(flat.stale_account_count_short, 0);
+    assert_eq!(flat.pending_obligation_count_long, 0);
+    assert_eq!(flat.pending_obligation_count_short, 0);
+    assert_eq!(flat.loss_weight_sum_long, 0);
+    assert_eq!(flat.loss_weight_sum_short, 0);
+    let old_market_id = flat.market_id;
+
+    market.retire_empty_asset_not_atomic(0, 3).unwrap();
+    market
+        .restart_empty_asset_preserving_insurance_budget_not_atomic(0, FUNDING_COUNTER_PRICE, 4)
+        .unwrap();
+    let restarted = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_ne!(restarted.market_id, old_market_id);
+    assert_eq!(restarted.f_long_num, 0);
+    assert_eq!(restarted.f_short_num, 0);
+    market.validate_shape().unwrap();
+}
+
+#[test]
+fn v16_retire_and_restart_empty_asset_after_discharged_social_loss_history() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let old_market_id = markets[0].engine.asset.market_id.get();
+    let vault_before = header.vault.get();
+    let c_tot_before = header.c_tot.get();
+    let insurance_before = header.insurance.get();
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.lifecycle = AssetLifecycleV16::Recovery;
+    asset.b_long_num = 11;
+    asset.b_short_num = 13;
+    asset.b_epoch_start_long_num = 17;
+    asset.b_epoch_start_short_num = 19;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    market.retire_empty_asset_not_atomic(0, 3).unwrap();
+    let retired = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(retired.lifecycle, AssetLifecycleV16::Retired);
+    assert_eq!(retired.b_long_num, 11);
+    assert_eq!(retired.b_short_num, 13);
+    assert_eq!(retired.b_epoch_start_long_num, 17);
+    assert_eq!(retired.b_epoch_start_short_num, 19);
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), c_tot_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
+
+    market
+        .restart_empty_asset_preserving_insurance_budget_not_atomic(0, 100, 4)
+        .unwrap();
+    let restarted = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(restarted.lifecycle, AssetLifecycleV16::Active);
+    assert_ne!(restarted.market_id, old_market_id);
+    assert_eq!(restarted.b_long_num, 0);
+    assert_eq!(restarted.b_short_num, 0);
+    assert_eq!(restarted.b_epoch_start_long_num, 0);
+    assert_eq!(restarted.b_epoch_start_short_num, 0);
     assert_eq!(market.header.vault.get(), vault_before);
     assert_eq!(market.header.c_tot.get(), c_tot_before);
     assert_eq!(market.header.insurance.get(), insurance_before);
@@ -1601,6 +2405,8 @@ fn v16_reused_market_slot_rejects_old_market_id_leg() {
         a_basis: ADL_ONE,
         k_snap: 0,
         f_snap: 0,
+        k_rem_num: 0,
+        f_rem_num: 0,
         epoch_snap: 0,
         loss_weight: POS_SCALE,
         b_snap: 0,
@@ -2108,6 +2914,8 @@ fn v16_public_liquidation_on_unfunded_domain_cannot_drain_shared_insurance() {
         a_basis: ADL_ONE,
         k_snap: asset.k_long,
         f_snap: asset.f_long_num,
+        k_rem_num: 0,
+        f_rem_num: 0,
         epoch_snap: asset.epoch_long,
         loss_weight: POS_SCALE,
         b_snap: asset.b_long_num,
@@ -2176,6 +2984,8 @@ fn v16_liquidation_engine_selects_full_close_and_allows_dust_min_fee() {
             a_basis: ADL_ONE,
             k_snap: asset.k_long,
             f_snap: asset.f_long_num,
+            k_rem_num: 0,
+            f_rem_num: 0,
             epoch_snap: asset.epoch_long,
             loss_weight: POSITION_Q,
             b_snap: asset.b_long_num,
@@ -2258,6 +3068,8 @@ fn v16_liquidation_engine_selects_healthy_partial_before_margin_floor() {
         a_basis: ADL_ONE,
         k_snap: asset.k_long,
         f_snap: asset.f_long_num,
+        k_rem_num: 0,
+        f_rem_num: 0,
         epoch_snap: asset.epoch_long,
         loss_weight: POSITION_Q,
         b_snap: asset.b_long_num,
@@ -2333,6 +3145,8 @@ fn v16_permissionless_liquidation_progresses_when_unrelated_asset_is_loss_stale(
         a_basis: ADL_ONE,
         k_snap: asset0.k_long,
         f_snap: asset0.f_long_num,
+        k_rem_num: 0,
+        f_rem_num: 0,
         epoch_snap: asset0.epoch_long,
         loss_weight: POS_SCALE,
         b_snap: asset0.b_long_num,
@@ -2626,6 +3440,287 @@ fn v16_risk_increasing_trade_creates_source_credit_lien_for_im() {
 }
 
 #[test]
+fn v16_live_mark_reversal_unwinds_source_lien_before_claim_burn() {
+    const OPEN_Q: u128 = 1_000 * POS_SCALE;
+    const INCREASE_Q: u128 = 50 * POS_SCALE;
+    let (mut header, mut markets) = market_fixture(1, 100);
+    header.config.maintenance_margin_bps = V16PodU64::new(1_000);
+    header.config.initial_margin_bps = V16PodU64::new(5_000);
+    header.config.max_price_move_bps_per_slot = V16PodU64::new(500);
+    header.config.max_accrual_dt_slots = V16PodU64::new(1);
+    header.config.min_funding_lifetime_slots = V16PodU64::new(1);
+    let mut long_header = account_fixture(1, 10);
+    let mut short_header = account_fixture(1, 11);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market
+        .deposit_fresh_counterparty_backing_not_atomic(1, 100_000, 100)
+        .unwrap();
+    market.deposit_not_atomic(&mut long, 52_501).unwrap();
+    market.deposit_not_atomic(&mut short, 1_000_000).unwrap();
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: signed_q(OPEN_Q),
+                exec_price: 100,
+                fee_bps: 0,
+            },
+        )
+        .unwrap();
+
+    market
+        .set_asset_raw_oracle_target_not_atomic(0, 105)
+        .unwrap();
+    market
+        .accrue_asset_to_not_atomic(0, 2, 105, 0, true)
+        .unwrap();
+    market.full_account_refresh_not_atomic(&mut short).unwrap();
+    market.full_account_refresh_not_atomic(&mut long).unwrap();
+    assert_eq!(long.header.pnl.get(), 5_000);
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: signed_q(INCREASE_Q),
+                exec_price: 105,
+                fee_bps: 0,
+            },
+        )
+        .unwrap();
+    let lien_before = long.header.source_domains[0];
+    assert_eq!(long.header.pnl.get(), 5_000);
+    assert!(lien_before.source_claim_liened_num.get() > 0);
+    assert!(lien_before.source_lien_counterparty_backing_num.get() > 0);
+    let capital_before_reversal = long.header.capital.get();
+    let lien_effective = lien_before.source_lien_effective_reserved.get();
+    let backing_before_reversal = market.markets[0]
+        .engine
+        .backing_short
+        .try_to_runtime()
+        .unwrap();
+
+    market
+        .set_asset_raw_oracle_target_not_atomic(0, 100)
+        .unwrap();
+    market
+        .accrue_asset_to_not_atomic(0, 3, 100, 0, true)
+        .unwrap();
+    market.full_account_refresh_not_atomic(&mut short).unwrap();
+    let cert = market
+        .full_account_refresh_not_atomic(&mut long)
+        .expect("a mark reversal must settle even when the prior positive claim backed IM");
+
+    let backing_after_reversal = market.markets[0]
+        .engine
+        .backing_short
+        .try_to_runtime()
+        .unwrap();
+    let unliened_support_consumed = 5_000 - lien_effective;
+    let principal_loss = 5_250 - unliened_support_consumed;
+    assert_eq!(long.header.pnl.get(), 0);
+    assert_eq!(
+        long.header.capital.get(),
+        capital_before_reversal - principal_loss
+    );
+    assert_eq!(long.header.source_domains[0], Default::default());
+    assert_eq!(
+        backing_after_reversal.fresh_unliened_backing_num,
+        backing_before_reversal
+            .fresh_unliened_backing_num
+            .checked_sub(unliened_support_consumed * BOUND_SCALE)
+            .unwrap()
+            .checked_add(lien_before.source_lien_counterparty_backing_num.get())
+            .unwrap(),
+        "the still-liened backing is unpledged rather than consumed"
+    );
+    assert_eq!(backing_after_reversal.valid_liened_backing_num, 0);
+    assert_eq!(
+        backing_after_reversal.consumed_liened_backing_num,
+        backing_before_reversal.consumed_liened_backing_num
+            + unliened_support_consumed * BOUND_SCALE,
+        "only realizable unliened support offsets the reversal loss"
+    );
+    assert!(cert.valid);
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+    short.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_expired_counterparty_source_lien_is_impaired_before_health_read() {
+    const OPEN_Q: u128 = 1_000 * POS_SCALE;
+    const INCREASE_Q: u128 = 50 * POS_SCALE;
+    let (mut header, mut markets) = market_fixture(1, 100);
+    header.config.maintenance_margin_bps = V16PodU64::new(1_000);
+    header.config.initial_margin_bps = V16PodU64::new(5_000);
+    header.config.max_price_move_bps_per_slot = V16PodU64::new(500);
+    header.config.max_accrual_dt_slots = V16PodU64::new(1);
+    header.config.min_funding_lifetime_slots = V16PodU64::new(1);
+    header.config.backing_fee_base_rate_e9_per_slot = V16PodU64::new(1_000_000_000);
+    let mut long_header = account_fixture(1, 10);
+    let mut short_header = account_fixture(1, 11);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market
+        .deposit_fresh_counterparty_backing_not_atomic(1, 100_000, 3)
+        .unwrap();
+    market.deposit_not_atomic(&mut long, 52_501).unwrap();
+    market.deposit_not_atomic(&mut short, 1_000_000).unwrap();
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: signed_q(OPEN_Q),
+                exec_price: 100,
+                fee_bps: 0,
+            },
+        )
+        .unwrap();
+
+    market
+        .set_asset_raw_oracle_target_not_atomic(0, 105)
+        .unwrap();
+    market
+        .accrue_asset_to_not_atomic(0, 2, 105, 0, true)
+        .unwrap();
+    market.full_account_refresh_not_atomic(&mut short).unwrap();
+    market.full_account_refresh_not_atomic(&mut long).unwrap();
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: signed_q(INCREASE_Q),
+                exec_price: 105,
+                fee_bps: 0,
+            },
+        )
+        .unwrap();
+    let lien_before = long.header.source_domains[0];
+    assert!(lien_before.source_claim_counterparty_liened_num.get() > 0);
+    assert!(lien_before.source_lien_counterparty_backing_num.get() > 0);
+
+    market
+        .accrue_asset_to_not_atomic(0, 3, 105, 0, true)
+        .unwrap();
+    market
+        .accrue_asset_to_not_atomic(0, 4, 105, 0, true)
+        .unwrap();
+    market.full_account_refresh_not_atomic(&mut short).unwrap();
+    let summary = market.build_actionable_summary(&long.as_view()).unwrap();
+    assert!(
+        summary.stale,
+        "bucket expiry alone must make a current certificate actionable"
+    );
+    let observations = [AutoCrankObservationV16 {
+        asset_index: 0,
+        effective_price: 105,
+        funding_rate_e9: 0,
+    }];
+    let crank = market
+        .permissionless_auto_crank_not_atomic(
+            &mut long,
+            AutoCrankWorkV16 {
+                now_slot: 4,
+                observations: &observations,
+                observations_preaccrued: false,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("an expired source lien must impair and remain progressable");
+    assert_eq!(
+        crank.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    );
+    assert!(matches!(
+        crank.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::SourceBackingExpired {
+            domain: 1
+        })
+    ));
+    assert!(
+        !long.header.health_cert.try_to_runtime().unwrap().valid,
+        "the bounded expiry step must not certify before reading the impaired state"
+    );
+
+    let source = long.header.source_domains[0];
+    let bucket = market.markets[0]
+        .engine
+        .backing_short
+        .try_to_runtime()
+        .unwrap();
+    let domain = market.markets[0]
+        .engine
+        .source_credit_short
+        .try_to_runtime()
+        .unwrap();
+    assert_eq!(bucket.status, BackingBucketStatusV16::Impaired);
+    assert_eq!(
+        bucket.utilization_fee_earnings,
+        lien_before.source_lien_effective_reserved.get(),
+        "utilization rent must stop at expiry rather than charging through reconciliation"
+    );
+    assert_eq!(bucket.valid_liened_backing_num, 0);
+    assert_eq!(domain.valid_liened_backing_num, 0);
+    assert_eq!(domain.fresh_reserved_backing_num, 0);
+    assert_eq!(domain.credit_rate_num, 0);
+    assert_eq!(source.source_claim_liened_num.get(), 0);
+    assert_eq!(source.source_claim_counterparty_liened_num.get(), 0);
+    assert_eq!(source.source_lien_effective_reserved.get(), 0);
+    assert_eq!(source.source_lien_counterparty_backing_num.get(), 0);
+    assert_eq!(
+        source.source_claim_impaired_num.get(),
+        lien_before.source_claim_counterparty_liened_num.get()
+    );
+    assert_eq!(
+        source.source_lien_impaired_effective_reserved.get(),
+        lien_before.source_lien_effective_reserved.get()
+    );
+    assert_eq!(
+        source
+            .source_lien_impaired_capital_at_risk_fee_revenue
+            .get(),
+        lien_before.source_lien_effective_reserved.get()
+    );
+
+    let refresh = market
+        .permissionless_auto_crank_not_atomic(
+            &mut long,
+            AutoCrankWorkV16 {
+                now_slot: 4,
+                observations: &observations,
+                observations_preaccrued: false,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the next bounded crank must certify from the impaired state");
+    assert!(matches!(
+        refresh.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+    ));
+    let cert = long.header.health_cert.try_to_runtime().unwrap();
+    assert!(cert.valid);
+    assert_eq!(cert.certified_equity, long.header.capital.get() as i128);
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+    short.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_residual_reward_credit_uses_real_principal_not_notional() {
     let (mut header, mut markets) = market_fixture(1, 1_000);
     header.config.initial_margin_bps = V16PodU64::new(500);
@@ -2791,6 +3886,93 @@ fn v16_source_backed_conversion_clears_sparse_source_domain_slot() {
     );
     account.validate_with_market(&market.as_view()).unwrap();
     market.validate_shape().unwrap();
+}
+
+fn source_backed_conversion_hlock_fixture() -> (
+    MarketGroupV16HeaderAccount,
+    Vec<Market<u64>>,
+    PortfolioAccountV16Account,
+    u128,
+) {
+    let (mut header, mut markets) = market_fixture(2, 1);
+    let mut account = account_fixture(2, 118);
+    let claim = 20u128;
+    let claim_num = claim * BOUND_SCALE;
+    header.vault = V16PodU128::new(claim);
+    header.pnl_pos_tot = V16PodU128::new(claim);
+    header.pnl_pos_bound_tot_num = V16PodU128::new(claim_num);
+    header.pnl_pos_bound_tot = V16PodU128::new(claim);
+    header.source_claim_bound_total_num = V16PodU128::new(claim_num);
+    header.source_fresh_backing_total_num = V16PodU128::new(claim_num);
+    account.pnl = V16PodI128::new(claim as i128);
+    account.source_domains[0].domain = V16PodU32::new(0);
+    account.source_domains[0].source_claim_market_id = V16PodU64::new(1);
+    account.source_domains[0].source_claim_bound_num = V16PodU128::new(claim_num);
+    markets[0].engine.source_credit_long =
+        SourceCreditStateV16Account::from_runtime(&SourceCreditStateV16 {
+            positive_claim_bound_num: claim_num,
+            exact_positive_claim_num: claim_num,
+            fresh_reserved_backing_num: claim_num,
+            credit_rate_num: CREDIT_RATE_SCALE,
+            ..SourceCreditStateV16::EMPTY
+        });
+    markets[0].engine.backing_long = BackingBucketV16Account::from_runtime(&BackingBucketV16 {
+        market_id: 1,
+        fresh_unliened_backing_num: claim_num,
+        expiry_slot: 100,
+        status: BackingBucketStatusV16::Fresh,
+        ..BackingBucketV16::EMPTY
+    });
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account_view = PortfolioV16ViewMut::new(&mut account);
+        market
+            .full_account_refresh_not_atomic(&mut account_view)
+            .unwrap();
+    }
+    (header, markets, account, claim)
+}
+
+#[test]
+fn v16_unrelated_bankruptcy_hlock_does_not_freeze_source_backed_conversion() {
+    let (mut header, mut markets, mut account, claim) = source_backed_conversion_hlock_fixture();
+    header.bankruptcy_hlock_active = 2;
+    header.bankruptcy_hlock_asset_count = V16PodU32::new(1);
+    markets[1].engine.bankruptcy_hlock_active = 1;
+    markets[0].engine.asset.mode_long = SideModeV16::DrainOnly as u8;
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account_view = PortfolioV16ViewMut::new(&mut account);
+    let converted = market
+        .convert_released_pnl_to_capital_not_atomic(&mut account_view)
+        .expect("asset-1 bankruptcy cannot freeze asset-0 source-backed PnL");
+    assert_eq!(converted, claim);
+    assert_eq!(account_view.header.capital.get(), claim);
+    assert_eq!(account_view.header.pnl.get(), 0);
+    market.validate_shape().unwrap();
+    account_view
+        .validate_with_market(&market.as_view())
+        .unwrap();
+}
+
+#[test]
+fn v16_related_or_unattributed_bankruptcy_hlock_still_blocks_conversion() {
+    for related in [false, true] {
+        let (mut header, mut markets, mut account, _) = source_backed_conversion_hlock_fixture();
+        header.bankruptcy_hlock_active = if related { 2 } else { 1 };
+        if related {
+            header.bankruptcy_hlock_asset_count = V16PodU32::new(1);
+            markets[0].engine.bankruptcy_hlock_active = 1;
+        }
+
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account_view = PortfolioV16ViewMut::new(&mut account);
+        assert_eq!(
+            market.convert_released_pnl_to_capital_not_atomic(&mut account_view),
+            Err(V16Error::LockActive),
+            "same-asset and unattributed hlocks remain conservative",
+        );
+    }
 }
 
 #[test]
@@ -2997,6 +4179,7 @@ fn v16_auto_crank_classifies_fresh_account_stale_then_refreshes_to_clean() {
     let work = AutoCrankWorkV16 {
         now_slot: 5,
         observations: &obs,
+        observations_preaccrued: false,
         resolved_close_fee_rate_per_slot: 0,
     };
 
@@ -3028,6 +4211,143 @@ fn v16_auto_crank_classifies_fresh_account_stale_then_refreshes_to_clean() {
 
     market.validate_shape().unwrap();
     account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_auto_crank_preaccrued_observation_does_not_apply_a_second_segment() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut long_header = account_fixture(1, 22);
+    let mut short_header = account_fixture(1, 23);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market.deposit_not_atomic(&mut long, 1_000).unwrap();
+        market.deposit_not_atomic(&mut short, 1_000).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: signed_q(POS_SCALE),
+                    exec_price: 100,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+        market
+            .set_asset_raw_oracle_target_not_atomic(0, 300)
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(0, 2, 200, 0, true)
+            .unwrap();
+    }
+
+    let asset_before = markets[0].engine.asset;
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let observations = [AutoCrankObservationV16 {
+        asset_index: 0,
+        effective_price: 200,
+        funding_rate_e9: 0,
+    }];
+    let result = market
+        .permissionless_auto_crank_not_atomic(
+            &mut long,
+            AutoCrankWorkV16 {
+                now_slot: 2,
+                observations: &observations,
+                observations_preaccrued: true,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .unwrap();
+
+    assert!(matches!(
+        result.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    ));
+    assert_eq!(
+        result.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+    );
+    assert_eq!(market.markets[0].engine.asset, asset_before);
+    assert!(
+        !market
+            .build_actionable_summary(&long.as_view())
+            .unwrap()
+            .stale
+    );
+}
+
+#[test]
+fn v16_auto_crank_missing_selected_observation_refreshes_without_accruing_asset() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut account_header = account_fixture(2, 24);
+    let mut counterparty_header = account_fixture(2, 25);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut account_header);
+        let mut counterparty = PortfolioV16ViewMut::new(&mut counterparty_header);
+        open_one_lot_pair(&mut market, &mut account, &mut counterparty);
+        market
+            .full_account_refresh_not_atomic(&mut account)
+            .unwrap();
+
+        // Move an unrelated asset to stale the account certificate. The selected
+        // asset remains asset 0, for which this crank carries no observation.
+        market
+            .set_asset_raw_oracle_target_not_atomic(1, 200)
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(1, 2, 200, 0, false)
+            .unwrap();
+        assert!(
+            market
+                .build_actionable_summary(&account.as_view())
+                .unwrap()
+                .stale
+        );
+    }
+
+    let selected_asset_before = markets[0].engine.asset;
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let result = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 2,
+                observations: &[],
+                observations_preaccrued: false,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("committed-state refresh must remain permissionless");
+
+    assert_eq!(
+        result.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    );
+    assert_eq!(
+        result.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+    );
+    assert_eq!(
+        market.markets[0].engine.asset, selected_asset_before,
+        "an absent observation may refresh the account but must not consume the asset's accrual slot"
+    );
+    assert!(
+        !market
+            .build_actionable_summary(&account.as_view())
+            .unwrap()
+            .stale
+    );
 }
 
 // ROADMAP 3C step 4 / NB2 finite-multi-step liveness via the self-classifying
@@ -3076,6 +4396,8 @@ fn v16_auto_crank_drives_stale_underwater_account_to_derisked_fixed_point() {
         a_basis: ADL_ONE,
         k_snap: asset0.k_long,
         f_snap: asset0.f_long_num,
+        k_rem_num: 0,
+        f_rem_num: 0,
         epoch_snap: asset0.epoch_long,
         loss_weight: POS_SCALE,
         b_snap: asset0.b_long_num,
@@ -3097,6 +4419,7 @@ fn v16_auto_crank_drives_stale_underwater_account_to_derisked_fixed_point() {
     let work = AutoCrankWorkV16 {
         now_slot: 10,
         observations: &obs,
+        observations_preaccrued: false,
         resolved_close_fee_rate_per_slot: 0,
     };
 
@@ -3153,6 +4476,711 @@ fn v16_auto_crank_drives_stale_underwater_account_to_derisked_fixed_point() {
 }
 
 #[test]
+fn v16_auto_crank_settles_each_stale_kf_tail_leg_before_certifying() {
+    const PRICE: u64 = 1_000_000;
+    let (mut header, mut markets) = market_fixture(14, PRICE);
+    let mut long_header = account_fixture(14, 211);
+    let mut short_header = account_fixture(14, 212);
+    let requests = [
+        TradeRequestV16 {
+            asset_index: 0,
+            size_q: signed_q(POS_SCALE),
+            exec_price: PRICE,
+            fee_bps: 0,
+        },
+        TradeRequestV16 {
+            asset_index: 1,
+            size_q: signed_q(POS_SCALE),
+            exec_price: PRICE,
+            fee_bps: 0,
+        },
+        TradeRequestV16 {
+            asset_index: 2,
+            size_q: signed_q(POS_SCALE),
+            exec_price: PRICE,
+            fee_bps: 0,
+        },
+    ];
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market.deposit_not_atomic(&mut long, 10_000_000).unwrap();
+    market.deposit_not_atomic(&mut short, 10_000_000).unwrap();
+    market
+        .execute_batch_with_fee_loss_stale_scoped_not_atomic(&mut long, &mut short, &requests)
+        .unwrap();
+    for domain in 0..11 {
+        market
+            .add_account_source_positive_pnl_not_atomic(&mut long, domain, 1)
+            .unwrap();
+    }
+    market
+        .accrue_asset_to_not_atomic(0, 20, 1_001_000, 0, true)
+        .unwrap();
+    market
+        .accrue_asset_to_not_atomic(1, 20, 1_001_000, 0, true)
+        .unwrap();
+    market
+        .accrue_asset_to_not_atomic(2, 20, 1_001_000, 0, true)
+        .unwrap();
+    assert_eq!(
+        long.header
+            .source_domains
+            .iter()
+            .filter(|source| source.is_occupied())
+            .count(),
+        11
+    );
+    assert_ne!(
+        long.header.legs[0].try_to_runtime().unwrap().k_snap,
+        market.markets[0]
+            .engine
+            .asset
+            .try_to_runtime()
+            .unwrap()
+            .k_long,
+    );
+
+    let work = AutoCrankWorkV16 {
+        now_slot: 20,
+        observations: &[],
+        observations_preaccrued: false,
+        resolved_close_fee_rate_per_slot: 0,
+    };
+    let first = market
+        .permissionless_auto_crank_not_atomic(&mut long, work)
+        .unwrap();
+    assert_eq!(
+        first.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountLegSettled {
+            asset_index: 0
+        })
+    );
+    assert!(!long.header.health_cert.try_to_runtime().unwrap().valid);
+    assert_eq!(
+        long.header.legs[0].try_to_runtime().unwrap().k_snap,
+        market.markets[0]
+            .engine
+            .asset
+            .try_to_runtime()
+            .unwrap()
+            .k_long,
+    );
+    assert_ne!(
+        long.header.legs[1].try_to_runtime().unwrap().k_snap,
+        market.markets[1]
+            .engine
+            .asset
+            .try_to_runtime()
+            .unwrap()
+            .k_long,
+    );
+
+    let second = market
+        .permissionless_auto_crank_not_atomic(&mut long, work)
+        .unwrap();
+    assert_eq!(
+        second.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountLegSettled {
+            asset_index: 1
+        })
+    );
+    assert!(!long.header.health_cert.try_to_runtime().unwrap().valid);
+
+    let third = market
+        .permissionless_auto_crank_not_atomic(&mut long, work)
+        .unwrap();
+    assert_eq!(
+        third.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountLegSettled {
+            asset_index: 2
+        })
+    );
+    assert!(!long.header.health_cert.try_to_runtime().unwrap().valid);
+
+    let certified = market
+        .permissionless_auto_crank_not_atomic(&mut long, work)
+        .unwrap();
+    assert_eq!(
+        certified.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+    );
+    assert!(long.header.health_cert.try_to_runtime().unwrap().valid);
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut account_header = account_fixture(2, 22);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut account_header);
+        market.deposit_not_atomic(&mut account, 100).unwrap();
+        market
+            .deposit_fresh_counterparty_backing_not_atomic(1, 40, 5)
+            .unwrap();
+        market
+            .deposit_fresh_counterparty_backing_not_atomic(3, 40, 5)
+            .unwrap();
+        market
+            .add_account_source_positive_pnl_not_atomic(&mut account, 1, 40)
+            .unwrap();
+        market
+            .add_account_source_positive_pnl_not_atomic(&mut account, 3, 40)
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(0, 10, 100, 0, true)
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(1, 10, 100, 0, true)
+            .unwrap();
+    }
+
+    let before = markets[0].engine.backing_short.try_to_runtime().unwrap();
+    assert_eq!(before.status, BackingBucketStatusV16::Fresh);
+    assert_eq!(before.expiry_slot, 5);
+    assert_eq!(
+        markets[1]
+            .engine
+            .backing_short
+            .try_to_runtime()
+            .unwrap()
+            .status,
+        BackingBucketStatusV16::Fresh
+    );
+    assert!(header.current_slot.get() > before.expiry_slot);
+    let vault_before = header.vault.get();
+    let c_tot_before = header.c_tot.get();
+    let insurance_before = header.insurance.get();
+    let earnings_before = header.backing_provider_earnings_total.get();
+    let source_backing_before = header.source_fresh_backing_total_num.get();
+    let risk_epoch_before = header.risk_epoch.get();
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let observations = [AutoCrankObservationV16 {
+        asset_index: 0,
+        effective_price: 100,
+        funding_rate_e9: 0,
+    }];
+    let expiry = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &observations,
+                observations_preaccrued: false,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("Live auto-crank must expire lapsed backing instead of returning Stale");
+
+    assert!(matches!(
+        expiry.selected,
+        AutoCrankPlanV16::RefreshAccount { .. }
+    ));
+    assert_eq!(
+        expiry.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::SourceBackingExpired {
+            domain: 1
+        })
+    );
+    let after = market.markets[0]
+        .engine
+        .backing_short
+        .try_to_runtime()
+        .unwrap();
+    assert_eq!(after.status, BackingBucketStatusV16::Expired);
+    assert_eq!(after.fresh_unliened_backing_num, 0);
+    assert_eq!(
+        market.markets[1]
+            .engine
+            .backing_short
+            .try_to_runtime()
+            .unwrap()
+            .status,
+        BackingBucketStatusV16::Fresh,
+        "one auto-crank expires exactly one source domain"
+    );
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), c_tot_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
+    assert_eq!(
+        market.header.backing_provider_earnings_total.get(),
+        earnings_before
+    );
+    assert_eq!(
+        market.header.source_fresh_backing_total_num.get(),
+        source_backing_before - 40 * BOUND_SCALE
+    );
+    assert_eq!(market.header.risk_epoch.get(), risk_epoch_before + 1);
+    assert_eq!(account.header.capital.get(), 100);
+    assert_eq!(account.header.pnl.get(), 80);
+    assert!(!account.header.health_cert.try_to_runtime().unwrap().valid);
+
+    let second_expiry = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &observations,
+                observations_preaccrued: false,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the next bounded auto-crank must expire the next domain");
+    assert_eq!(
+        second_expiry.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::SourceBackingExpired {
+            domain: 3
+        })
+    );
+    assert_eq!(
+        market.markets[1]
+            .engine
+            .backing_short
+            .try_to_runtime()
+            .unwrap()
+            .status,
+        BackingBucketStatusV16::Expired
+    );
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), c_tot_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
+    assert_eq!(
+        market.header.backing_provider_earnings_total.get(),
+        earnings_before
+    );
+    assert_eq!(market.header.source_fresh_backing_total_num.get(), 0);
+    assert_eq!(market.header.risk_epoch.get(), risk_epoch_before + 2);
+
+    let refresh = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &observations,
+                observations_preaccrued: false,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the final bounded auto-crank must finish account refresh");
+    assert_eq!(
+        refresh.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+    );
+    assert!(account.header.health_cert.try_to_runtime().unwrap().valid);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_auto_crank_skips_recovery_first_leg_for_live_refresh() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut long_header = account_fixture(2, 14);
+    let mut short_header = account_fixture(2, 15);
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+
+    market.deposit_not_atomic(&mut long, 1_000_000).unwrap();
+    market.deposit_not_atomic(&mut short, 1_000_000).unwrap();
+    for asset_index in [1, 0] {
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index,
+                    size_q: POS_SCALE as i128,
+                    exec_price: 100,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+    }
+    assert_eq!(
+        long.header.legs[0].try_to_runtime().unwrap().asset_index,
+        1,
+        "the Recovery asset must occupy the first active leg"
+    );
+
+    market.force_asset_recovery_not_atomic(1, 3).unwrap();
+    let summary = market.build_actionable_summary(&long.as_view()).unwrap();
+    assert!(
+        summary.stale,
+        "the lifecycle epoch bump must stale the account"
+    );
+
+    let result = market
+        .permissionless_auto_crank_not_atomic(
+            &mut long,
+            AutoCrankWorkV16 {
+                now_slot: 3,
+                observations: &[],
+                observations_preaccrued: false,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the auto-crank must select the later live leg");
+    assert_eq!(
+        result.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    );
+    assert!(
+        !market
+            .build_actionable_summary(&long.as_view())
+            .unwrap()
+            .stale,
+        "the selected live refresh must certify the mixed-lifecycle account"
+    );
+    assert_eq!(
+        market.markets[1]
+            .engine
+            .asset
+            .try_to_runtime()
+            .unwrap()
+            .lifecycle,
+        AssetLifecycleV16::Recovery
+    );
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_auto_crank_skips_prior_reset_obligation_for_live_liquidation() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut account_header = account_fixture(2, 23);
+    header.current_slot = V16PodU64::new(10);
+    header.slot_last = V16PodU64::new(10);
+
+    let mut asset0 = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset0.slot_last = 10;
+    asset0.epoch_long = 1;
+    asset0.mode_long = SideModeV16::ResetPending;
+    asset0.oi_eff_long_q = 0;
+    asset0.oi_eff_short_q = 0;
+    asset0.loss_weight_sum_long = 0;
+    asset0.loss_weight_sum_short = 0;
+    asset0.stored_pos_count_long = 1;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset0);
+
+    let mut asset1 = markets[1].engine.asset.try_to_runtime().unwrap();
+    asset1.slot_last = 10;
+    asset1.oi_eff_long_q = 2 * POS_SCALE;
+    asset1.oi_eff_short_q = 2 * POS_SCALE;
+    asset1.loss_weight_sum_long = 2 * POS_SCALE;
+    asset1.loss_weight_sum_short = 2 * POS_SCALE;
+    asset1.stored_pos_count_long = 2;
+    asset1.stored_pos_count_short = 2;
+    markets[1].engine.asset = AssetStateV16Account::from_runtime(&asset1);
+    header.resolved_payout_blocker_count = V16PodU64::new(5);
+
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset0.market_id,
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset0.k_epoch_start_long,
+        f_snap: asset0.f_epoch_start_long_num,
+        k_rem_num: 0,
+        f_rem_num: 0,
+        epoch_snap: 0,
+        loss_weight: POS_SCALE,
+        b_snap: asset0.b_epoch_start_long_num,
+        b_rem: 0,
+        b_epoch_snap: 0,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.legs[1] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 1,
+        market_id: asset1.market_id,
+        side: SideV16::Short,
+        basis_pos_q: -(POS_SCALE as i128),
+        a_basis: ADL_ONE,
+        k_snap: asset1.k_short,
+        f_snap: asset1.f_short_num,
+        k_rem_num: 0,
+        f_rem_num: 0,
+        epoch_snap: asset1.epoch_short,
+        loss_weight: POS_SCALE,
+        b_snap: asset1.b_short_num,
+        b_rem: 0,
+        b_epoch_snap: asset1.epoch_short,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(3);
+    account_header.health_cert = HealthCertV16Account::from_runtime(&HealthCertV16 {
+        certified_equity: 0,
+        certified_initial_req: 2,
+        certified_maintenance_req: 2,
+        certified_liq_deficit: 2,
+        certified_worst_case_loss: 200,
+        cert_oracle_epoch: header.oracle_epoch.get(),
+        cert_funding_epoch: header.funding_epoch.get(),
+        cert_risk_epoch: header.risk_epoch.get(),
+        cert_asset_set_epoch: header.asset_set_epoch.get(),
+        active_bitmap_at_cert: [3],
+        valid: true,
+    });
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let refresh = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &[],
+                observations_preaccrued: false,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the prior-reset first leg must be detached permissionlessly");
+
+    assert_eq!(
+        refresh.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    );
+    assert!(!account.header.legs[0].try_to_runtime().unwrap().active);
+    assert!(account.header.legs[1].try_to_runtime().unwrap().active);
+
+    let liquidation = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &[],
+                observations_preaccrued: false,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the next step must liquidate the remaining live asset");
+    assert_eq!(
+        liquidation.selected,
+        AutoCrankPlanV16::Liquidate { asset_index: 1 }
+    );
+    assert!(!account.header.legs[1].try_to_runtime().unwrap().active);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_adl_reduced_basis_caps_exit_to_effective_oi_then_detaches_residue() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 24);
+
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.oi_eff_long_q = POS_SCALE;
+    asset.oi_eff_short_q = POS_SCALE;
+    asset.a_long = ADL_ONE / 2;
+    asset.loss_weight_sum_long = 2 * POS_SCALE;
+    asset.loss_weight_sum_short = POS_SCALE;
+    asset.stored_pos_count_long = 1;
+    asset.stored_pos_count_short = 1;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(2);
+
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Long,
+        basis_pos_q: (2 * POS_SCALE) as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset.k_long,
+        f_snap: asset.f_long_num,
+        k_rem_num: 0,
+        f_rem_num: 0,
+        epoch_snap: asset.epoch_long,
+        loss_weight: 2 * POS_SCALE,
+        b_snap: asset.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(1);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market.deposit_not_atomic(&mut account, 1_000).unwrap();
+
+    let reduced = market
+        .rebalance_reduce_position_not_atomic(
+            &mut account,
+            RebalanceRequestV16 {
+                asset_index: 0,
+                reduce_q: 2 * POS_SCALE,
+            },
+        )
+        .expect("max-work exit must clamp to matched effective OI");
+    assert_eq!(reduced.reduced_q, POS_SCALE);
+    let residue = account.header.legs[0].try_to_runtime().unwrap();
+    assert_eq!(residue.basis_pos_q, POS_SCALE as i128);
+    let reset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(reset.oi_eff_long_q, 0);
+    assert_eq!(reset.oi_eff_short_q, 0);
+    assert_eq!(reset.mode_long, SideModeV16::ResetPending);
+    assert_eq!(reset.mode_short, SideModeV16::ResetPending);
+
+    let cleanup = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 1,
+                observations: &[],
+                observations_preaccrued: false,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("terminal ADL residue must be permissionlessly detachable");
+    assert_eq!(
+        cleanup.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    );
+    assert!(!account.header.legs[0].try_to_runtime().unwrap().active);
+    assert_eq!(account.header.active_bitmap[0].get(), 0);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_auto_crank_migrates_legacy_normal_adl_residue_into_reset_cleanup() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 25);
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.oi_eff_long_q = 0;
+    asset.oi_eff_short_q = 0;
+    asset.a_long = ADL_ONE / 2;
+    asset.loss_weight_sum_long = POS_SCALE;
+    asset.stored_pos_count_long = 1;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(1);
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset.k_long,
+        f_snap: asset.f_long_num,
+        k_rem_num: 0,
+        f_rem_num: 0,
+        epoch_snap: asset.epoch_long,
+        loss_weight: POS_SCALE,
+        b_snap: asset.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(1);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market.deposit_not_atomic(&mut account, 1_000).unwrap();
+    let result = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 1,
+                observations: &[],
+                observations_preaccrued: false,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("a legacy zero-effective-OI residue must remain crankable after upgrade");
+    assert_eq!(
+        result.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    );
+    assert_eq!(account.header.active_bitmap[0].get(), 0);
+    assert!(!account.header.legs[0].try_to_runtime().unwrap().active);
+    let reset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(reset.mode_long, SideModeV16::ResetPending);
+    assert_eq!(reset.stored_pos_count_long, 0);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_recovery_forfeit_migrates_legacy_normal_adl_residue_before_detach() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 27);
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.oi_eff_long_q = 0;
+    asset.oi_eff_short_q = 0;
+    asset.a_long = ADL_ONE / 2;
+    asset.loss_weight_sum_long = POS_SCALE;
+    asset.stored_pos_count_long = 1;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(1);
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset.k_long,
+        f_snap: asset.f_long_num,
+        k_rem_num: 0,
+        f_rem_num: 0,
+        epoch_snap: asset.epoch_long,
+        loss_weight: POS_SCALE,
+        b_snap: asset.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(1);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market.deposit_not_atomic(&mut account, 1_000).unwrap();
+    market.force_asset_recovery_not_atomic(0, 1).unwrap();
+    let vault_before = market.header.vault.get();
+    let c_tot_before = market.header.c_tot.get();
+    let insurance_before = market.header.insurance.get();
+    let capital_before = account.header.capital.get();
+    let pnl_before = account.header.pnl.get();
+    let outcome = market
+        .forfeit_recovery_leg_not_atomic(&mut account, 0, POS_SCALE)
+        .expect("Recovery forfeit must detach a zero-effective-OI ADL residue");
+    assert!(outcome.detached);
+    assert_eq!(account.header.active_bitmap[0].get(), 0);
+    let reset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(reset.mode_long, SideModeV16::ResetPending);
+    assert_eq!(reset.stored_pos_count_long, 0);
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), c_tot_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
+    assert_eq!(account.header.capital.get(), capital_before);
+    assert_eq!(account.header.pnl.get(), pnl_before);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_auto_crank_liquidates_current_account_without_observation() {
     let (mut header, mut markets) = market_fixture(1, 100);
     let mut account_header = account_fixture(1, 14);
@@ -3183,6 +5211,8 @@ fn v16_auto_crank_liquidates_current_account_without_observation() {
         a_basis: ADL_ONE,
         k_snap: asset.k_long,
         f_snap: asset.f_long_num,
+        k_rem_num: 0,
+        f_rem_num: 0,
         epoch_snap: asset.epoch_long,
         loss_weight: POS_SCALE,
         b_snap: asset.b_long_num,
@@ -3205,8 +5235,9 @@ fn v16_auto_crank_liquidates_current_account_without_observation() {
     );
 
     let work = AutoCrankWorkV16 {
-        now_slot: 10,
+        now_slot: 12,
         observations: &[],
+        observations_preaccrued: false,
         resolved_close_fee_rate_per_slot: 0,
     };
     let result = market
@@ -3226,6 +5257,132 @@ fn v16_auto_crank_liquidates_current_account_without_observation() {
         0,
         "liquidation must close the selected position"
     );
+    assert_eq!(
+        market.markets[0]
+            .engine
+            .asset
+            .try_to_runtime()
+            .unwrap()
+            .slot_last,
+        10,
+        "observation-free liquidation must not consume a later market-accrual slot"
+    );
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_auto_crank_commits_recovery_for_uncovered_cross_margin_liquidation() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut account_header = account_fixture(2, 15);
+    header.current_slot = V16PodU64::new(10);
+    header.slot_last = V16PodU64::new(10);
+    header.vault = V16PodU128::new(50);
+    header.insurance = V16PodU128::new(50);
+    header.negative_pnl_account_count = V16PodU64::new(1);
+
+    for (asset_index, market_slot) in markets.iter_mut().enumerate() {
+        let mut asset = market_slot.engine.asset.try_to_runtime().unwrap();
+        asset.slot_last = 10;
+        asset.oi_eff_long_q = 2 * POS_SCALE;
+        asset.oi_eff_short_q = 2 * POS_SCALE;
+        asset.loss_weight_sum_long = 2 * POS_SCALE;
+        asset.loss_weight_sum_short = 2 * POS_SCALE;
+        asset.stored_pos_count_long = 2;
+        asset.stored_pos_count_short = 2;
+        market_slot.engine.asset = AssetStateV16Account::from_runtime(&asset);
+        account_header.legs[asset_index] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+            active: true,
+            asset_index: asset_index as u32,
+            market_id: asset.market_id,
+            side: SideV16::Long,
+            basis_pos_q: POS_SCALE as i128,
+            a_basis: ADL_ONE,
+            k_snap: asset.k_long,
+            f_snap: asset.f_long_num,
+            k_rem_num: 0,
+            f_rem_num: 0,
+            epoch_snap: asset.epoch_long,
+            loss_weight: POS_SCALE,
+            b_snap: asset.b_long_num,
+            b_rem: 0,
+            b_epoch_snap: asset.epoch_long,
+            b_stale: false,
+            stale: false,
+        });
+    }
+    header.resolved_payout_blocker_count = V16PodU64::new(8);
+    account_header.active_bitmap[0] = V16PodU64::new(0b11);
+    account_header.pnl = V16PodI128::new(-5);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market
+        .full_account_refresh_not_atomic(&mut account)
+        .expect("setup must produce a current cross-margin liquidation cert");
+    let summary = market.build_actionable_summary(&account.as_view()).unwrap();
+    assert!(summary.liquidatable && !summary.recovery_eligible);
+
+    let bitmap_before = account.header.active_bitmap;
+    let pnl_before = account.header.pnl;
+    let capital_before = account.header.capital;
+    let vault_before = market.header.vault;
+    let c_tot_before = market.header.c_tot;
+    let insurance_before = market.header.insurance;
+    let result = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &[],
+                observations_preaccrued: false,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("recovery-required liquidation must commit crank progress");
+
+    assert_eq!(
+        result.selected,
+        AutoCrankPlanV16::Liquidate { asset_index: 0 }
+    );
+    assert_eq!(
+        result.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::RecoveryDeclared(
+            PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+        ))
+    );
+    assert_eq!(market.header.mode, 2);
+    assert_eq!(account.header.active_bitmap, bitmap_before);
+    assert_eq!(account.header.pnl, pnl_before);
+    assert_eq!(account.header.capital, capital_before);
+    assert_eq!(market.header.vault, vault_before);
+    assert_eq!(market.header.c_tot, c_tot_before);
+    assert_eq!(market.header.insurance, insurance_before);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+
+    let recovery_reason_before = market.header.recovery_reason;
+    let finalized = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &[],
+                observations_preaccrued: false,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the next public crank must finalize Recovery into Resolved");
+    assert_eq!(finalized.selected, AutoCrankPlanV16::FinalizeRecovery);
+    assert_eq!(finalized.outcome, AutoCrankOutcomeV16::RecoveryResolved);
+    assert_eq!(market.header.mode, 1);
+    assert_eq!(market.header.recovery_reason, recovery_reason_before);
+    assert_eq!(account.header.active_bitmap, bitmap_before);
+    assert_eq!(account.header.pnl, pnl_before);
+    assert_eq!(account.header.capital, capital_before);
+    assert_eq!(market.header.vault, vault_before);
+    assert_eq!(market.header.c_tot, c_tot_before);
+    assert_eq!(market.header.insurance, insurance_before);
     market.validate_shape().unwrap();
     account.validate_with_market(&market.as_view()).unwrap();
 }
@@ -3281,6 +5438,7 @@ fn v16_auto_crank_declares_recovery_for_expired_live_close() {
     let work = AutoCrankWorkV16 {
         now_slot: 10,
         observations: &[],
+        observations_preaccrued: false,
         resolved_close_fee_rate_per_slot: 0,
     };
     let vault_before = market.header.vault;
@@ -3302,6 +5460,131 @@ fn v16_auto_crank_declares_recovery_for_expired_live_close() {
     // recovery declaration moves no value.
     assert_eq!(market.header.vault, vault_before);
     market.validate_shape().unwrap();
+}
+
+fn asset_local_recovery_close_fixture() -> (
+    MarketGroupV16HeaderAccount,
+    Vec<Market<u64>>,
+    PortfolioAccountV16Account,
+) {
+    let (market_id, _, _) = ids();
+    let mut config = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
+    config.public_b_chunk_atoms = 1;
+    config.max_bankrupt_close_lifetime_slots = 1;
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_id, config, 1, 0).unwrap();
+    let mut markets = vec![Market::new(0, EngineAssetSlotV16Account::default())];
+    header
+        .activate_empty_asset_slot_not_atomic(0, &mut markets[0].engine, 100, 1)
+        .unwrap();
+    let mut long_header = account_fixture(1, 210);
+    let mut short_header = account_fixture(1, 211);
+
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market.deposit_not_atomic(&mut long, 10).unwrap();
+        market.deposit_not_atomic(&mut short, 2).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: signed_q(POS_SCALE / 50),
+                    exec_price: 100,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(0, 2, 200, 0, true)
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(0, 3, 300, 0, true)
+            .unwrap();
+        market.full_account_refresh_not_atomic(&mut short).unwrap();
+        assert_eq!(short.header.capital.get(), 0);
+        assert_eq!(short.header.pnl.get(), -2);
+
+        market.force_asset_recovery_not_atomic(0, 3).unwrap();
+        let first = market
+            .forfeit_recovery_leg_not_atomic(&mut short, 0, 1)
+            .unwrap();
+        assert!(!first.detached);
+        assert_eq!(first.residual_booked, 1);
+        assert_eq!(short.header.pnl.get(), -1);
+        assert_eq!(
+            short
+                .header
+                .close_progress
+                .try_to_runtime()
+                .unwrap()
+                .residual_remaining,
+            1
+        );
+    }
+
+    header.current_slot = V16PodU64::new(10);
+    (header, markets, short_header)
+}
+
+#[test]
+fn v16_auto_crank_advances_expired_asset_local_recovery_close() {
+    // The frozen asset makes slot drift harmless. Even after the ledger deadline,
+    // auto-crank must select the asset-local continuation rather than global Recovery.
+    let (mut header, mut markets, mut short_header) = asset_local_recovery_close_fixture();
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    let summary = market.build_actionable_summary(&short.as_view()).unwrap();
+    assert!(summary.pending_close);
+    assert!(!summary.expired_close);
+
+    let result = market
+        .permissionless_auto_crank_not_atomic(
+            &mut short,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &[],
+                observations_preaccrued: false,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .unwrap();
+    assert_eq!(
+        result.selected,
+        AutoCrankPlanV16::AdvanceRecoveryClose { asset_index: 0 }
+    );
+    assert!(matches!(
+        result.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::ResidualBooked(
+            outcome
+        )) if outcome.booked_loss == 1 && outcome.remaining_after == 0
+    ));
+    assert_eq!(market.header.mode, 0, "market must remain Live");
+    assert_eq!(short.header.pnl.get(), 0);
+    assert_eq!(short.header.active_bitmap[0].get(), 0);
+    market.validate_shape().unwrap();
+    short.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_owner_forfeit_reuses_expired_asset_local_close_ledger() {
+    let (mut header, mut markets, mut short_header) = asset_local_recovery_close_fixture();
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+
+    let result = market
+        .forfeit_recovery_leg_not_atomic(&mut short, 0, 1)
+        .unwrap();
+
+    assert!(result.detached);
+    assert_eq!(result.residual_booked, 1);
+    assert_eq!(market.header.mode, 0);
+    assert_eq!(short.header.pnl.get(), 0);
+    assert_eq!(short.header.active_bitmap[0].get(), 0);
+    market.validate_shape().unwrap();
+    short.validate_with_market(&market.as_view()).unwrap();
 }
 
 // ROADMAP 3C step 4 — resolved_winner classification (selector routes it to
@@ -3372,6 +5655,8 @@ fn v16_auto_crank_settles_b_stale_leg() {
         a_basis: ADL_ONE,
         k_snap: asset0.k_long,
         f_snap: asset0.f_long_num,
+        k_rem_num: 0,
+        f_rem_num: 0,
         epoch_snap: asset0.epoch_long,
         loss_weight: POS_SCALE,
         b_snap: asset0.b_long_num,
@@ -3394,6 +5679,7 @@ fn v16_auto_crank_settles_b_stale_leg() {
     let work = AutoCrankWorkV16 {
         now_slot: 10,
         observations: &[],
+        observations_preaccrued: false,
         resolved_close_fee_rate_per_slot: 0,
     };
     let r = market
@@ -3438,6 +5724,7 @@ fn v16_auto_crank_missing_observation_is_clean_nonprogress_no_mutation() {
     let work = AutoCrankWorkV16 {
         now_slot: 5,
         observations: &[],
+        observations_preaccrued: false,
         resolved_close_fee_rate_per_slot: 0,
     };
     let r = market.permissionless_auto_crank_not_atomic(&mut account, work);
@@ -3448,11 +5735,12 @@ fn v16_auto_crank_missing_observation_is_clean_nonprogress_no_mutation() {
 }
 
 // REALIZABILITY MATRIX — closes the no-DoS dispatch seam that hid the b-stale /
-// committed-state-liquidation stall. The faithful invariant is OBSERVATION-
-// INDEPENDENCE: for a plan that `auto_crank_plan_requires_caller_observation`
-// reports as NOT requiring one, the single public crank must return the SAME
-// outcome whether or not an observation is supplied (the observation is redundant
-// — the plan is realizable from committed state). For the one form that DOES
+// committed-state-liquidation stall. For a plan that
+// `auto_crank_plan_requires_caller_observation` reports as NOT requiring one, the
+// single public crank must select and complete the SAME account action whether or
+// not an observation is supplied. A supplied observation may additionally
+// authorize market accrual, so full post-state equality is intentionally not the
+// invariant. For the one form that DOES
 // require one (RefreshAccount with no active asset), the empty-observation call
 // cleanly stalls (NonProgress) while supplying the observation progresses. This
 // both guards liveness AND ties the pure predicate to the REAL dispatch per class,
@@ -3460,7 +5748,7 @@ fn v16_auto_crank_missing_observation_is_clean_nonprogress_no_mutation() {
 // still return a genuine economic terminal (e.g. RecoveryRequired) — that is fine,
 // because it returns the SAME terminal with or without the observation; the bug
 // was an outcome that DIFFERED on the observation.
-fn assert_observation_independent(
+fn assert_account_action_realizable_without_observation(
     label: &str,
     build: impl Fn() -> (
         MarketGroupV16HeaderAccount,
@@ -3488,6 +5776,7 @@ fn assert_observation_independent(
             AutoCrankWorkV16 {
                 now_slot,
                 observations,
+                observations_preaccrued: false,
                 resolved_close_fee_rate_per_slot: 0,
             },
         )
@@ -3543,7 +5832,7 @@ fn assert_observation_independent(
 fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
     // --- A1 stale with no active asset: fallback refresh has no committed asset
     // to use, so it still needs a caller observation.
-    assert_observation_independent(
+    assert_account_action_realizable_without_observation(
         "stale_empty_account",
         || {
             let (mut header, mut markets) = market_fixture(1, 100);
@@ -3564,7 +5853,7 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
     // --- A1 stale with an active asset: refresh is realizable from committed
     // state. This is the no-DoS case for stale multi-asset accounts whose first
     // active asset does not have a fresh oracle observation available.
-    assert_observation_independent(
+    assert_account_action_realizable_without_observation(
         "stale_active_asset",
         || {
             let (mut header, mut markets) = market_fixture(1, 100);
@@ -3590,8 +5879,19 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
         false,
     );
 
+    // --- A3 pending close on a frozen Recovery asset: one residual chunk is
+    // selected from the ledger and needs no oracle observation.
+    assert_account_action_realizable_without_observation(
+        "asset_local_pending_close",
+        asset_local_recovery_close_fixture,
+        0,
+        10,
+        AutoCrankPlanV16::AdvanceRecoveryClose { asset_index: 0 },
+        false,
+    );
+
     // --- A2 b_stale: SettleBChunk ignores price -> observation REDUNDANT.
-    assert_observation_independent(
+    assert_account_action_realizable_without_observation(
         "b_stale",
         || {
             let (mut header, mut markets) = market_fixture(1, 100);
@@ -3616,6 +5916,8 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
                 a_basis: ADL_ONE,
                 k_snap: asset0.k_long,
                 f_snap: asset0.f_long_num,
+                k_rem_num: 0,
+                f_rem_num: 0,
                 epoch_snap: asset0.epoch_long,
                 loss_weight: POS_SCALE,
                 b_snap: asset0.b_long_num,
@@ -3634,7 +5936,7 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
     );
 
     // --- A5 liquidatable: Liquidate reads the current cert -> observation REDUNDANT.
-    assert_observation_independent(
+    assert_account_action_realizable_without_observation(
         "liquidatable",
         || {
             let (mut header, mut markets) = market_fixture(1, 100);
@@ -3664,6 +5966,8 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
                 a_basis: ADL_ONE,
                 k_snap: asset.k_long,
                 f_snap: asset.f_long_num,
+                k_rem_num: 0,
+                f_rem_num: 0,
                 epoch_snap: asset.epoch_long,
                 loss_weight: POS_SCALE,
                 b_snap: asset.b_long_num,
@@ -3689,7 +5993,7 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
     );
 
     // --- A4 expired_close: DeclareRecovery needs no price -> observation REDUNDANT.
-    assert_observation_independent(
+    assert_account_action_realizable_without_observation(
         "expired_close",
         || {
             use percolator::{CloseProgressLedgerV16, CloseProgressLedgerV16Account};
@@ -3728,10 +6032,29 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
         false,
     );
 
+    // --- A6 market Recovery: the next step is a value-neutral transition to
+    // Resolved and needs no oracle observation.
+    assert_account_action_realizable_without_observation(
+        "finalize_recovery",
+        || {
+            let (mut header, markets) = market_fixture(1, 100);
+            let account_header = account_fixture(1, 205);
+            header.mode = 2;
+            header.recovery_reason = V16OptionalRecoveryReasonAccount::from_runtime(Some(
+                PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+            ));
+            (header, markets, account_header)
+        },
+        0,
+        10,
+        AutoCrankPlanV16::FinalizeRecovery,
+        false,
+    );
+
     // --- A7 resolved_winner: CloseResolved needs no price -> observation REDUNDANT.
     // (Previously only its CLASSIFICATION was tested; the empty-observation DISPATCH
     // — including a legitimate RecoveryRequired terminal — was uncovered.)
-    assert_observation_independent(
+    assert_account_action_realizable_without_observation(
         "resolved_winner",
         || {
             let (mut header, mut markets) = market_fixture(1, 100);


### PR DESCRIPTION
## Summary

This patch hardens several V16 accounting and recovery paths that could depend on crank cadence or leave an account unable to exit.

Main changes:

- persist K/F division remainders so fragmented and delayed settlement produce the same result
- cap unilateral closes using effective matched OI and clean up remaining ADL state through reset epochs
- reconcile source-backing expiry, lien burns, backing release and fee attribution in bounded steps
- scope attributable bankruptcy locks to the affected asset while keeping unknown locks fail-closed
- make auto-crank selection lifecycle-aware and avoid unnecessary or duplicate oracle accrual
- allow maintenance-healthy risk reduction without requiring full initial-margin recovery in one fill
- make resolved-close claims, legs and payouts progress through explicit bounded steps

This should let keepers continue work that does not require a new observation, allow users to reduce risk when below initial margin, and prevent an attributable bankruptcy in one asset from unnecessarily freezing unrelated activity.

## Compatibility note

This changes the V16 account layout by adding per-leg K/F remainder fields and per-asset bankruptcy-lock state. The layout discriminator is bumped from 17 to 18. A migration path for existing V16 accounts is not included in this PR.

## Verification

- `cargo fmt --all -- --check`
- `cargo test` — 160 tests passed
- `cargo test --features fuzz` — 189 tests passed
- `git diff --check`

The patch also adds regression and proof coverage for settlement cadence, ADL cleanup, source-lien accounting, bankruptcy-lock scoping, auto-crank scheduling and resolved-close conservation.

Kani was not rerun locally because `cargo-kani` is not installed in the current environment. The new and changed proof harnesses still need to be run in the Linux/Kani CI environment.