### PR TITLE
[REAL DoS] Reserve source capacity for admitted positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 244 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 245 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -12767,6 +12767,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         asset_index: usize,
         side: SideV16,
     ) -> V16Result<()> {
+        // Source entries are compacted by PortfolioV16ViewMut::new. If the first slot beyond the
+        // universally safe occupancy threshold is empty, even the worst case (every configured
+        // active leg needs a distinct missing domain) fits without any scan.
+        let max_active = self.header.config.max_portfolio_assets.get() as usize;
+        if max_active != 0 && max_active <= PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let safe_occupied = PORTFOLIO_SOURCE_DOMAIN_CAP - max_active;
+            if account.header.source_domains[safe_occupied].is_sparse_tail_default() {
+                return Ok(());
+            }
+        }
+
         let candidate_domain = self.insurance_domain_index(asset_index, opposite_side(side))?;
         let candidate_missing =
             usize::from(account.source_domain_slot(candidate_domain)?.is_none());
@@ -12782,15 +12793,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 occupied += 1;
             }
             source_slot += 1;
-        }
-
-        // Below this threshold, even if every active leg still needs a distinct source domain,
-        // the configured active-leg cap guarantees enough room. Keep ordinary and max-leg batch
-        // admission on this constant-time path; only claim-heavy historical portfolios need the
-        // detailed reservation scan below.
-        let max_active = self.header.config.max_portfolio_assets.get() as usize;
-        if occupied <= PORTFOLIO_SOURCE_DOMAIN_CAP.saturating_sub(max_active) {
-            return Ok(());
         }
 
         // Every active leg reserves the one source domain that a favorable K/F move can create.

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -12744,6 +12744,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         validate_basis(basis_pos_q)?;
         let asset = self.asset_state(asset_index)?;
         self.require_asset_risk_change_allowed(asset_index, true)?;
+        self.ensure_source_domain_capacity_for_new_exposure(&account.as_view(), asset_index, side)?;
         let a_basis = match side {
             SideV16::Long => asset.a_long,
             SideV16::Short => asset.a_short,
@@ -12757,6 +12758,52 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account.header.active_bitmap = bitmap.map(V16PodU64::new);
         account.header.health_cert.valid = 0;
         self.set_asset_state(asset_index, asset)?;
+        Ok(())
+    }
+
+    fn ensure_source_domain_capacity_for_new_exposure(
+        &self,
+        account: &PortfolioV16View<'_>,
+        asset_index: usize,
+        side: SideV16,
+    ) -> V16Result<()> {
+        let candidate_domain = self.insurance_domain_index(asset_index, opposite_side(side))?;
+        let candidate_missing =
+            usize::from(account.source_domain_slot(candidate_domain)?.is_none());
+
+        let mut occupied = 0usize;
+        let mut source_slot = 0usize;
+        while source_slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            if account.header.source_domains[source_slot].is_occupied() {
+                occupied += 1;
+            }
+            source_slot += 1;
+        }
+
+        // Every active leg reserves the one source domain that a favorable K/F move can create.
+        // Without this reservation, a full historical source table can admit a new position and
+        // later make its first profitable settlement fail before any close/reduce path can run.
+        let mut missing_active = 0usize;
+        let mut leg_slot = 0usize;
+        while leg_slot < V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg = account.header.legs[leg_slot].try_to_runtime()?;
+            if leg.active {
+                let domain =
+                    self.insurance_domain_index(leg.asset_index as usize, opposite_side(leg.side))?;
+                if account.source_domain_slot(domain)?.is_none() {
+                    missing_active += 1;
+                }
+            }
+            leg_slot += 1;
+        }
+
+        let required = occupied
+            .checked_add(missing_active)
+            .and_then(|v| v.checked_add(candidate_missing))
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        if required > PORTFOLIO_SOURCE_DOMAIN_CAP {
+            return Err(V16Error::LockActive);
+        }
         Ok(())
     }
 

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -12774,10 +12774,23 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let mut occupied = 0usize;
         let mut source_slot = 0usize;
         while source_slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
-            if account.header.source_domains[source_slot].is_occupied() {
+            let source = account.header.source_domains[source_slot];
+            if source.is_sparse_tail_default() {
+                break;
+            }
+            if source.is_occupied() {
                 occupied += 1;
             }
             source_slot += 1;
+        }
+
+        // Below this threshold, even if every active leg still needs a distinct source domain,
+        // the configured active-leg cap guarantees enough room. Keep ordinary and max-leg batch
+        // admission on this constant-time path; only claim-heavy historical portfolios need the
+        // detailed reservation scan below.
+        let max_active = self.header.config.max_portfolio_assets.get() as usize;
+        if occupied <= PORTFOLIO_SOURCE_DOMAIN_CAP.saturating_sub(max_active) {
+            return Ok(());
         }
 
         // Every active leg reserves the one source domain that a favorable K/F move can create.

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -34,6 +34,25 @@ pub const BACKING_FEE_RATE_DEN_E9: u128 = 1_000_000_000;
 pub const MAX_BACKING_FEE_RATE_E9_PER_SLOT: u64 = 1_000_000_000;
 pub const MAX_BACKING_FEE_UTIL_BPS: u64 = 10_000;
 
