### PR TITLE
[REAL DoS] Reset exact-OI ADL trade residues

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 244 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 247 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -14092,10 +14092,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             short_delta,
             trade_preflight.short_lookup,
         )?;
-        // ADL can leave stored basis larger than effective OI. If a matched trade consumes the
-        // final effective unit while basis remains, enter the existing reset epoch so public crank
-        // can clear the economically exhausted residue instead of leaving a Normal-mode zero-OI leg.
-        self.begin_zero_oi_trade_residue_resets(request.asset_index)?;
         self.transfer_trade_residual_reward_credit(
             long_account,
             short_account,
@@ -14304,6 +14300,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             long_has_source_claims,
             short_has_source_claims,
         )?;
+        // ADL can leave stored basis larger than effective OI. Start resets only after final margin
+        // checks so the reset's risk-epoch advance leaves each affected account certificate stale;
+        // the public auto-crank then selects Refresh and clears the economically exhausted residue.
+        let mut i = 0usize;
+        while i < requests.len() {
+            self.begin_zero_oi_trade_residue_resets(requests[i].asset_index)?;
+            i += 1;
+        }
         Ok(outcome)
     }
 

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -13594,6 +13594,25 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
+    fn begin_zero_oi_trade_residue_resets(&mut self, asset_index: usize) -> V16Result<()> {
+        let asset = self.asset_state(asset_index)?;
+        let reset_long = asset.oi_eff_long_q == 0
+            && asset.stored_pos_count_long != 0
+            && asset.pending_obligation_count_long == 0
+            && asset.mode_long != SideModeV16::ResetPending;
+        let reset_short = asset.oi_eff_short_q == 0
+            && asset.stored_pos_count_short != 0
+            && asset.pending_obligation_count_short == 0
+            && asset.mode_short != SideModeV16::ResetPending;
+        if reset_long {
+            self.begin_full_drain_reset_inner(asset_index, SideV16::Long)?;
+        }
+        if reset_short {
+            self.begin_full_drain_reset_inner(asset_index, SideV16::Short)?;
+        }
+        Ok(())
+    }
+
     fn reduce_matching_open_interest_for_unilateral_close(
         &mut self,
         asset_index: usize,
@@ -14073,6 +14092,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             short_delta,
             trade_preflight.short_lookup,
         )?;
