### PR TITLE
[REAL LoF] Retire B losses from their source domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 244 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 249 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -8844,51 +8844,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
             let d = source_snapshot.domain.get() as usize;
             self.domain_asset_side(d)?;
-            let burnable = Self::source_claim_unliened_num(&account.as_view(), d)?;
-            let burn = burnable.min(burn_num);
-            if burn != 0 {
-                self.decrement_account_source_claim_for_domain_not_atomic(account, slot, d, burn)?;
-                burn_num -= burn;
-            }
-            if burn_num != 0 {
-                let liened_burn = account.header.source_domains[slot]
-                    .source_claim_liened_num
-                    .get()
-                    .min(burn_num);
-                if liened_burn != 0 {
-                    self.burn_account_source_lien_face_not_atomic(account, slot, d, liened_burn)?;
-                    burn_num -= liened_burn;
-                }
-            }
-            if burn_num != 0 {
-                let (impaired_burn, impaired_effective_burn) =
-                    Self::burn_impaired_account_source_claim_fields(account, slot, burn_num)?;
-                if impaired_burn != 0 {
-                    if decode_market_mode(self.header.mode)? == MarketModeV16::Resolved
-                        && impaired_effective_burn != 0
-                    {
-                        let impaired_insurance_backing =
-                            V16Core::bound_num_from_amount(impaired_effective_burn)?;
-                        self.release_source_credit_lien_from_insurance_terminal_not_atomic(
-                            d,
-                            impaired_insurance_backing,
-                        )?;
-                    }
-                    let mut source_credit = self.source_credit_for_domain(d)?;
-                    source_credit.positive_claim_bound_num = source_credit
-                        .positive_claim_bound_num
-                        .checked_sub(impaired_burn)
-                        .ok_or(V16Error::CounterUnderflow)?;
-                    source_credit.exact_positive_claim_num = source_credit
-                        .exact_positive_claim_num
-                        .checked_sub(impaired_burn.min(source_credit.exact_positive_claim_num))
-                        .ok_or(V16Error::CounterUnderflow)?;
-                    burn_num -= impaired_burn;
-                    self.set_source_credit_for_domain(d, source_credit)?;
-                    account.reset_source_domain_slot_if_empty(slot);
-                    self.recompute_source_credit_domain_after_mutation(d)?;
-                }
-            }
+            let burned =
+                self.burn_account_source_claim_at_slot_up_to(account, slot, d, burn_num)?;
+            burn_num = burn_num
+                .checked_sub(burned)
+                .ok_or(V16Error::CounterUnderflow)?;
             slot += 1;
         }
         if burn_num != 0 {
@@ -8896,6 +8856,96 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         account.compact_source_domains();
         Ok(())
+    }
+
+    fn burn_account_source_claim_at_slot_up_to(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        slot: usize,
+        domain: usize,
+        burn_num: u128,
+    ) -> V16Result<u128> {
+        if burn_num == 0 {
+            return Ok(0);
+        }
+        if slot >= PORTFOLIO_SOURCE_DOMAIN_CAP || account.source_domain_slot(domain)? != Some(slot)
+        {
+            return Err(V16Error::CounterUnderflow);
+        }
+        let target = burn_num.min(
+            account.header.source_domains[slot]
+                .source_claim_bound_num
+                .get(),
+        );
+        let mut remaining = target;
+
+        let burn = Self::source_claim_unliened_num(&account.as_view(), domain)?.min(remaining);
+        if burn != 0 {
+            self.decrement_account_source_claim_for_domain_not_atomic(account, slot, domain, burn)?;
+            remaining -= burn;
+        }
+        if remaining != 0 {
+            let liened_burn = account.header.source_domains[slot]
+                .source_claim_liened_num
+                .get()
+                .min(remaining);
+            if liened_burn != 0 {
+                self.burn_account_source_lien_face_not_atomic(account, slot, domain, liened_burn)?;
+                remaining -= liened_burn;
+            }
+        }
+        if remaining != 0 {
+            let (impaired_burn, impaired_effective_burn) =
+                Self::burn_impaired_account_source_claim_fields(account, slot, remaining)?;
+            if impaired_burn != 0 {
+                if decode_market_mode(self.header.mode)? == MarketModeV16::Resolved
+                    && impaired_effective_burn != 0
+                {
+                    let impaired_insurance_backing =
+                        V16Core::bound_num_from_amount(impaired_effective_burn)?;
+                    self.release_source_credit_lien_from_insurance_terminal_not_atomic(
+                        domain,
+                        impaired_insurance_backing,
+                    )?;
+                }
+                let mut source_credit = self.source_credit_for_domain(domain)?;
+                source_credit.positive_claim_bound_num = source_credit
+                    .positive_claim_bound_num
+                    .checked_sub(impaired_burn)
+                    .ok_or(V16Error::CounterUnderflow)?;
+                source_credit.exact_positive_claim_num = source_credit
+                    .exact_positive_claim_num
+                    .checked_sub(impaired_burn.min(source_credit.exact_positive_claim_num))
+                    .ok_or(V16Error::CounterUnderflow)?;
+                self.set_source_credit_for_domain(domain, source_credit)?;
+                account.reset_source_domain_slot_if_empty(slot);
+                self.recompute_source_credit_domain_after_mutation(domain)?;
+                remaining -= impaired_burn;
+            }
+        }
+        if remaining != 0 {
+            return Err(V16Error::LockActive);
+        }
+        Ok(target)
+    }
+
+    fn burn_account_source_claim_bound_num_for_domain_up_to(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        domain: usize,
+        burn_num: u128,
+    ) -> V16Result<u128> {
+        if burn_num == 0 {
+            return Ok(0);
+        }
+        self.domain_asset_side(domain)?;
+        let Some(slot) = account.source_domain_slot(domain)? else {
+            return Ok(0);
+        };
+        let burned =
+            self.burn_account_source_claim_at_slot_up_to(account, slot, domain, burn_num)?;
+        account.compact_source_domains();
+        Ok(burned)
     }
 
     fn source_domain_realizable_support_for_face(
@@ -10184,7 +10234,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
         new_pnl: i128,
     ) -> V16Result<()> {
-        self.set_account_pnl_inner(account, new_pnl, None)
+        self.set_account_pnl_inner(account, new_pnl, None, 0)
     }
 
     fn set_account_pnl_with_source(
@@ -10194,7 +10244,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         source_domain: usize,
     ) -> V16Result<()> {
         self.domain_asset_side(source_domain)?;
-        self.set_account_pnl_inner(account, new_pnl, Some(source_domain))
+        self.set_account_pnl_inner(account, new_pnl, Some(source_domain), 0)
+    }
+
+    fn set_account_pnl_after_source_claim_burn(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        new_pnl: i128,
+        source_face_burn_num: u128,
+    ) -> V16Result<()> {
+        self.set_account_pnl_inner(account, new_pnl, None, source_face_burn_num)
     }
 
     /// Grants source-attributed positive PnL to an account — the first-class