+/// Admission resource invariant for latent favorable settlement domains.
+/// `occupied + missing_active` is the reserved pre-state; admission adds the
+/// candidate only when its favorable source is not already materialized.
+#[inline]
+fn source_domain_capacity_after_admission(
+    occupied: usize,
+    missing_active: usize,
+    candidate_missing: bool,
+) -> V16Result<usize> {
+    let required = occupied
+        .checked_add(missing_active)
+        .and_then(|v| v.checked_add(usize::from(candidate_missing)))
+        .ok_or(V16Error::ArithmeticOverflow)?;
+    if required > PORTFOLIO_SOURCE_DOMAIN_CAP {
+        return Err(V16Error::LockActive);
+    }
+    Ok(required)
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct BackingDomainFeeSplitV16 {
     pub lien_delta_atoms: u128,
@@ -12779,8 +12798,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
 
         let candidate_domain = self.insurance_domain_index(asset_index, opposite_side(side))?;
-        let candidate_missing =
-            usize::from(account.source_domain_slot(candidate_domain)?.is_none());
+        let candidate_missing = account.source_domain_slot(candidate_domain)?.is_none();
 
         let mut occupied = 0usize;
         let mut source_slot = 0usize;
@@ -12812,13 +12830,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             leg_slot += 1;
         }
 
-        let required = occupied
-            .checked_add(missing_active)
-            .and_then(|v| v.checked_add(candidate_missing))
-            .ok_or(V16Error::ArithmeticOverflow)?;
-        if required > PORTFOLIO_SOURCE_DOMAIN_CAP {
-            return Err(V16Error::LockActive);
-        }
+        source_domain_capacity_after_admission(occupied, missing_active, candidate_missing)?;
         Ok(())
     }
 

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -195,6 +195,14 @@ pub fn kani_loss_stale_trade_scope_allowed(
     )
 }
 
