### PR TITLE
[INVALID] Terminal residual probe did not reproduce a DoS

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1020,6 +1020,14 @@ If a rounding method would produce `sum(A_j) > X`, the payer MUST be charged the
 
 `SettlementRoundingResidue` is protocol-owned dust. It may be swept only into `UnallocatedProtocolSurplus` through a balanced `TokenValueFlowProof`. It MUST NOT be used as account health, source-credit backing, insurance credit, resolved payout entitlement, hedge collateral, or senior capital. This is the only sanctioned non-fee source of `unallocated_protocol_surplus` growth.
 
+After a market is resolved and its last materialized portfolio is empty and
+deregistered, no user or source claim can remain. Any vault atoms above capital,
+insurance, backing-provider earnings, and recoverable fresh backing are then
+terminal protocol surplus. The engine MUST move that exact residual to insurance
+through a balanced `TokenValueFlowProof`; it MUST preserve the vault and every
+senior class. A wrapper with per-domain insurance budgets MUST assign the delta
+to its canonical terminal-residual insurance domain before allowing withdrawal.
+
 
 For every close ledger entry, residual partition is an equality over quote atoms:
 

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -638,6 +638,28 @@ pub fn active_bitmap_count_ones(bitmap: V16ActiveBitmap) -> u32 {
 struct V16Core;
 
 impl V16Core {
+    fn terminal_residual_to_insurance_delta(
+        vault: u128,
+        c_tot: u128,
+        insurance: u128,
+        backing_provider_earnings: u128,
+        source_fresh_backing: u128,
+    ) -> V16Result<(u128, u128)> {
+        let senior = c_tot
+            .checked_add(insurance)
+            .and_then(|v| v.checked_add(backing_provider_earnings))
+            .and_then(|v| v.checked_add(source_fresh_backing))
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        if senior > vault {
+            return Err(V16Error::InvalidConfig);
+        }
+        let residual = vault - senior;
+        let next_insurance = insurance
+            .checked_add(residual)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        Ok((residual, next_insurance))
+    }
+
     fn loss_stale_trade_scope_allowed(
         market_loss_stale_active: bool,
         trade_asset_loss_stale: bool,
@@ -5061,6 +5083,17 @@ impl TokenValueFlowProofV16 {
         Ok(proof)
     }
 
+    fn terminal_protocol_surplus_to_insurance(
+        amount: u128,
+        vault_before: u128,
+        vault_after: u128,
+    ) -> V16Result<Self> {
+        let mut proof = Self::empty(vault_before, vault_after);
+        proof.debit(TokenValueClassV16::UnallocatedProtocolSurplus, amount)?;
+        proof.credit(TokenValueClassV16::InsuranceCapital, amount)?;
+        Ok(proof)
+    }
+
     fn external_in_to_insurance_capital(
         amount: u128,
         vault_before: u128,
@@ -7112,14 +7145,55 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if !account.is_empty_for_dematerialization()? {
             return Err(V16Error::LockActive);
         }
-        self.header.materialized_portfolio_count = V16PodU64::new(
-            self.header
-                .materialized_portfolio_count
-                .get()
-                .checked_sub(1)
-                .ok_or(V16Error::CounterUnderflow)?,
-        );
+        let next_count = self
+            .header
+            .materialized_portfolio_count
+            .get()
+            .checked_sub(1)
+            .ok_or(V16Error::CounterUnderflow)?;
+        self.header.materialized_portfolio_count = V16PodU64::new(next_count);
+        if next_count == 0 && decode_market_mode(self.header.mode)? == MarketModeV16::Resolved {
+            self.absorb_unclaimed_terminal_residual_into_insurance()?;
+        }
         self.validate_shape_audit_scan()
+    }
+
+    fn absorb_unclaimed_terminal_residual_into_insurance(&mut self) -> V16Result<u128> {
+        let payout_ledger = self.header.resolved_payout_ledger.try_to_runtime()?;
+        if self.header.materialized_portfolio_count.get() != 0
+            || self.header.c_tot.get() != 0
+            || self.header.pnl_pos_tot.get() != 0
+            || self.header.pnl_pos_bound_tot_num.get() != 0
+            || self.header.pnl_pos_bound_tot.get() != 0
+            || self.header.pnl_matured_pos_tot.get() != 0
+            || self.header.source_claim_bound_total_num.get() != 0
+            || self
+                .header
+                .source_insurance_credit_reserved_total_atoms
+                .get()
+                != 0
+            || self.header.resolved_payout_blocker_count.get() != 0
+            || self.header.stale_certificate_count.get() != 0
+            || self.header.b_stale_account_count.get() != 0
+            || self.header.negative_pnl_account_count.get() != 0
+            || payout_ledger.terminal_claim_bound_unreceipted_num != 0
+            || payout_ledger.payout_halted
+        {
+            return Err(V16Error::LockActive);
+        }
+
+        let vault = self.header.vault.get();
+        let (absorbed, next_insurance) = V16Core::terminal_residual_to_insurance_delta(
+            vault,
+            self.header.c_tot.get(),
+            self.header.insurance.get(),
+            self.backing_provider_earnings_total(),
+            self.source_fresh_backing_total_atoms(),
+        )?;
+        self.header.insurance = V16PodU128::new(next_insurance);
+        TokenValueFlowProofV16::terminal_protocol_surplus_to_insurance(absorbed, vault, vault)?
+            .validate()?;
+        Ok(absorbed)
     }
 
     #[cfg(kani)]

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -9,6 +9,22 @@
 use super::*;
 use crate::wide_math::U256;
 
+pub fn kani_terminal_residual_to_insurance_delta(
+    vault: u128,
+    c_tot: u128,
+    insurance: u128,
+    backing_provider_earnings: u128,
+    source_fresh_backing: u128,
+) -> V16Result<(u128, u128)> {
+    V16Core::terminal_residual_to_insurance_delta(
+        vault,
+        c_tot,
+        insurance,
+        backing_provider_earnings,
+        source_fresh_backing,
+    )
+}
+
 pub fn kani_apply_backing_utilization_fee_charge(
     account_capital: u128,
     group_c_tot: u128,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -16,13 +16,14 @@ use percolator::v16::{
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
     kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
     kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
-    kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
-    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
-    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
-    BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
-    CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
-    HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
-    Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
+    kani_target_effective_lag_adverse_delta, kani_terminal_residual_to_insurance_delta,
+    kani_trade_preexisting_oi_reduction_gate, kani_trade_preflight_risk_gate,
+    kani_validate_positive_pnl_source_attribution, AssetLifecycleV16, AssetStateV16,
+    AssetStateV16Account, BackingBucketStatusV16, BackingBucketV16, BackingBucketV16Account,
+    BatchTradeOutcomeV16, CloseProgressLedgerV16, CloseProgressLedgerV16Account,
+    EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16, HealthCertV16Account,
+    InsuranceCreditReservationV16, InsuranceCreditReservationV16Account, Market,
+    MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
     PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
@@ -35,6 +36,7 @@ use percolator::v16::{
     BACKING_FEE_RATE_DEN_E9, MAX_BACKING_FEE_RATE_E9_PER_SLOT, MAX_BACKING_FEE_UTIL_BPS,
     PORTFOLIO_SOURCE_DOMAIN_CAP, V16_EMPTY_ACTIVE_BITMAP, V16_MAX_PORTFOLIO_ASSETS_N,
 };
+
 use percolator::v16::{
     kani_eq_engine_asset_slot_v16_account, kani_eq_market_group_v16_header_account,
     kani_eq_portfolio_account_v16_account,
@@ -44,6 +46,36 @@ use percolator::{
     MAX_ORACLE_PRICE, MAX_POSITION_ABS_Q, MAX_TRADE_SIZE_Q, MAX_VAULT_TVL, POS_SCALE,
     SOCIAL_LOSS_DEN, V16_ACTIVE_BITMAP_WORDS,
 };
+
+#[kani::proof]
+fn proof_v16_terminal_residual_escheat_preserves_every_senior_class() {
+    let vault: u128 = kani::any();
+    let c_tot: u128 = kani::any();
+    let insurance: u128 = kani::any();
+    let backing_provider_earnings: u128 = kani::any();
+    let source_fresh_backing: u128 = kani::any();
+    kani::assume(c_tot <= vault);
+    kani::assume(insurance <= vault - c_tot);
+    kani::assume(backing_provider_earnings <= vault - c_tot - insurance);
+    kani::assume(source_fresh_backing <= vault - c_tot - insurance - backing_provider_earnings);
+
+    let senior_before = c_tot + insurance + backing_provider_earnings + source_fresh_backing;
+    let (absorbed, next_insurance) = kani_terminal_residual_to_insurance_delta(
+        vault,
+        c_tot,
+        insurance,
+        backing_provider_earnings,
+        source_fresh_backing,
+    )
+    .unwrap();
+
+    assert_eq!(absorbed, vault - senior_before);
+    assert_eq!(next_insurance, insurance + absorbed);
+    assert_eq!(
+        c_tot + next_insurance + backing_provider_earnings + source_fresh_backing,
+        vault
+    );
+}
 
 fn ids() -> ([u8; 32], [u8; 32], [u8; 32]) {
     ([1; 32], [2; 32], [3; 32])
@@ -624,7 +656,7 @@ fn proof_v16_public_materialized_portfolio_register_is_value_neutral() {
 #[kani::proof]
 #[kani::unwind(64)]
 #[kani::solver(cadical)]
-fn proof_v16_public_materialized_portfolio_deregister_is_value_neutral() {
+fn proof_v16_public_live_materialized_portfolio_deregister_is_value_neutral() {
     let count_raw: u8 = kani::any();
     let c_tot_raw: u8 = kani::any();
     let insurance_raw: u8 = kani::any();
@@ -664,6 +696,46 @@ fn proof_v16_public_materialized_portfolio_deregister_is_value_neutral() {
         Ok(()),
         "deregistering an empty portfolio must not mutate account safety shape"
     );
+}
+
+#[kani::proof]
+#[kani::unwind(64)]
+#[kani::solver(cadical)]
+fn proof_v16_public_last_resolved_portfolio_deregister_escheats_only_terminal_residual() {
+    let insurance_raw: u8 = kani::any();
+    let residual_raw: u8 = kani::any();
+
+    let (mut header, mut markets, account_header) = one_market_view_fixture();
+    header.materialized_portfolio_count = V16PodU64::new(1);
+    header.insurance = V16PodU128::new(insurance_raw as u128);
+    header.vault = V16PodU128::new(insurance_raw as u128 + residual_raw as u128);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        market.resolve_market_not_atomic(1).unwrap();
+    }
+
+    let vault_before = header.vault.get();
+    let insurance_before = header.insurance.get();
+    let risk_epoch_before = header.risk_epoch.get();
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let account = PortfolioV16View::new(&account_header);
+    let result = market.deregister_empty_materialized_portfolio_not_atomic(&account);
+
+    kani::cover!(
+        insurance_raw > 2 && residual_raw > 2,
+        "last resolved deregister covers existing insurance and nontrivial terminal residual"
+    );
+    assert_eq!(result, Ok(()));
+    assert_eq!(market.header.materialized_portfolio_count.get(), 0);
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), 0);
+    assert_eq!(
+        market.header.insurance.get(),
+        insurance_before + residual_raw as u128
+    );
+    assert_eq!(market.header.risk_epoch.get(), risk_epoch_before);
+    assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
+    assert_eq!(market.validate_shape(), Ok(()));
 }
 
 #[kani::proof]

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -160,6 +160,36 @@ fn v16_view_deposit_and_withdraw_are_the_tested_paths() {
 }
 
 #[test]
+fn v16_last_resolved_portfolio_escheats_unclaimed_residual_to_insurance() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let first_account_header = account_fixture(1, 4);
+    let last_account_header = account_fixture(1, 5);
+    header.materialized_portfolio_count = V16PodU64::new(2);
+    header.vault = V16PodU128::new(100_000);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    market.resolve_market_not_atomic(2).unwrap();
+    let first_account = PortfolioV16View::new(&first_account_header);
+    market
+        .deregister_empty_materialized_portfolio_not_atomic(&first_account)
+        .unwrap();
+
+    assert_eq!(market.header.materialized_portfolio_count.get(), 1);
+    assert_eq!(market.header.insurance.get(), 0);
+
+    let last_account = PortfolioV16View::new(&last_account_header);
+    market
+        .deregister_empty_materialized_portfolio_not_atomic(&last_account)
+        .unwrap();
+
+    assert_eq!(market.header.materialized_portfolio_count.get(), 0);
+    assert_eq!(market.header.vault.get(), 100_000);
+    assert_eq!(market.header.c_tot.get(), 0);
+    assert_eq!(market.header.insurance.get(), 100_000);
+    market.validate_shape().unwrap();
+}
+
+#[test]
 fn v16_funding_counter_layout_canary_places_fields_before_fee_state() {
     let width = core::mem::size_of::<V16PodU128>();
 


### PR DESCRIPTION
Closed after completing the public continuation sweep. The observed vault value is `source_fresh_backing_total_num`, an intentionally senior provider-withdrawable stock class. A public `WithdrawBackingBucket` followed by `CloseSlab` succeeds, so the original test did not establish all-path terminal DoS. The proposed terminal-residual escheat also intentionally excluded this senior class and therefore did not fix the observed path. No finding retained.