@@ -10235,11 +10294,15 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
         new_pnl: i128,
         source_domain: Option<usize>,
+        preburned_source_claim_num: u128,
     ) -> V16Result<()> {
         validate_non_min_i128(new_pnl)?;
         let old_pos = account.header.pnl.get().max(0) as u128;
         let new_pos = new_pnl.max(0) as u128;
         if new_pos >= old_pos {
+            if preburned_source_claim_num != 0 {
+                return Err(V16Error::InvalidConfig);
+            }
             let increase = new_pos - old_pos;
             let increase_num = V16Core::bound_num_from_amount(increase)?;
             let increase_domain = if increase_num != 0 {
@@ -10296,7 +10359,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         } else {
             let decrease = old_pos - new_pos;
             let decrease_num = V16Core::bound_num_from_amount(decrease)?;
-            self.burn_account_source_claim_bound_num(account, decrease_num)?;
+            let remaining_source_claim_burn = decrease_num
+                .checked_sub(preburned_source_claim_num)
+                .ok_or(V16Error::CounterUnderflow)?;
+            self.burn_account_source_claim_bound_num(account, remaining_source_claim_burn)?;
             self.header.pnl_pos_tot = V16PodU128::new(
                 self.header
                     .pnl_pos_tot
@@ -11377,7 +11443,15 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             chunk.remaining_after,
         )?;
         account.header.legs[leg_slot] = PortfolioLegV16Account::from_runtime(&leg);
-        self.set_account_pnl(account, new_pnl)?;
+        let positive_pnl_loss = old_pnl.max(0) as u128 - new_pnl.max(0) as u128;
+        let positive_pnl_loss_num = V16Core::bound_num_from_amount(positive_pnl_loss)?;
+        let source_domain = self.insurance_domain_index(asset_index, opposite_side(leg.side))?;
+        let source_burn_num = self.burn_account_source_claim_bound_num_for_domain_up_to(
+            account,
+            source_domain,
+            positive_pnl_loss_num,
+        )?;
+        self.set_account_pnl_after_source_claim_burn(account, new_pnl, source_burn_num)?;
         if chunk.remaining_after != 0 {
             self.mark_account_b_stale(account)?;
         } else if !Self::has_b_stale_leg(&account.as_view())? {

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -8868,8 +8868,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if burn_num == 0 {
             return Ok(0);
         }
-        if slot >= PORTFOLIO_SOURCE_DOMAIN_CAP || account.source_domain_slot(domain)? != Some(slot)
-        {
+        if slot >= PORTFOLIO_SOURCE_DOMAIN_CAP {
+            return Err(V16Error::CounterUnderflow);
+        }
+        let source = account.header.source_domains[slot];
+        if !source.is_occupied() || source.domain.get() as usize != domain {
             return Err(V16Error::CounterUnderflow);
         }
         let target = burn_num.min(

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -907,6 +907,9 @@ impl V16Core {
             return Ok(CREDIT_RATE_SCALE);
         }
         let available = Self::available_backing_num_for_source_credit_state(state)?;
+        if available == 0 {
+            return Ok(0);
+        }
         let rate = U256::from_u128(available)
             .checked_mul(U256::from_u128(CREDIT_RATE_SCALE))
             .and_then(|v| v.checked_div(U256::from_u128(state.positive_claim_bound_num)))
@@ -1050,6 +1053,15 @@ impl V16Core {
             source,
             risk_epoch.checked_add(1).ok_or(V16Error::CounterOverflow)?,
         ))
+    }
+
+    #[inline]
+    fn source_claim_domain_first_burn_partition(
+        source_claim_num: u128,
+        burn_num: u128,
+    ) -> (u128, u128) {
+        let source_burn_num = source_claim_num.min(burn_num);
+        (source_burn_num, burn_num - source_burn_num)
     }
 
     #[cfg(any(kani, feature = "fuzz"))]
@@ -8932,23 +8944,30 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(target)
     }
 
-    fn burn_account_source_claim_bound_num_for_domain_up_to(
+    fn burn_account_source_claim_bound_num_domain_first(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
         domain: usize,
         burn_num: u128,
-    ) -> V16Result<u128> {
+    ) -> V16Result<()> {
         if burn_num == 0 {
-            return Ok(0);
+            return Ok(());
         }
         self.domain_asset_side(domain)?;
-        let Some(slot) = account.source_domain_slot(domain)? else {
-            return Ok(0);
+        let slot = account.source_domain_slot(domain)?;
+        let source_claim_num = match slot {
+            Some(slot) => account.header.source_domains[slot]
+                .source_claim_bound_num
+                .get(),
+            None => 0,
         };
-        let burned =
-            self.burn_account_source_claim_at_slot_up_to(account, slot, domain, burn_num)?;
-        account.compact_source_domains();
-        Ok(burned)
+        let (source_burn_num, fallback_burn_num) =
+            V16Core::source_claim_domain_first_burn_partition(source_claim_num, burn_num);
+        if let Some(slot) = slot {
+            self.burn_account_source_claim_at_slot_up_to(account, slot, domain, source_burn_num)?;
+            account.compact_source_domains();
+        }
+        self.burn_account_source_claim_bound_num(account, fallback_burn_num)
     }
 
     fn source_domain_realizable_support_for_face(
@@ -10259,6 +10278,26 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.set_account_pnl_inner(account, new_pnl, None, source_face_burn_num)
     }
 
+    fn set_account_pnl_after_domain_first_source_claim_burn(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        new_pnl: i128,
+        source_domain: usize,
+    ) -> V16Result<()> {
+        let old_pos = account.header.pnl.get().max(0) as u128;
+        let new_pos = new_pnl.max(0) as u128;
+        let decrease = old_pos
+            .checked_sub(new_pos)
+            .ok_or(V16Error::InvalidConfig)?;
+        let decrease_num = V16Core::bound_num_from_amount(decrease)?;
+        self.burn_account_source_claim_bound_num_domain_first(
+            account,
+            source_domain,
+            decrease_num,
+        )?;
+        self.set_account_pnl_after_source_claim_burn(account, new_pnl, decrease_num)
+    }
+
     /// Grants source-attributed positive PnL to an account — the first-class
     /// API for crediting a source-backed claim (e.g. an external settlement
     /// feed). Live-mode only. The grant is pure notional attribution: no quote
@@ -11446,15 +11485,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             chunk.remaining_after,
         )?;
         account.header.legs[leg_slot] = PortfolioLegV16Account::from_runtime(&leg);
-        let positive_pnl_loss = old_pnl.max(0) as u128 - new_pnl.max(0) as u128;
-        let positive_pnl_loss_num = V16Core::bound_num_from_amount(positive_pnl_loss)?;
         let source_domain = self.insurance_domain_index(asset_index, opposite_side(leg.side))?;
-        let source_burn_num = self.burn_account_source_claim_bound_num_for_domain_up_to(
-            account,
-            source_domain,
-            positive_pnl_loss_num,
-        )?;
-        self.set_account_pnl_after_source_claim_burn(account, new_pnl, source_burn_num)?;
+        self.set_account_pnl_after_domain_first_source_claim_burn(account, new_pnl, source_domain)?;
         if chunk.remaining_after != 0 {
             self.mark_account_b_stale(account)?;
         } else if !Self::has_b_stale_leg(&account.as_view())? {

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -181,6 +181,13 @@ pub fn kani_available_backing_num_for_source_credit_state(
     V16Core::available_backing_num_for_source_credit_state(state)
 }
 
+pub fn kani_source_claim_domain_first_burn_partition(
+    source_claim_num: u128,
+    burn_num: u128,
+) -> (u128, u128) {
+    V16Core::source_claim_domain_first_burn_partition(source_claim_num, burn_num)
+}
+
 pub fn kani_loss_stale_trade_scope_allowed(
     market_loss_stale_active: bool,
     trade_asset_loss_stale: bool,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -797,6 +797,15 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.set_account_pnl(account, new_pnl)
     }
 
+    pub fn kani_settle_account_b_chunk(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        asset_index: usize,
+        endpoint_delta_budget: u128,
+    ) -> V16Result<AccountBSettlementChunkV16> {
+        self.settle_account_b_chunk(account, asset_index, endpoint_delta_budget)
+    }
+
     pub fn kani_apply_signed_kf_delta_to_pnl(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -15,14 +15,15 @@ use percolator::v16::{
     kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
     kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
-    kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
-    kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
-    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
-    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
-    BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
-    CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
-    HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
-    Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
+    kani_prepare_asset_recovery_transition, kani_source_claim_domain_first_burn_partition,
+    kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
+    kani_trade_preexisting_oi_reduction_gate, kani_trade_preflight_risk_gate,
+    kani_validate_positive_pnl_source_attribution, AssetLifecycleV16, AssetStateV16,
+    AssetStateV16Account, BackingBucketStatusV16, BackingBucketV16, BackingBucketV16Account,
+    BatchTradeOutcomeV16, CloseProgressLedgerV16, CloseProgressLedgerV16Account,
+    EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16, HealthCertV16Account,
+    InsuranceCreditReservationV16, InsuranceCreditReservationV16Account, Market,
+    MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
     PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
@@ -1284,6 +1285,62 @@ fn proof_v16_mutable_view_compacts_persisted_source_domain_tail() {
     let source = view.kani_source_domain(0).unwrap();
     assert_eq!(source.source_claim_market_id.get(), 1);
     assert_eq!(source.source_claim_bound_num.get(), claim_num);
+}
+
+// Domain-isolation theorem for every representable two-domain claim rank. The
+// affected domain is exhausted before fallback can touch an unrelated domain,
+// while the aggregate claim rank falls by exactly the requested B loss.
+#[kani::proof]
+#[kani::solver(cadical)]
+fn proof_v16_source_claim_burn_partition_is_domain_first_conservative_and_isolated() {
+    let source_claim_num: u128 = kani::any();
+    let unrelated_claim_num: u128 = kani::any();
+    let burn_num: u128 = kani::any();
+    let Some(total_claim_num) = source_claim_num.checked_add(unrelated_claim_num) else {
+        kani::assume(false);
+        return;
+    };
+    kani::assume(burn_num <= total_claim_num);
+
+    let (source_burn_num, fallback_burn_num) =
+        kani_source_claim_domain_first_burn_partition(source_claim_num, burn_num);
+    let source_after = source_claim_num.checked_sub(source_burn_num).unwrap();
+    let unrelated_after = unrelated_claim_num.checked_sub(fallback_burn_num).unwrap();
+
+    assert!(source_burn_num <= source_claim_num);
+    assert!(source_burn_num <= burn_num);
+    assert!(fallback_burn_num <= unrelated_claim_num);
+    assert_eq!(
+        source_burn_num.checked_add(fallback_burn_num),
+        Some(burn_num)
+    );
+    assert_eq!(
+        source_after.checked_add(unrelated_after),
+        total_claim_num.checked_sub(burn_num)
+    );
+    if burn_num <= source_claim_num {
+        assert_eq!(fallback_burn_num, 0);
+        assert_eq!(unrelated_after, unrelated_claim_num);
+    } else {
+        assert_eq!(source_after, 0);
+        assert_eq!(fallback_burn_num, burn_num - source_claim_num);
+    }
+
+    kani::cover!(
+        burn_num > 0 && burn_num < source_claim_num && unrelated_claim_num > 0,
+        "partial source burn frames an unrelated claim"
+    );
+    kani::cover!(
+        source_claim_num > 0
+            && unrelated_claim_num > 0
+            && burn_num > source_claim_num
+            && burn_num < total_claim_num,
+        "fallback burns only a strict uncovered remainder"
+    );
+    kani::cover!(
+        total_claim_num > 1 && burn_num == total_claim_num,
+        "the exact aggregate claim rank can be retired"
+    );
 }
 
 #[kani::proof]

--- a/tests/v16_fuzzing.rs
+++ b/tests/v16_fuzzing.rs
@@ -274,6 +274,47 @@ fn v16_b_loss_preserves_the_unburned_part_of_a_matching_insurance_lien() {
     assert_eq!(after.target_valid_insurance_num, 50 * BOUND_SCALE);
 }
 
+#[test]
+fn v16_source_claim_burn_crosses_a_just_emptied_sparse_slot() {
+    let (market_id, _, _, owner) = ids();
+    let cfg = V16Config::public_user_fund_with_market_slots(2, 2, 0, 10);
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_id, cfg, 2, 0).unwrap();
+    let mut markets = vec![
+        Market::new(0u64, EngineAssetSlotV16Account::default()),
+        Market::new(1u64, EngineAssetSlotV16Account::default()),
+    ];
+    for (asset_index, market) in markets.iter_mut().enumerate() {
+        header
+            .activate_empty_asset_slot_not_atomic(
+                asset_index as u32,
+                &mut market.engine,
+                100,
+                (asset_index + 1) as u64,
+            )
+            .unwrap();
+    }
+    let mut account_header = PortfolioAccountV16Account::default();
+    account_header
+        .init_empty_in_place(ProvenanceHeaderV16Account::from_runtime(
+            &ProvenanceHeaderV16::new(market_id, [11; 32], owner),
+        ))
+        .unwrap();
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market
+        .add_account_source_positive_pnl_not_atomic(&mut account, 1, 100)
+        .unwrap();
+    market
+        .add_account_source_positive_pnl_not_atomic(&mut account, 3, 100)
+        .unwrap();
+
+    market.kani_set_account_pnl(&mut account, 0).unwrap();
+    assert_eq!(account.header.pnl.get(), 0);
+    assert_eq!(source_claim_num(account.header, 1), 0);
+    assert_eq!(source_claim_num(account.header, 3), 0);
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_with_svm_rollback(
     header: &mut MarketGroupV16HeaderAccount,

--- a/tests/v16_fuzzing.rs
+++ b/tests/v16_fuzzing.rs
@@ -5,8 +5,9 @@ use percolator::{
     MarketGroupV16ViewMut, PermissionlessCrankActionV16, PermissionlessCrankRequestV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioV16View,
     PortfolioV16ViewMut, ProvenanceHeaderV16, ProvenanceHeaderV16Account, TradeRequestV16,
-    V16Config, V16Error,
+    V16Config, V16Error, V16PodU128,
 };
+use percolator::{BOUND_SCALE, POS_SCALE, SOCIAL_LOSS_DEN};
 use proptest::prelude::*;
 
 fn ids() -> ([u8; 32], [u8; 32], [u8; 32], [u8; 32]) {
@@ -63,6 +64,214 @@ fn assert_fuzz_invariants(
         .map(|pnl| pnl as u128)
         .sum::<u128>();
     assert_eq!(market.header.pnl_pos_tot.get(), positive_pnl);
+}
+
+fn source_claim_num(account: &PortfolioAccountV16Account, domain: usize) -> u128 {
+    account
+        .source_domains
+        .iter()
+        .find(|source| {
+            source.source_claim_market_id.get() != 0 && source.domain.get() as usize == domain
+        })
+        .map(|source| source.source_claim_bound_num.get())
+        .unwrap_or(0)
+}
+
+struct TwoDomainBSettlement {
+    other_claim_num: u128,
+    target_claim_num: u128,
+    target_lien_num: u128,
+    target_valid_backing_num: u128,
+    target_valid_insurance_num: u128,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TargetLienBacking {
+    None,
+    Counterparty,
+    Insurance,
+}
+
+fn settle_two_domain_b_loss(
+    target_claim: u128,
+    other_claim: u128,
+    loss: u128,
+    target_lien: u128,
+    target_lien_backing: TargetLienBacking,
+) -> TwoDomainBSettlement {
+    let (market_id, _, _, owner) = ids();
+    let mut cfg = V16Config::public_user_fund_with_market_slots(2, 2, 0, 10);
+    cfg.public_b_chunk_atoms = loss.max(1);
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_id, cfg, 2, 0).unwrap();
+    let mut markets = vec![
+        Market::new(0u64, EngineAssetSlotV16Account::default()),
+        Market::new(1u64, EngineAssetSlotV16Account::default()),
+    ];
+    for (asset_index, market) in markets.iter_mut().enumerate() {
+        header
+            .activate_empty_asset_slot_not_atomic(
+                asset_index as u32,
+                &mut market.engine,
+                100,
+                (asset_index + 1) as u64,
+            )
+            .unwrap();
+    }
+    let mut long_header = PortfolioAccountV16Account::default();
+    long_header
+        .init_empty_in_place(ProvenanceHeaderV16Account::from_runtime(
+            &ProvenanceHeaderV16::new(market_id, [9; 32], owner),
+        ))
+        .unwrap();
+    let mut short_header = PortfolioAccountV16Account::default();
+    short_header
+        .init_empty_in_place(ProvenanceHeaderV16Account::from_runtime(
+            &ProvenanceHeaderV16::new(market_id, [10; 32], owner),
+        ))
+        .unwrap();
+
+    let loss_weight = {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market.deposit_not_atomic(&mut long, 10_000).unwrap();
+        market.deposit_not_atomic(&mut short, 10_000).unwrap();
+        match target_lien_backing {
+            TargetLienBacking::None => {}
+            TargetLienBacking::Counterparty => market
+                .deposit_fresh_counterparty_backing_not_atomic(3, 1_000, 100)
+                .unwrap(),
+            TargetLienBacking::Insurance => {
+                market
+                    .deposit_domain_insurance_not_atomic(3, 1_000)
+                    .unwrap();
+                market
+                    .reserve_insurance_credit_not_atomic(3, 1_000 * BOUND_SCALE)
+                    .unwrap();
+            }
+        }
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 1,
+                    size_q: POS_SCALE as i128,
+                    exec_price: 100,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+        market
+            .add_account_source_positive_pnl_not_atomic(&mut long, 1, other_claim)
+            .unwrap();
+        market
+            .add_account_source_positive_pnl_not_atomic(&mut long, 3, target_claim)
+            .unwrap();
+        if target_lien != 0 {
+            long.header.health_cert.certified_initial_req =
+                V16PodU128::new(long.header.capital.get() + target_lien);
+            long.header.health_cert.valid = 1;
+            market
+                .kani_create_initial_margin_source_lien_if_needed(&mut long)
+                .unwrap();
+            assert_eq!(
+                source_claim_num(&*long.header, 3),
+                target_claim * BOUND_SCALE
+            );
+            let target_source = long
+                .header
+                .source_domains
+                .iter()
+                .find(|source| {
+                    source.source_claim_market_id.get() != 0 && source.domain.get() as usize == 3
+                })
+                .expect("target-domain claim");
+            assert_eq!(
+                target_source.source_claim_liened_num.get(),
+                target_lien * BOUND_SCALE
+            );
+        }
+        long.header
+            .legs
+            .iter()
+            .find_map(|leg| {
+                let leg = leg.try_to_runtime().ok()?;
+                (leg.active && leg.asset_index == 1).then_some(leg.loss_weight)
+            })
+            .unwrap()
+    };
+    let delta_b = loss
+        .checked_mul(SOCIAL_LOSS_DEN)
+        .unwrap()
+        .checked_div(loss_weight)
+        .unwrap();
+    markets[1].engine.asset.b_long_num = V16PodU128::new(delta_b);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let outcome = market
+        .kani_settle_account_b_chunk(&mut long, 1, delta_b)
+        .unwrap();
+    assert_eq!(outcome.loss, loss);
+    let target_source = long_header
+        .source_domains
+        .iter()
+        .find(|source| {
+            source.source_claim_market_id.get() != 0 && source.domain.get() as usize == 3
+        })
+        .copied()
+        .unwrap_or_default();
+    TwoDomainBSettlement {
+        other_claim_num: source_claim_num(&long_header, 1),
+        target_claim_num: source_claim_num(&long_header, 3),
+        target_lien_num: target_source.source_claim_liened_num.get(),
+        target_valid_backing_num: markets[1]
+            .engine
+            .backing_short
+            .try_to_runtime()
+            .unwrap()
+            .valid_liened_backing_num,
+        target_valid_insurance_num: markets[1]
+            .engine
+            .insurance_reservation_short
+            .try_to_runtime()
+            .unwrap()
+            .valid_liened_insurance_num,
+    }
+}
+
+#[test]
+fn v16_b_loss_burns_the_matching_source_domain_before_sparse_slot_order() {
+    let after = settle_two_domain_b_loss(100, 100, 50, 0, TargetLienBacking::None);
+    assert_eq!(after.other_claim_num, 100 * BOUND_SCALE);
+    assert_eq!(after.target_claim_num, 50 * BOUND_SCALE);
+}
+
+#[test]
+fn v16_b_loss_falls_back_to_cross_margin_claims_after_its_domain_is_exhausted() {
+    let after = settle_two_domain_b_loss(20, 100, 50, 0, TargetLienBacking::None);
+    assert_eq!(after.target_claim_num, 0);
+    assert_eq!(after.other_claim_num, 70 * BOUND_SCALE);
+}
+
+#[test]
+fn v16_b_loss_preserves_the_unburned_part_of_a_matching_source_lien() {
+    let after = settle_two_domain_b_loss(100, 100, 50, 80, TargetLienBacking::Counterparty);
+    assert_eq!(after.other_claim_num, 100 * BOUND_SCALE);
+    assert_eq!(after.target_claim_num, 50 * BOUND_SCALE);
+    assert_eq!(after.target_lien_num, 50 * BOUND_SCALE);
+    assert_eq!(after.target_valid_backing_num, 50 * BOUND_SCALE);
+}
+
+#[test]
+fn v16_b_loss_preserves_the_unburned_part_of_a_matching_insurance_lien() {
+    let after = settle_two_domain_b_loss(100, 100, 50, 80, TargetLienBacking::Insurance);
+    assert_eq!(after.other_claim_num, 100 * BOUND_SCALE);
+    assert_eq!(after.target_claim_num, 50 * BOUND_SCALE);
+    assert_eq!(after.target_lien_num, 50 * BOUND_SCALE);
+    assert_eq!(after.target_valid_backing_num, 0);
+    assert_eq!(after.target_valid_insurance_num, 50 * BOUND_SCALE);
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## Impact

B/social-loss settlement reduced aggregate positive PnL in sparse portfolio-slot order instead of retiring the claim in the bankrupt asset's source domain first. A multi-asset winner could therefore burn an unrelated claim, preserve the claim backed by the affected asset, and realize that preserved claim against an independent canonical provider during terminal close.

The reproduction uses normally initialized engine state and public-equivalent transitions. Asset 0's short-source claim occupies an earlier portfolio slot, asset 1's short-source claim is backed by an independent provider, and an asset-1 bankruptcy creates B loss. Before this fix, settling B burned asset 0's claim first and left the asset-1 claim extractable.

## Root cause

`settle_account_b_chunk` computed the affected asset but delegated its positive-PnL reduction to aggregate `set_account_pnl`, whose source-claim traversal intentionally follows sparse account-slot order. That order is valid for generic aggregate reductions but not for asset-scoped B loss.

## Fix

- Retire B loss from `insurance_domain_index(asset_index, opposite_side(leg.side))` first.
- Fall back to other source claims only when the affected domain cannot cover the full reduction.
- Reuse PR #111's proved partial source-lien unwind path instead of duplicating lien arithmetic.
- Validate the already-selected physical source-claim slot after a prior slot is emptied, so the sparse terminator cannot hide a later fallback claim.
- Preserve the existing aggregate sparse-slot behavior for non-B callers.

## TDD and verification

- Exact-parent RED at `5027db0e`: `v16_b_loss_burns_the_matching_source_domain_before_sparse_slot_order` fails with the unrelated asset-0 claim erased.
- Sparse fallback regression: `v16_source_claim_burn_crosses_a_just_emptied_sparse_slot` covers an earlier claim becoming the terminator before a later physical slot is consumed.
- `cargo test --all-targets --features fuzz`: 164 tests pass.
- Re-ran the inherited source-lien partition, minimality/isolation, backing-release, and fee-proration Kani proofs: all pass.
- A public LiteSVM terminal extraction reproduction passes on the fixed wrapper integration, and the full wrapper suite passes 6 unit + 566 LiteSVM/CU tests.

## Dependency

This PR is intentionally stacked on #111 because it consumes that PR's production, contract-proved partial source-lien unwind primitive.