+pub fn kani_source_domain_capacity_after_admission(
+    occupied: usize,
+    missing_active: usize,
+    candidate_missing: bool,
+) -> V16Result<usize> {
+    source_domain_capacity_after_admission(occupied, missing_active, candidate_missing)
+}
+
 pub fn kani_prepare_asset_recovery_transition(
     asset: AssetStateV16,
     asset_set_epoch: u64,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -16,13 +16,14 @@ use percolator::v16::{
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
     kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
     kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
-    kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
-    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
-    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
-    BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
-    CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
-    HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
-    Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
+    kani_source_domain_capacity_after_admission, kani_target_effective_lag_adverse_delta,
+    kani_trade_preexisting_oi_reduction_gate, kani_trade_preflight_risk_gate,
+    kani_validate_positive_pnl_source_attribution, AssetLifecycleV16, AssetStateV16,
+    AssetStateV16Account, BackingBucketStatusV16, BackingBucketV16, BackingBucketV16Account,
+    BatchTradeOutcomeV16, CloseProgressLedgerV16, CloseProgressLedgerV16Account,
+    EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16, HealthCertV16Account,
+    InsuranceCreditReservationV16, InsuranceCreditReservationV16Account, Market,
+    MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
     PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
@@ -1143,6 +1144,75 @@ fn proof_v16_sparse_source_domain_cap_full_rejects_new_domain() {
         "sparse source-domain cap-full rejection covers symbolic new domain"
     );
     assert_eq!(rejected, Err(V16Error::LockActive));
+}
+
+// High-level admission-to-continuation theorem. Every active leg owns one
+// distinct latent favorable source domain (active-asset uniqueness is proven by
+// `proof_v16_duplicate_asset_legs_reject_before_double_counting_support`), so
+// the reserved resource is `occupied + missing_active`. An accepted candidate
+// must leave enough physical slots to materialize every latent domain in any
+// order.
+#[kani::proof]
+#[kani::unwind(6)]
+#[kani::solver(cadical)]
+fn proof_v16_source_capacity_admission_closes_all_favorable_domains() {
+    let occupied_raw: u8 = kani::any();
+    let missing_active_raw: u8 = kani::any();
+    let candidate_missing: bool = kani::any();
+    kani::assume(occupied_raw as usize <= PORTFOLIO_SOURCE_DOMAIN_CAP);
+    kani::assume(missing_active_raw as usize <= PORTFOLIO_SOURCE_DOMAIN_CAP);
+
+    let occupied = occupied_raw as usize;
+    let missing_active = missing_active_raw as usize;
+    let reserved_before = occupied + missing_active;
+    kani::assume(reserved_before <= PORTFOLIO_SOURCE_DOMAIN_CAP);
+    let candidate_reservation = usize::from(candidate_missing);
+    let required = reserved_before + candidate_reservation;
+    let admission =
+        kani_source_domain_capacity_after_admission(occupied, missing_active, candidate_missing);
+
+    if required > PORTFOLIO_SOURCE_DOMAIN_CAP {
+        assert_eq!(admission, Err(V16Error::LockActive));
+        assert!(candidate_missing);
+        assert_eq!(reserved_before, PORTFOLIO_SOURCE_DOMAIN_CAP);
+        kani::cover!(
+            occupied == PORTFOLIO_SOURCE_DOMAIN_CAP,
+            "a full historical table rejects a missing candidate domain"
+        );
+        kani::cover!(
+            occupied < PORTFOLIO_SOURCE_DOMAIN_CAP && missing_active > 0,
+            "latent active domains reject over-admission before the table is physically full"
+        );
+        return;
+    }
+
+    let admitted_required = admission.unwrap();
+    assert_eq!(admitted_required, required);
+    let mut materialized = occupied;
+    let mut latent = missing_active + candidate_reservation;
+    while latent != 0 {
+        // Any ordering is equivalent: each distinct latent domain consumes one
+        // free slot and removes one reservation, preserving the union cardinality.
+        assert!(materialized < PORTFOLIO_SOURCE_DOMAIN_CAP);
+        materialized += 1;
+        latent -= 1;
+        assert_eq!(materialized + latent, admitted_required);
+    }
+    assert_eq!(materialized, admitted_required);
+    assert!(materialized <= PORTFOLIO_SOURCE_DOMAIN_CAP);
+
+    kani::cover!(
+        candidate_missing && missing_active > 0 && admitted_required == PORTFOLIO_SOURCE_DOMAIN_CAP,
+        "multiple latent domains materialize at the exact capacity boundary"
+    );
+    kani::cover!(
+        !candidate_missing && reserved_before == PORTFOLIO_SOURCE_DOMAIN_CAP,
+        "a represented candidate remains admissible at full reserved capacity"
+    );
+    kani::cover!(
+        occupied > 0 && missing_active > 0 && materialized == PORTFOLIO_SOURCE_DOMAIN_CAP,
+        "historical and latent domains coexist and fully materialize"
+    );
 }
 
 #[kani::proof]

--- a/tests/v16_fuzzing.rs
+++ b/tests/v16_fuzzing.rs
@@ -3,9 +3,10 @@
 use percolator::{
     EngineAssetSlotV16Account, LiquidationRequestV16, Market, MarketGroupV16HeaderAccount,
     MarketGroupV16ViewMut, PermissionlessCrankActionV16, PermissionlessCrankRequestV16,
-    PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioV16View,
-    PortfolioV16ViewMut, ProvenanceHeaderV16, ProvenanceHeaderV16Account, TradeRequestV16,
-    V16Config, V16Error,
+    PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioSourceDomainV16Account,
+    PortfolioV16View, PortfolioV16ViewMut, ProvenanceHeaderV16, ProvenanceHeaderV16Account,
+    SideV16, TradeRequestV16, V16Config, V16Error, V16PodU128, V16PodU32, V16PodU64, BOUND_SCALE,
+    PORTFOLIO_SOURCE_DOMAIN_CAP, POS_SCALE,
 };
 use proptest::prelude::*;
 
@@ -349,4 +350,118 @@ proptest! {
             );
         }
     }