+        // ADL can leave stored basis larger than effective OI. If a matched trade consumes the
+        // final effective unit while basis remains, enter the existing reset epoch so public crank
+        // can clear the economically exhausted residue instead of leaving a Normal-mode zero-OI leg.
+        self.begin_zero_oi_trade_residue_resets(request.asset_index)?;
         self.transfer_trade_residual_reward_credit(
             long_account,
             short_account,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -512,6 +512,10 @@ impl MarketGroupV16HeaderAccount {
 }
 
 impl<'a, T> MarketGroupV16ViewMut<'a, T> {
+    pub fn kani_begin_zero_oi_trade_residue_resets(&mut self, asset_index: usize) -> V16Result<()> {
+        self.begin_zero_oi_trade_residue_resets(asset_index)
+    }
+
     pub fn kani_clear_leg(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -370,6 +370,178 @@ fn proof_v16_public_finalize_side_reset_rejects_each_blocker_without_mutation() 
     }
 }
 
+// Continuation-closure theorem for exact-OI ADL residue. The exact mutable-view
+// helper must move every economically exhausted side with surviving positions
+// into the bounded ResetPending route, independently for long and short, while
+// preserving all value state and every unrelated slot field. The public trade
+// regression binds this helper to the successful trade entrypoint.
+#[kani::proof]
+#[kani::solver(cadical)]
+fn proof_v16_zero_oi_residue_reset_is_complete_independent_and_value_neutral() {
+    let long_oi_raw: u8 = kani::any();
+    let short_oi_raw: u8 = kani::any();
+    let long_stored: u8 = kani::any();
+    let short_stored: u8 = kani::any();
+    let long_pending: u8 = kani::any();
+    let short_pending: u8 = kani::any();
+    let long_mode_raw: u8 = kani::any();
+    let short_mode_raw: u8 = kani::any();
+    let long_epoch_raw: u8 = kani::any();
+    let short_epoch_raw: u8 = kani::any();
+    let risk_epoch_raw: u8 = kani::any();
+    let long_k_raw: i8 = kani::any();
+    let short_k_raw: i8 = kani::any();
+    let long_f_raw: i8 = kani::any();
+    let short_f_raw: i8 = kani::any();
+    let long_b_raw: u8 = kani::any();
+    let short_b_raw: u8 = kani::any();
+    let long_weight_raw: u8 = kani::any();
+    let short_weight_raw: u8 = kani::any();
+    let long_remainder_raw: u8 = kani::any();
+    let short_remainder_raw: u8 = kani::any();
+    let long_dust_raw: u8 = kani::any();
+    let short_dust_raw: u8 = kani::any();
+    kani::assume(long_mode_raw <= 2 && short_mode_raw <= 2);
+
+    let decode_mode = |raw| match raw {
+        0 => SideModeV16::Normal,
+        1 => SideModeV16::DrainOnly,
+        _ => SideModeV16::ResetPending,
+    };
+    let (mut header, mut markets, _) = one_market_direct_view_fixture();
+    header.risk_epoch = V16PodU64::new(risk_epoch_raw as u64);
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.oi_eff_long_q = long_oi_raw as u128;
+    asset.oi_eff_short_q = short_oi_raw as u128;
+    asset.stored_pos_count_long = long_stored as u64;
+    asset.stored_pos_count_short = short_stored as u64;
+    asset.pending_obligation_count_long = long_pending as u64;
+    asset.pending_obligation_count_short = short_pending as u64;
+    asset.mode_long = decode_mode(long_mode_raw);
+    asset.mode_short = decode_mode(short_mode_raw);
+    asset.epoch_long = long_epoch_raw as u64;
+    asset.epoch_short = short_epoch_raw as u64;
+    asset.k_long = long_k_raw as i128;
+    asset.k_short = short_k_raw as i128;
+    asset.f_long_num = long_f_raw as i128;
+    asset.f_short_num = short_f_raw as i128;
+    asset.b_long_num = long_b_raw as u128;
+    asset.b_short_num = short_b_raw as u128;
+    asset.loss_weight_sum_long = long_weight_raw as u128;
+    asset.loss_weight_sum_short = short_weight_raw as u128;
+    asset.social_loss_remainder_long_num = long_remainder_raw as u128;
+    asset.social_loss_remainder_short_num = short_remainder_raw as u128;
+    asset.social_loss_dust_long_num = long_dust_raw as u128;
+    asset.social_loss_dust_short_num = short_dust_raw as u128;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+
+    let header_before = header;
+    let slot_before = markets[0].engine;
+    let asset_before = asset;
+    let reset_long = asset_before.oi_eff_long_q == 0
+        && asset_before.stored_pos_count_long != 0
+        && asset_before.pending_obligation_count_long == 0
+        && asset_before.mode_long != SideModeV16::ResetPending;
+    let reset_short = asset_before.oi_eff_short_q == 0
+        && asset_before.stored_pos_count_short != 0
+        && asset_before.pending_obligation_count_short == 0
+        && asset_before.mode_short != SideModeV16::ResetPending;
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    assert_eq!(market.kani_begin_zero_oi_trade_residue_resets(0), Ok(()));
+    let after = market.markets[0].engine.asset.try_to_runtime().unwrap();
+
+    if asset_before.oi_eff_long_q == 0
+        && asset_before.stored_pos_count_long != 0
+        && asset_before.pending_obligation_count_long == 0
+    {
+        assert_eq!(after.mode_long, SideModeV16::ResetPending);
+    }
+    if asset_before.oi_eff_short_q == 0
+        && asset_before.stored_pos_count_short != 0
+        && asset_before.pending_obligation_count_short == 0
+    {
+        assert_eq!(after.mode_short, SideModeV16::ResetPending);
+    }
+
+    let mut expected_asset = asset_before;
+    if reset_long {
+        expected_asset.k_epoch_start_long = asset_before.k_long;
+        expected_asset.f_epoch_start_long_num = asset_before.f_long_num;
+        expected_asset.b_epoch_start_long_num = asset_before.b_long_num;
+        expected_asset.k_long = 0;
+        expected_asset.f_long_num = 0;
+        expected_asset.b_long_num = 0;
+        expected_asset.loss_weight_sum_long = 0;
+        expected_asset.a_long = ADL_ONE;
+        expected_asset.social_loss_dust_long_num = asset_before
+            .social_loss_dust_long_num
+            .checked_add(asset_before.social_loss_remainder_long_num)
+            .unwrap();
+        expected_asset.social_loss_remainder_long_num = 0;
+        expected_asset.epoch_long = asset_before.epoch_long + 1;
+        expected_asset.mode_long = SideModeV16::ResetPending;
+    }
+    if reset_short {
+        expected_asset.k_epoch_start_short = asset_before.k_short;
+        expected_asset.f_epoch_start_short_num = asset_before.f_short_num;
+        expected_asset.b_epoch_start_short_num = asset_before.b_short_num;
+        expected_asset.k_short = 0;
+        expected_asset.f_short_num = 0;
+        expected_asset.b_short_num = 0;
+        expected_asset.loss_weight_sum_short = 0;
+        expected_asset.a_short = ADL_ONE;
+        expected_asset.social_loss_dust_short_num = asset_before
+            .social_loss_dust_short_num
+            .checked_add(asset_before.social_loss_remainder_short_num)
+            .unwrap();
+        expected_asset.social_loss_remainder_short_num = 0;
+        expected_asset.epoch_short = asset_before.epoch_short + 1;
+        expected_asset.mode_short = SideModeV16::ResetPending;
+    }
+    assert_eq!(after, expected_asset);
+
+    let reset_count = u64::from(reset_long) + u64::from(reset_short);
+    let mut expected_header = header_before;
+    expected_header.risk_epoch = V16PodU64::new(header_before.risk_epoch.get() + reset_count);
+    assert!(kani_eq_market_group_v16_header_account(
+        market.header,
+        &expected_header
+    ));
+    let mut expected_slot = slot_before;
+    expected_slot.asset = AssetStateV16Account::from_runtime(&expected_asset);
+    assert!(kani_eq_engine_asset_slot_v16_account(
+        &market.markets[0].engine,
+        &expected_slot
+    ));
+
+    kani::cover!(
+        reset_long && reset_short,
+        "both residue sides reset independently"
+    );
+    kani::cover!(
+        reset_long && !reset_short,
+        "only the long residue side resets"
+    );
+    kani::cover!(
+        !reset_long && reset_short,
+        "only the short residue side resets"
+    );
+    kani::cover!(
+        !reset_long && !reset_short,
+        "a non-residue state is a full no-op"
+    );
+    kani::cover!(
+        reset_long && asset_before.mode_long == SideModeV16::DrainOnly,
+        "a drain-only residue still enters bounded reset cleanup"
+    );
+    kani::cover!(
+        (reset_long && asset_before.social_loss_remainder_long_num != 0)
+            || (reset_short && asset_before.social_loss_remainder_short_num != 0),
+        "reset quarantines nonzero social-loss remainder without losing it"
+    );
+}
+
 #[kani::proof]
 #[kani::unwind(32)]
 #[kani::solver(cadical)]

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -803,6 +803,105 @@ fn v16_crossed_trade_cannot_spend_same_call_addition_as_preexisting_oi() {
 }
 
 #[test]
+fn v16_exact_oi_cross_starts_reset_for_adl_basis_residue() {
+    const SURVIVOR_Q: u128 = 13 * POS_SCALE;
+    const MATCHED_Q: u128 = 10 * POS_SCALE;
+
+    let (mut header, mut markets) = market_fixture(1, 1);
+    let mut survivor_header = account_fixture(1, 20);
+    let mut liquidated_header = account_fixture(1, 21);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut survivor = PortfolioV16ViewMut::new(&mut survivor_header);
+        let mut liquidated = PortfolioV16ViewMut::new(&mut liquidated_header);
+        market.deposit_not_atomic(&mut survivor, 100).unwrap();
+        market.deposit_not_atomic(&mut liquidated, 100).unwrap();
+    }
+
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.a_long = ADL_ONE * MATCHED_Q / SURVIVOR_Q;
+    asset.oi_eff_long_q = MATCHED_Q;
+    asset.oi_eff_short_q = MATCHED_Q;
+    asset.stored_pos_count_long = 1;
+    asset.stored_pos_count_short = 1;
+    asset.loss_weight_sum_long = SURVIVOR_Q;
+    asset.loss_weight_sum_short = MATCHED_Q;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(2);
+
+    survivor_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Long,
+        basis_pos_q: signed_q(SURVIVOR_Q),
+        a_basis: ADL_ONE,
+        k_snap: asset.k_long,
+        f_snap: asset.f_long_num,
+        epoch_snap: asset.epoch_long,
+        loss_weight: SURVIVOR_Q,
+        b_snap: asset.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    survivor_header.active_bitmap[0] = V16PodU64::new(1);
+    survivor_header.health_cert.valid = 0;
+    liquidated_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Short,
+        basis_pos_q: -signed_q(MATCHED_Q),
+        a_basis: ADL_ONE,
+        k_snap: asset.k_short,
+        f_snap: asset.f_short_num,
+        epoch_snap: asset.epoch_short,
+        loss_weight: MATCHED_Q,
+        b_snap: asset.b_short_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_short,
+        b_stale: false,
+        stale: false,
+    });
+    liquidated_header.active_bitmap[0] = V16PodU64::new(1);
+    liquidated_header.health_cert.valid = 0;
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut survivor = PortfolioV16ViewMut::new(&mut survivor_header);
+    let mut liquidated = PortfolioV16ViewMut::new(&mut liquidated_header);
+    market.validate_shape().unwrap();
+    survivor.validate_with_market(&market.as_view()).unwrap();
+    liquidated.validate_with_market(&market.as_view()).unwrap();
+
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut liquidated,
+            &mut survivor,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: signed_q(MATCHED_Q),
+                exec_price: 1,
+                fee_bps: 0,
+            },
+        )
+        .unwrap();
+
+    let after = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    let survivor_leg = survivor.header.legs[0].try_to_runtime().unwrap();
+    assert_eq!(after.oi_eff_long_q, 0);
+    assert_eq!(after.oi_eff_short_q, 0);
+    assert_eq!(survivor_leg.basis_pos_q, signed_q(SURVIVOR_Q - MATCHED_Q));
+    assert!(survivor_leg.active);
+    assert_eq!(after.mode_long, SideModeV16::ResetPending);
+    assert_eq!(after.loss_weight_sum_long, 0);
+    market.validate_shape().unwrap();
+    survivor.validate_with_market(&market.as_view()).unwrap();
+    liquidated.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_batch_trade_applies_multiple_fills_after_inline_refresh() {
     let (mut header, mut markets) = market_fixture(2, 100);
     let mut long_header = account_fixture(2, 201);


### PR DESCRIPTION
## Summary

- Detect crossed trades that reduce one side's effective OI exactly to zero while ADL survivor basis remains stored.
- Move that side into the existing `ResetPending` bounded-cleanup route after all trade margin checks.
- Leave the affected certificate stale so the permissionless cleanup from engine #99 refreshes and removes the dead leg.

## Public red case

Paired wrapper LiteSVM TDD: https://github.com/aeyakovenko/percolator-prog/pull/266

Through ordinary public instructions, two users open opposing positions, one side is partially liquidated, and a crossed trade reduces effective OI by exactly the remaining amount. On the pre-fix dependency head, the trade succeeds but leaves `1_000_000` basis units in an active survivor leg while both effective-OI counters are zero and both sides remain `Normal`.

The survivor's direct reduction returns `CounterUnderflow`, another willing counterparty cannot trade the position out, and ten permissionless cranks each return success while making no state change. Deposited capital remains locked despite an honest cranker.

The strict-greater-than case was fixed by #109. This is the adjacent equality boundary and a different production route from engine #118 / wrapper #219, which concern unilateral bankruptcy close.

## Fix

After successful trade checks, inspect only touched assets. If a side has zero effective OI, still has stored position basis, has no pending payout obligation, and is not already resetting, start the existing full-drain reset. This preserves trade availability and delegates cleanup to the bounded permissionless route.

## Validation

- rebased public red `bc790f69`: OI `(0,0)`, modes `(Normal,Normal)`, residual `1_000_000`; owner exit `Custom(25)`; 10/10 successful cranks are identical no-ops
- fixed public head `2fe02df1`: enters `ResetPending`; one crank clears the leg at 100,151 CU; all remaining principal withdraws
- `cargo test --all-targets --features fuzz`: 161 passed
- Kani `proof_v16_trade_reductions_are_funded_only_by_preexisting_side_oi`: passed
- Kani `proof_v16_prior_reset_cleanup_cannot_starve_live_liquidation`: passed
- paired wrapper aggregate: 6 unit + 568 serialized LiteSVM/CU tests passed
- `cargo fmt --all -- --check`
- `git diff --check`

## Stack

Base: engine PR #99 at `28a7338bd8c0dff7134ea0aa06404795bbb8557b`.

Head: `619f3fec9a2f6c0cf2462414c47a65eeefdde81c`.
