### PR TITLE
[REAL LoF] Keep source-claim conversion domain-local

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 244 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 245 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -14599,10 +14599,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if released == 0 {
             return Ok(0);
         }
-        if Self::account_has_source_claims(&account.as_view())?
-            && self.account_has_active_source_claim_exposure(&account.as_view())?
-        {
-            return Err(V16Error::LockActive);
+        if Self::account_has_source_claims(&account.as_view())? {
+            if self.account_has_active_source_claim_exposure(&account.as_view())?
+                || Self::valid_source_lien_effective_reserved_sum(&account.as_view())? != 0
+            {
+                return Err(V16Error::LockActive);
+            }
         }
         let converted = if Self::account_has_source_claims(&account.as_view())? {
             self.account_source_realizable_support(&account.as_view(), released)?

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -5438,6 +5438,7 @@ struct SupportLossApplicationV16 {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct SourceCreditConsumptionV16 {
     face_burn: u128,
+    source_face_burn_num: u128,
     counterparty_credit_consumed: u128,
     insurance_credit_consumed: u128,
 }
@@ -8663,6 +8664,43 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
+    fn burn_account_source_claim_bound_num_for_domain(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        slot: usize,
+        domain: usize,
+        burn_num: u128,
+    ) -> V16Result<()> {
+        if burn_num == 0 {
+            return Ok(());
+        }
+        if slot >= PORTFOLIO_SOURCE_DOMAIN_CAP
+            || account.source_domain_slot(domain)? != Some(slot)
+            || Self::source_claim_unliened_num(&account.as_view(), domain)? < burn_num
+        {
+            return Err(V16Error::CounterUnderflow);
+        }
+        let source = &mut account.header.source_domains[slot];
+        source.source_claim_bound_num = V16PodU128::new(
+            source
+                .source_claim_bound_num
+                .get()
+                .checked_sub(burn_num)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        let mut source_credit = self.source_credit_for_domain(domain)?;
+        source_credit.positive_claim_bound_num = source_credit
+            .positive_claim_bound_num
+            .checked_sub(burn_num)
+            .ok_or(V16Error::CounterUnderflow)?;
+        source_credit.exact_positive_claim_num = source_credit
+            .exact_positive_claim_num
+            .checked_sub(burn_num.min(source_credit.exact_positive_claim_num))
+            .ok_or(V16Error::CounterUnderflow)?;
+        self.set_source_credit_for_domain(domain, source_credit)?;
+        self.recompute_source_credit_domain_after_mutation(domain)
+    }
+
     fn source_domain_realizable_support_for_face(
         &self,
         domain: usize,
@@ -9392,6 +9430,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if effective_credit == 0 {
             return Ok(SourceCreditConsumptionV16 {
                 face_burn: 0,
+                source_face_burn_num: 0,
                 counterparty_credit_consumed: 0,
                 insurance_credit_consumed: 0,
             });
@@ -9424,6 +9463,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         Ok(SourceCreditConsumptionV16 {
             face_burn: V16Core::amount_from_bound_num(required_face_num)?,
+            source_face_burn_num: 0,
             counterparty_credit_consumed,
             insurance_credit_consumed,
         })
@@ -9438,6 +9478,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if effective_credit == 0 {
             return Ok(SourceCreditConsumptionV16 {
                 face_burn: 0,
+                source_face_burn_num: 0,
                 counterparty_credit_consumed: 0,
                 insurance_credit_consumed: 0,
             });
@@ -9493,6 +9534,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                             .checked_add(take)
                             .ok_or(V16Error::ArithmeticOverflow)?;
                     }
+                    self.burn_account_source_claim_bound_num_for_domain(
+                        account, slot, d, face_num,
+                    )?;
                     face_burn_num = face_burn_num
                         .checked_add(face_num)
                         .ok_or(V16Error::ArithmeticOverflow)?;
@@ -9504,8 +9548,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if remaining != 0 {
             return Err(V16Error::LockActive);
         }
+        account.compact_source_domains();
         Ok(SourceCreditConsumptionV16 {
             face_burn: V16Core::amount_from_bound_num(face_burn_num)?,
+            source_face_burn_num: face_burn_num,
             counterparty_credit_consumed,
             insurance_credit_consumed,
         })
@@ -9949,7 +9995,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
         new_pnl: i128,
     ) -> V16Result<()> {
-        self.set_account_pnl_inner(account, new_pnl, None)
+        self.set_account_pnl_inner(account, new_pnl, None, 0)
     }
 
     fn set_account_pnl_with_source(
@@ -9959,7 +10005,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         source_domain: usize,
     ) -> V16Result<()> {
         self.domain_asset_side(source_domain)?;
-        self.set_account_pnl_inner(account, new_pnl, Some(source_domain))
+        self.set_account_pnl_inner(account, new_pnl, Some(source_domain), 0)
+    }
+
+    fn set_account_pnl_after_source_claim_burn(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        new_pnl: i128,
+        source_face_burn_num: u128,
+    ) -> V16Result<()> {
+        self.set_account_pnl_inner(account, new_pnl, None, source_face_burn_num)
     }
 
     /// Grants source-attributed positive PnL to an account — the first-class
@@ -10000,11 +10055,15 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
         new_pnl: i128,
         source_domain: Option<usize>,
+        preburned_source_claim_num: u128,
     ) -> V16Result<()> {
         validate_non_min_i128(new_pnl)?;
         let old_pos = account.header.pnl.get().max(0) as u128;
         let new_pos = new_pnl.max(0) as u128;
         if new_pos >= old_pos {
+            if preburned_source_claim_num != 0 {
+                return Err(V16Error::InvalidConfig);
+            }
             let increase = new_pos - old_pos;
             let increase_num = V16Core::bound_num_from_amount(increase)?;
             let increase_domain = if increase_num != 0 {
@@ -10061,7 +10120,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         } else {
             let decrease = old_pos - new_pos;
             let decrease_num = V16Core::bound_num_from_amount(decrease)?;
-            self.burn_account_source_claim_bound_num(account, decrease_num)?;
+            let remaining_source_claim_burn = decrease_num
+                .checked_sub(preburned_source_claim_num)
+                .ok_or(V16Error::CounterUnderflow)?;
+            self.burn_account_source_claim_bound_num(account, remaining_source_claim_burn)?;
             self.header.pnl_pos_tot = V16PodU128::new(
                 self.header
                     .pnl_pos_tot
@@ -10181,13 +10243,15 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let remaining_loss = loss_abs
             .checked_sub(support_consumed)
             .ok_or(V16Error::ArithmeticOverflow)?;
+        let mut source_face_burn_num = 0u128;
         let mut junior_face_burned = if has_source_claims {
-            self.create_and_consume_account_source_credit_for_effective_not_atomic(
-                account,
-                support_consumed,
-            )?
-            .face_burn
-            .min(old_positive_face)
+            let consumption = self
+                .create_and_consume_account_source_credit_for_effective_not_atomic(
+                    account,
+                    support_consumed,
+                )?;
+            source_face_burn_num = consumption.source_face_burn_num;
+            consumption.face_burn.min(old_positive_face)
         } else if support_consumed == 0 {
             0
         } else {
@@ -10218,7 +10282,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .get()
                 .min(new_pnl.max(0) as u128),
         );
-        self.set_account_pnl(account, new_pnl)?;
+        self.set_account_pnl_after_source_claim_burn(account, new_pnl, source_face_burn_num)?;
         Ok(SupportLossApplicationV16 {
             support_consumed,
             junior_face_burned,
@@ -14564,6 +14628,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     residual,
                     junior_bound,
                 )?,
+                source_face_burn_num: 0,
                 counterparty_credit_consumed: 0,
                 insurance_credit_consumed: 0,
             }
@@ -14576,7 +14641,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             .get()
             .checked_sub(face_i128)
             .ok_or(V16Error::ArithmeticOverflow)?;
-        self.set_account_pnl(account, new_pnl)?;
+        self.set_account_pnl_after_source_claim_burn(
+            account,
+            new_pnl,
+            consumption.source_face_burn_num,
+        )?;
         account.header.capital = V16PodU128::new(
             account
                 .header

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -984,6 +984,53 @@ impl V16Core {
         Ok(source)
     }
 
+    /// Atomically binds a source-claim burn to the selected domain ledger.
+    #[inline]
+    fn prepare_domain_local_source_claim_burn_delta(
+        mut account_source: PortfolioSourceDomainV16Account,
+        mut source_credit: SourceCreditStateV16,
+        expected_domain: u32,
+        burn_num: u128,
+    ) -> V16Result<(PortfolioSourceDomainV16Account, SourceCreditStateV16)> {
+        if burn_num == 0 {
+            return Ok((account_source, source_credit));
+        }
+        if !account_source.is_occupied() || account_source.domain.get() != expected_domain {
+            return Err(V16Error::CounterUnderflow);
+        }
+        let locked = account_source
+            .source_claim_liened_num
+            .get()
+            .checked_add(account_source.source_claim_impaired_num.get())
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        let unliened = account_source
+            .source_claim_bound_num
+            .get()
+            .checked_sub(locked)
+            .ok_or(V16Error::CounterUnderflow)?;
+        if burn_num > unliened || burn_num > source_credit.positive_claim_bound_num {
+            return Err(V16Error::CounterUnderflow);
+        }
+        account_source.source_claim_bound_num =
+            V16PodU128::new(account_source.source_claim_bound_num.get() - burn_num);
+        source_credit.positive_claim_bound_num -= burn_num;
+        source_credit.exact_positive_claim_num = source_credit
+            .exact_positive_claim_num
+            .checked_sub(burn_num.min(source_credit.exact_positive_claim_num))
+            .ok_or(V16Error::CounterUnderflow)?;
+        Ok((account_source, source_credit))
+    }
+
+    #[inline]
+    fn source_claim_burn_remainder(
+        decrease_num: u128,
+        preburned_source_claim_num: u128,
+    ) -> V16Result<u128> {
+        decrease_num
+            .checked_sub(preburned_source_claim_num)
+            .ok_or(V16Error::CounterUnderflow)
+    }
+
     #[cfg_attr(all(kani, feature = "contracts"), kani::requires(new_signed != 0))]
     #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &V16Result<(PortfolioLegV16, AssetStateV16)>| match result {
         Ok((l, a)) => {
@@ -8674,29 +8721,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if burn_num == 0 {
             return Ok(());
         }
-        if slot >= PORTFOLIO_SOURCE_DOMAIN_CAP
-            || account.source_domain_slot(domain)? != Some(slot)
-            || Self::source_claim_unliened_num(&account.as_view(), domain)? < burn_num
+        if slot >= PORTFOLIO_SOURCE_DOMAIN_CAP || account.source_domain_slot(domain)? != Some(slot)
         {
             return Err(V16Error::CounterUnderflow);
         }
-        let source = &mut account.header.source_domains[slot];
-        source.source_claim_bound_num = V16PodU128::new(
-            source
-                .source_claim_bound_num
-                .get()
-                .checked_sub(burn_num)
-                .ok_or(V16Error::CounterUnderflow)?,
-        );
-        let mut source_credit = self.source_credit_for_domain(domain)?;
-        source_credit.positive_claim_bound_num = source_credit
-            .positive_claim_bound_num
-            .checked_sub(burn_num)
-            .ok_or(V16Error::CounterUnderflow)?;
-        source_credit.exact_positive_claim_num = source_credit
-            .exact_positive_claim_num
-            .checked_sub(burn_num.min(source_credit.exact_positive_claim_num))
-            .ok_or(V16Error::CounterUnderflow)?;
+        let (source, source_credit) = V16Core::prepare_domain_local_source_claim_burn_delta(
+            account.header.source_domains[slot],
+            self.source_credit_for_domain(domain)?,
+            domain as u32,
+            burn_num,
+        )?;
+        account.header.source_domains[slot] = source;
         self.set_source_credit_for_domain(domain, source_credit)?;
         self.recompute_source_credit_domain_after_mutation(domain)
     }
@@ -10120,9 +10155,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         } else {
             let decrease = old_pos - new_pos;
             let decrease_num = V16Core::bound_num_from_amount(decrease)?;
-            let remaining_source_claim_burn = decrease_num
-                .checked_sub(preburned_source_claim_num)
-                .ok_or(V16Error::CounterUnderflow)?;
+            let remaining_source_claim_burn =
+                V16Core::source_claim_burn_remainder(decrease_num, preburned_source_claim_num)?;
             self.burn_account_source_claim_bound_num(account, remaining_source_claim_burn)?;
             self.header.pnl_pos_tot = V16PodU128::new(
                 self.header

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -169,6 +169,27 @@ pub fn kani_validate_positive_pnl_source_attribution(
     V16Core::validate_positive_pnl_source_attribution(pnl, source_claim_sum_num)
 }
 
+pub fn kani_prepare_domain_local_source_claim_burn_delta(
+    account_source: PortfolioSourceDomainV16Account,
+    source_credit: SourceCreditStateV16,
+    expected_domain: u32,
+    burn_num: u128,
+) -> V16Result<(PortfolioSourceDomainV16Account, SourceCreditStateV16)> {
+    V16Core::prepare_domain_local_source_claim_burn_delta(
+        account_source,
+        source_credit,
+        expected_domain,
+        burn_num,
+    )
+}
+
+pub fn kani_source_claim_burn_remainder(
+    decrease_num: u128,
+    preburned_source_claim_num: u128,
+) -> V16Result<u128> {
+    V16Core::source_claim_burn_remainder(decrease_num, preburned_source_claim_num)
+}
+
 pub fn kani_expected_source_credit_rate_num_for_state(
     state: SourceCreditStateV16,
 ) -> V16Result<u128> {

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -15,7 +15,8 @@ use percolator::v16::{
     kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
     kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
-    kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
+    kani_prepare_asset_recovery_transition, kani_prepare_domain_local_source_claim_burn_delta,
+    kani_source_claim_burn_remainder, kani_source_credit_state_realizable_support_for_face,
     kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
     kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
     AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
@@ -37,7 +38,8 @@ use percolator::v16::{
 };
 use percolator::v16::{
     kani_eq_engine_asset_slot_v16_account, kani_eq_market_group_v16_header_account,
-    kani_eq_portfolio_account_v16_account,
+    kani_eq_portfolio_account_v16_account, kani_eq_portfolio_source_domain_v16_account,
+    kani_eq_source_credit_state_v16_account,
 };
 use percolator::{
     ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, MAX_ACCOUNT_NOTIONAL, MAX_MARGIN_BPS,
@@ -3311,6 +3313,129 @@ fn proof_v16_open_source_claim_exposure_blocks_convert() {
         "active source-claim exposure reaches convert guard for wide symbolic claim"
     );
     assert!(blocked);
+}
+
+// Source conversion conservation theorem over the exact production burn and
+// pre-burn accounting kernels. Across the complete Kani source-domain table,
+// each backing-selected burn is confined to its named domain, the aggregate
+// claim rank falls exactly once, and the later PnL update can burn only the
+// residual face. The public conversion regression binds these kernels to the
+// zero-copy entrypoint.
+#[kani::proof]
+#[kani::unwind(6)]
+#[kani::solver(cadical)]
+fn proof_v16_source_conversion_burns_are_domain_local_disjoint_and_complete() {
+    let claim_raw: [u8; PORTFOLIO_SOURCE_DOMAIN_CAP] = kani::any();
+    let liened_raw: [u8; PORTFOLIO_SOURCE_DOMAIN_CAP] = kani::any();
+    let impaired_raw: [u8; PORTFOLIO_SOURCE_DOMAIN_CAP] = kani::any();
+    let burn_raw: [u8; PORTFOLIO_SOURCE_DOMAIN_CAP] = kani::any();
+    let residual_raw: u8 = kani::any();
+    let mut total_before = 0u128;
+    let mut total_after = 0u128;
+    let mut preburned = 0u128;
+    let mut slot = 0usize;
+
+    while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
+        let claim = claim_raw[slot] as u128;
+        let liened = liened_raw[slot] as u128;
+        let impaired = impaired_raw[slot] as u128;
+        let burn = burn_raw[slot] as u128;
+        kani::assume(claim > 0);
+        kani::assume(liened <= claim);
+        kani::assume(impaired <= claim - liened);
+        kani::assume(burn <= claim - liened - impaired);
+
+        let mut source = PortfolioSourceDomainV16Account::default();
+        source.domain = V16PodU32::new(slot as u32);
+        source.source_claim_market_id = V16PodU64::new((slot / 2 + 1) as u64);
+        source.source_claim_bound_num = V16PodU128::new(claim);
+        source.source_claim_liened_num = V16PodU128::new(liened);
+        source.source_claim_impaired_num = V16PodU128::new(impaired);
+        let credit = SourceCreditStateV16 {
+            positive_claim_bound_num: claim,
+            exact_positive_claim_num: claim,
+            ..SourceCreditStateV16::EMPTY
+        };
+        let source_before = source;
+        let credit_before = credit;
+        let (source_after, credit_after) =
+            kani_prepare_domain_local_source_claim_burn_delta(source, credit, slot as u32, burn)
+                .unwrap();
+
+        let mut expected_source = source_before;
+        expected_source.source_claim_bound_num = V16PodU128::new(claim - burn);
+        let mut expected_credit = credit_before;
+        expected_credit.positive_claim_bound_num = claim - burn;
+        expected_credit.exact_positive_claim_num = claim - burn;
+        assert!(kani_eq_portfolio_source_domain_v16_account(
+            &source_after,
+            &expected_source
+        ));
+        assert!(kani_eq_source_credit_state_v16_account(
+            &SourceCreditStateV16Account::from_runtime(&credit_after),
+            &SourceCreditStateV16Account::from_runtime(&expected_credit)
+        ));
+        assert_eq!(source_after.domain.get(), source_before.domain.get());
+        assert_eq!(
+            source_after.source_claim_liened_num.get(),
+            source_before.source_claim_liened_num.get()
+        );
+        assert_eq!(
+            source_after.source_claim_impaired_num.get(),
+            source_before.source_claim_impaired_num.get()
+        );
+
+        if burn != 0 {
+            assert!(matches!(
+                kani_prepare_domain_local_source_claim_burn_delta(
+                    source_before,
+                    credit_before,
+                    (slot as u32) ^ 1,
+                    burn,
+                ),
+                Err(V16Error::CounterUnderflow)
+            ));
+        }
+        total_before += claim;
+        total_after += source_after.source_claim_bound_num.get();
+        preburned += burn;
+        slot += 1;
+    }
+
+    let residual = residual_raw as u128;
+    let total_decrease = preburned + residual;
+    assert_eq!(total_before - total_after, preburned);
+    assert!(matches!(
+        kani_source_claim_burn_remainder(total_decrease, preburned),
+        Ok(value) if value == residual
+    ));
+    assert_eq!(preburned + residual, total_decrease);
+    assert!(matches!(
+        kani_source_claim_burn_remainder(preburned, preburned + 1),
+        Err(V16Error::CounterUnderflow)
+    ));
+
+    kani::cover!(
+        burn_raw[0] != 0 && burn_raw[1] != 0 && burn_raw[2] != 0 && burn_raw[3] != 0,
+        "all source domains can contribute disjoint conversion support"
+    );
+    kani::cover!(
+        burn_raw[0] == 0 && burn_raw[1] != 0,
+        "a later funded source cannot burn an earlier unfunded claim"
+    );
+    kani::cover!(
+        (liened_raw[0] != 0 || liened_raw[1] != 0 || liened_raw[2] != 0 || liened_raw[3] != 0)
+            && (impaired_raw[0] != 0
+                || impaired_raw[1] != 0
+                || impaired_raw[2] != 0
+                || impaired_raw[3] != 0)
+            && preburned != 0,
+        "valid and impaired locks coexist with domain-local unliened burns"
+    );
+    kani::cover!(
+        residual != 0 && preburned != 0,
+        "source pre-burn and residual PnL burn form one exact partition"
+    );
 }
 
 // Public-path favorable-action freshness: conversion preflight accepts exactly

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -2794,6 +2794,101 @@ fn v16_source_backed_conversion_clears_sparse_source_domain_slot() {
 }
 
 #[test]
+fn v16_source_backed_conversion_burns_claim_from_consumed_domain() {
+    let (mut header, mut markets) = market_fixture(2, 1);
+    let mut account_header = account_fixture(2, 28);
+    let claim = 100u128;
+    let claim_num = claim * BOUND_SCALE;
+    header.vault = V16PodU128::new(claim);
+    header.pnl_pos_tot = V16PodU128::new(2 * claim);
+    header.pnl_pos_bound_tot_num = V16PodU128::new(2 * claim_num);
+    header.pnl_pos_bound_tot = V16PodU128::new(2 * claim);
+    header.source_claim_bound_total_num = V16PodU128::new(2 * claim_num);
+    header.source_fresh_backing_total_num = V16PodU128::new(claim_num);
+    account_header.pnl = V16PodI128::new((2 * claim) as i128);
+    account_header.source_domains[0].domain = V16PodU32::new(1);
+    account_header.source_domains[0].source_claim_market_id = V16PodU64::new(1);
+    account_header.source_domains[0].source_claim_bound_num = V16PodU128::new(claim_num);
+    account_header.source_domains[1].domain = V16PodU32::new(3);
+    account_header.source_domains[1].source_claim_market_id = V16PodU64::new(2);
+    account_header.source_domains[1].source_claim_bound_num = V16PodU128::new(claim_num);
+
+    markets[0].engine.source_credit_short =
+        SourceCreditStateV16Account::from_runtime(&SourceCreditStateV16 {
+            positive_claim_bound_num: claim_num,
+            exact_positive_claim_num: claim_num,
+            credit_rate_num: 0,
+            ..SourceCreditStateV16::EMPTY
+        });
+    markets[0].engine.backing_short = BackingBucketV16Account::from_runtime(&BackingBucketV16 {
+        market_id: 1,
+        status: BackingBucketStatusV16::Expired,
+        ..BackingBucketV16::EMPTY
+    });
+    markets[1].engine.source_credit_short =
+        SourceCreditStateV16Account::from_runtime(&SourceCreditStateV16 {
+            positive_claim_bound_num: claim_num,
+            exact_positive_claim_num: claim_num,
+            fresh_reserved_backing_num: claim_num,
+            credit_rate_num: CREDIT_RATE_SCALE,
+            ..SourceCreditStateV16::EMPTY
+        });
+    markets[1].engine.backing_short = BackingBucketV16Account::from_runtime(&BackingBucketV16 {
+        market_id: 2,
+        fresh_unliened_backing_num: claim_num,
+        expiry_slot: 100,
+        status: BackingBucketStatusV16::Fresh,
+        ..BackingBucketV16::EMPTY
+    });
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market
+        .full_account_refresh_not_atomic(&mut account)
+        .unwrap();
+    let converted = market
+        .convert_released_pnl_to_capital_not_atomic(&mut account)
+        .expect("the backed domain should fund one conversion");
+
+    assert_eq!(converted, claim);
+    assert_eq!(account.header.pnl.get(), claim as i128);
+    assert_eq!(account.header.source_domains[0].domain.get(), 1);
+    assert_eq!(
+        account.header.source_domains[0]
+            .source_claim_bound_num
+            .get(),
+        claim_num,
+        "an unfunded domain's claim must not be burned for another domain's backing"
+    );
+    assert_eq!(
+        market.markets[0]
+            .engine
+            .source_credit_short
+            .positive_claim_bound_num
+            .get(),
+        claim_num
+    );
+    assert_eq!(
+        market.markets[1]
+            .engine
+            .source_credit_short
+            .positive_claim_bound_num
+            .get(),
+        0
+    );
+    assert_eq!(
+        market.markets[1]
+            .engine
+            .backing_short
+            .consumed_liened_backing_num
+            .get(),
+        claim_num
+    );
+    account.validate_with_market(&market.as_view()).unwrap();
+    market.validate_shape().unwrap();
+}
+
+#[test]
 fn v16_sparse_source_domains_reject_unoccupied_tagged_slot() {
     let (mut header, mut markets) = market_fixture(1, 1);
     let mut account_header = account_fixture(1, 19);


### PR DESCRIPTION
## Root cause

Account-wide source conversion selected backing by source domain, but returned only an aggregate face burn. The later PnL setter retired source claims in portfolio slot order. A winner with claims in two domains could therefore consume domain 3 backing while burning domain 1 claim, then consume domain 3 backing again. This crosses asset-isolation boundaries and overdraws an independent backing provider.

## Fix

- Retire each selected source claim in the same domain whose backing is consumed.
- Pass the exact pre-burned bound numerator into the aggregate PnL setter so it cannot double-burn claim face.
- Reject live conversion while any source claim remains liened.

## TDD

- `e7466b4` is the test-only commit and fails on the unmodified engine because domain 1 disappears while domain 3 survives.
- `f0e189a` is fixed-green.
- A dependent wrapper PR supplies the public LiteSVM exploit sequence without state injection.

## Verification

`cargo test --all-targets` passes: 50 unit/math, 9 backing fuzz, 2 resolved-insolvency fuzz, and 69 V16 spec tests.