+}
+
+#[test]
+fn v16_source_domain_capacity_reserves_favorable_settlement_for_each_active_leg() {
+    const MARKET_SLOTS: usize = 17;
+    const CANDIDATE_ASSET: usize = 16;
+    const EXISTING_ASSET: usize = 15;
+
+    let (market_id, _, _, _) = ids();
+    let cfg = V16Config::public_user_fund_with_market_slots(16, MARKET_SLOTS as u32, 0, 10);
+    let mut header =
+        MarketGroupV16HeaderAccount::new_dynamic(market_id, cfg, MARKET_SLOTS as u32, 0).unwrap();
+    let mut markets = (0..MARKET_SLOTS)
+        .map(|i| Market::new(i as u64, EngineAssetSlotV16Account::default()))
+        .collect::<Vec<_>>();
+    for (asset_index, market) in markets.iter_mut().enumerate() {
+        header
+            .activate_empty_asset_slot_not_atomic(
+                asset_index as u32,
+                &mut market.engine,
+                100,
+                asset_index as u64 + 1,
+            )
+            .unwrap();
+    }
+
+    let occupied_source = |domain: usize| PortfolioSourceDomainV16Account {
+        domain: V16PodU32::new(domain as u32),
+        source_claim_market_id: V16PodU64::new(1),
+        source_claim_bound_num: V16PodU128::new(BOUND_SCALE),
+        ..PortfolioSourceDomainV16Account::default()
+    };
+
+    let mut full = fuzz_account([20; 32]);
+    for (domain, source) in full.source_domains.iter_mut().enumerate() {
+        *source = occupied_source(domain);
+    }
+    let full_before = full;
+    let candidate_asset_before = markets[CANDIDATE_ASSET].engine.asset;
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut full);
+        assert_eq!(
+            market.kani_attach_leg_at_slot(
+                &mut account,
+                CANDIDATE_ASSET,
+                SideV16::Long,
+                POS_SCALE as i128,
+                0,
+            ),
+            Err(V16Error::LockActive)
+        );
+    }
+    assert_eq!(full, full_before);
+    assert_eq!(
+        markets[CANDIDATE_ASSET].engine.asset,
+        candidate_asset_before
+    );
+
+    // A full table is safe when it already contains the candidate long's favorable short domain.
+    let mut represented = fuzz_account([21; 32]);
+    for (domain, source) in represented.source_domains.iter_mut().enumerate() {
+        *source = occupied_source(domain);
+    }
+    represented.source_domains[PORTFOLIO_SOURCE_DOMAIN_CAP - 1] =
+        occupied_source(CANDIDATE_ASSET * 2 + 1);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut represented);
+        assert!(market
+            .kani_attach_leg_at_slot(
+                &mut account,
+                CANDIDATE_ASSET,
+                SideV16::Long,
+                POS_SCALE as i128,
+                0,
+            )
+            .is_ok());
+    }
+
+    // An active leg reserves capacity even before its first favorable settlement creates a claim.
+    let mut reserved = fuzz_account([22; 32]);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut reserved);
+        market
+            .kani_attach_leg_at_slot(
+                &mut account,
+                EXISTING_ASSET,
+                SideV16::Long,
+                POS_SCALE as i128,
+                0,
+            )
+            .unwrap();
+    }
+    for domain in 0..PORTFOLIO_SOURCE_DOMAIN_CAP - 1 {
+        reserved.source_domains[domain] = occupied_source(domain);
+    }
+    let reserved_before = reserved;
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut reserved);
+        assert_eq!(
+            market.kani_attach_leg_at_slot(
+                &mut account,
+                CANDIDATE_ASSET,
+                SideV16::Long,
+                POS_SCALE as i128,
+                1,
+            ),
+            Err(V16Error::LockActive)
+        );
+    }
+    assert_eq!(reserved, reserved_before);
 }


### PR DESCRIPTION
## What changed

Reserve sparse source-domain capacity before admitting each new position. Capacity now accounts for both occupied historical claims and every active leg whose favorable K/F source domain has not been materialized yet.

The focused engine regression covers three boundaries: a full table rejects a missing favorable domain without mutation, a full table permits a domain already represented, and an active leg reserves its still-empty favorable domain.

## Root cause and impact

`attach_leg_at_slot` checked the 16-leg limit but did not reserve one of the portfolio's 32 sparse source slots for the leg's first favorable settlement. A user could publicly accumulate claims in all 32 domains, retain an old claim-bearing exposure, and open a new asset whose favorable domain was absent. After an honest mark move, settlement needed a 33rd source entry and returned `LockActive`.

The paired public LiteSVM red test shows that auto-crank, source-claim conversion, closing either position through `TradeNoCpi`, and `RebalanceReduce` all fail with rollback. The live portfolio has no bounded owner or permissionless keeper continuation; only privileged asset shutdown followed by forfeiture can rescue it.

This is also a concrete gap in the conditional no-DoS proof claim: the selector's refresh witness exists at the kernel level, but the real dispatch body fails at source insertion. The capacity invariant closes that monolithic gate-reachability case for newly admitted positions.

## Verification

- `cargo test --all-targets -- --test-threads=1`
- `cargo test --features fuzz --all-targets -- --test-threads=1`
- `cargo kani -Z function-contracts --features fuzz,contracts --harness composition_attach_body_frame_division_stubbed --output-format terse`
  - 6,137 checks, 159 unreachable, 1/1 cover, zero failures
- Paired wrapper test is RED on engine `143e68c4917ed0400a27b952f036a5677047cd84` at the no-continuation assertion.
- Paired wrapper branch passes 6 unit tests and all 566 LiteSVM/CU tests.
- Max-shape wrapper measurements after the O(1) compact-tail fast path:
  - 14-leg `BatchTradeNoCpi`: 1,308,173 CU
  - 14-leg `BatchTradeCpi`: 1,339,517 CU
  - 14-leg `BatchTradeCpi` with four maximum tail accounts: 1,343,687 CU
