### PR TITLE
[REAL LoF / DoS] Credit post-snapshot expired backing to payouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 254 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 266 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1499,6 +1499,48 @@ impl V16Core {
         (payout, new_vault)
     }
 
+    /// Recompute the resolved payout rate from the ledger's current residual
+    /// and outstanding claim bound. This deliberately contains no wide
+    /// division: receipts apply the resulting fraction when they are paid.
+    pub(crate) fn kernel_recompute_resolved_payout_rate(
+        mut ledger: ResolvedPayoutLedgerV16,
+    ) -> V16Result<ResolvedPayoutLedgerV16> {
+        let total_bound_num = ledger
+            .terminal_claim_exact_receipts_num
+            .checked_add(ledger.terminal_claim_bound_unreceipted_num)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        if total_bound_num == 0 {
+            ledger.current_payout_rate_num = 1;
+            ledger.current_payout_rate_den = 1;
+        } else {
+            ledger.current_payout_rate_num = ledger
+                .snapshot_residual
+                .checked_mul(BOUND_SCALE)
+                .ok_or(V16Error::ArithmeticOverflow)?
+                .min(total_bound_num);
+            ledger.current_payout_rate_den = total_bound_num;
+        }
+        Ok(ledger)
+    }
+
+    /// Credit residual released after terminal snapshot capture into both
+    /// persisted snapshots and immediately raise the common payout rate.
+    pub(crate) fn kernel_credit_post_snapshot_residual(
+        mut ledger: ResolvedPayoutLedgerV16,
+        legacy_snapshot: u128,
+        released: u128,
+    ) -> V16Result<(ResolvedPayoutLedgerV16, u128)> {
+        ledger.snapshot_residual = ledger
+            .snapshot_residual
+            .checked_add(released)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        let legacy_snapshot = legacy_snapshot
+            .checked_add(released)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        ledger = Self::kernel_recompute_resolved_payout_rate(ledger)?;
+        Ok((ledger, legacy_snapshot))
+    }
+
     /// PRODUCTION KERNEL (roadmap 3A.1 trade spine): classify a position change
     /// from (current signed, new signed) into its leg route — the EXACT total
     /// decision the position-delta body dispatches on. `delta != 0` is enforced
@@ -8046,6 +8088,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         domain: usize,
         now_slot: u64,
     ) -> V16Result<()> {
+        let snapshot_captured = decode_bool(self.header.payout_snapshot_captured)?;
+        let residual_before = if snapshot_captured {
+            self.residual()
+        } else {
+            0
+        };
         let (bucket, source) = V16Core::prepare_counterparty_backing_expiry_delta(
             self.backing_bucket_for_domain(domain)?,
             self.source_credit_for_domain(domain)?,
@@ -8053,7 +8101,24 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         )?;
         self.set_backing_bucket_for_domain(domain, bucket)?;
         self.set_source_credit_for_domain(domain, source)?;
-        self.refresh_source_credit_domain_after_mutation(domain)
+        self.refresh_source_credit_domain_after_mutation(domain)?;
+        if snapshot_captured {
+            let released = self
+                .residual()
+                .checked_sub(residual_before)
+                .ok_or(V16Error::CounterUnderflow)?;
+            if released != 0 {
+                let (ledger, legacy_snapshot) = V16Core::kernel_credit_post_snapshot_residual(
+                    self.header.resolved_payout_ledger.try_to_runtime()?,
+                    self.header.payout_snapshot.get(),
+                    released,
+                )?;
+                self.header.payout_snapshot = V16PodU128::new(legacy_snapshot);
+                self.header.resolved_payout_ledger =
+                    ResolvedPayoutLedgerV16Account::from_runtime(&ledger);
+            }
+        }
+        Ok(())
     }
 
     fn first_lapsed_source_backing_for_account(
@@ -15479,22 +15544,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     }
 
     fn recompute_resolved_payout_rate(&mut self) -> V16Result<()> {
-        let mut ledger = self.header.resolved_payout_ledger.try_to_runtime()?;
-        let total_bound_num = ledger
-            .terminal_claim_exact_receipts_num
-            .checked_add(ledger.terminal_claim_bound_unreceipted_num)
-            .ok_or(V16Error::ArithmeticOverflow)?;
-        if total_bound_num == 0 {
-            ledger.current_payout_rate_num = 1;
-            ledger.current_payout_rate_den = 1;
-        } else {
-            ledger.current_payout_rate_num = ledger
-                .snapshot_residual
-                .checked_mul(BOUND_SCALE)
-                .ok_or(V16Error::ArithmeticOverflow)?
-                .min(total_bound_num);
-            ledger.current_payout_rate_den = total_bound_num;
-        }
+        let ledger = V16Core::kernel_recompute_resolved_payout_rate(
+            self.header.resolved_payout_ledger.try_to_runtime()?,
+        )?;
         self.header.resolved_payout_ledger = ResolvedPayoutLedgerV16Account::from_runtime(&ledger);
         Ok(())
     }

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -539,6 +539,14 @@ impl MarketGroupV16HeaderAccount {
 }
 
 impl<'a, T> MarketGroupV16ViewMut<'a, T> {
+    pub fn kani_kernel_credit_post_snapshot_residual(
+        ledger: ResolvedPayoutLedgerV16,
+        legacy_snapshot: u128,
+        released: u128,
+    ) -> V16Result<(ResolvedPayoutLedgerV16, u128)> {
+        V16Core::kernel_credit_post_snapshot_residual(ledger, legacy_snapshot, released)
+    }
+
     pub fn kani_kernel_unilateral_close_capacity(
         stored_abs: u128,
         oi_eff_long_q: u128,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -14465,6 +14465,62 @@ fn proof_v16_expired_backing_yields_zero_realizable_support_after_expiry() {
     );
 }
 
+// Once the terminal payout ledger exists, expiring Fresh backing changes that
+// principal from a senior provider claim into junior residual. The released
+// atoms must augment the existing snapshot and payout rate; otherwise close
+// order can strand the post-snapshot residual forever.
+#[kani::proof]
+#[kani::unwind(40)]
+#[kani::solver(cadical)]
+fn proof_v16_post_snapshot_backing_expiry_credits_junior_pool() {
+    let backing_raw: u8 = kani::any();
+    let junior_raw: u8 = kani::any();
+    let claim_raw: u8 = kani::any();
+    kani::assume((1..=8).contains(&backing_raw));
+    kani::assume(junior_raw <= 8);
+    kani::assume((1..=8).contains(&claim_raw));
+    let backing = backing_raw as u128;
+    let junior = junior_raw as u128;
+    let claim = claim_raw as u128;
+    let claim_num = claim * BOUND_SCALE;
+    let before = ResolvedPayoutLedgerV16 {
+        snapshot_residual: junior,
+        terminal_claim_exact_receipts_num: 0,
+        terminal_claim_bound_unreceipted_num: claim_num,
+        current_payout_rate_num: (junior * BOUND_SCALE).min(claim_num),
+        current_payout_rate_den: claim_num,
+        snapshot_slot: 20,
+        payout_halted: false,
+        finalized: false,
+    };
+    let (ledger, legacy_snapshot) =
+        MarketGroupV16ViewMut::<u64>::kani_kernel_credit_post_snapshot_residual(
+            before, junior, backing,
+        )
+        .unwrap();
+
+    kani::cover!(
+        junior < claim && junior + backing >= claim,
+        "expiry raises a haircut payout rate to full"
+    );
+    kani::cover!(
+        junior + backing < claim,
+        "expiry improves but does not eliminate a haircut"
+    );
+    assert_eq!(legacy_snapshot, junior + backing);
+    assert_eq!(ledger.snapshot_residual, junior + backing);
+    assert_eq!(ledger.terminal_claim_exact_receipts_num, 0);
+    assert_eq!(ledger.terminal_claim_bound_unreceipted_num, claim_num);
+    assert_eq!(ledger.current_payout_rate_den, claim_num);
+    assert_eq!(
+        ledger.current_payout_rate_num,
+        ((junior + backing) * BOUND_SCALE).min(claim_num)
+    );
+    assert_eq!(ledger.snapshot_slot, before.snapshot_slot);
+    assert_eq!(ledger.payout_halted, before.payout_halted);
+    assert_eq!(ledger.finalized, before.finalized);
+}
+
 // First-class engine API for granting source-attributed positive PnL (the
 // wrapper previously shadow-implemented this op host-side). The value-neutral
 // + aggregate-lockstep property is covered concretely by the unit test

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -14355,33 +14355,23 @@ fn proof_v16_residual_excludes_recoverable_counterparty_backing_principal() {
 // lapsed bucket forfeits its principal (fresh_reserved -> 0), drops the domain
 // credit rate to zero, and makes realizable support exactly zero — so the
 // realize step falls through to the junior receipt path instead of reverting.
-// The full close_resolved path is Kani-intractable; this pins the primitive.
-#[kani::proof]
-#[kani::unwind(40)]
-#[kani::solver(cadical)]
-fn proof_v16_expired_backing_yields_zero_realizable_support_after_expiry() {
-    // CONCRETE WITNESS (flagged): any symbolic input here blows the solver
+// The full close_resolved path is Kani-intractable; the two bounded route
+// bindings below pin this primitive for under-backed and fully-backed claims.
+fn assert_expired_backing_yields_zero_realizable_support(backing: u128) {
+    // BOUNDED BINDING (flagged): a symbolic backing value blows the solver
     // budget (the realizable-support query's per-domain U256 credit math on
     // top of the expire + audit-scan path). The symbolic surface is covered
-    // end-to-end by backing_double_claim_fuzz::terminal_close_with_expired_
-    // backing_does_not_strand; this witness pins the primitive exactly.
-    // CLEAN-ROOM FIX (was a dead cover): backing/claim were welded to 2/3, so
-    // cover!(backing == claim) was UNSATISFIABLE ("1 of 2 cover properties
-    // satisfied") and the fully-backed expiry case was never exercised. A
-    // symbolic selector drives BOTH concrete witnesses (under-backed and
-    // fully-backed) so both covers become satisfiable (2/2), without making the
-    // realizable-support math symbolic (which blows the solver budget). The
-    // post-expiry assertions are forfeiture-state facts that hold for either
-    // ratio (the lapsed backing is zeroed regardless of how much it was).
-    let fully_backed: bool = kani::any();
-    let backing: u128 = if fully_backed { 3 } else { 2 };
+    // by proof_v16_counterparty_backing_expiry_reclassifies_principal_and_
+    // impairs_lien and backing_double_claim_fuzz::terminal_close_with_expired_
+    // backing_does_not_strand. Separate concrete routes avoid a Cartesian U256
+    // branch while still mutation-binding both economically distinct cases.
     let claim = 3u128;
     let backing_num = backing * BOUND_SCALE;
     let claim_num = claim * BOUND_SCALE;
     let expiry_slot = 5u64;
     let current_slot = 20u64; // strictly past expiry
 
-    let (mut header, mut markets, mut account_header) = one_market_view_fixture();
+    let (mut header, mut markets, mut account_header) = one_market_direct_view_fixture();
     let market_id = markets[0].engine.asset.market_id.get();
     header.current_slot = V16PodU64::new(current_slot);
     header.slot_last = V16PodU64::new(current_slot);
@@ -14442,12 +14432,21 @@ fn proof_v16_expired_backing_yields_zero_realizable_support_after_expiry() {
         .try_to_runtime()
         .unwrap();
 
-    kani::cover!(backing < claim, "expiry covers under-backed claim");
-    kani::cover!(backing == claim, "expiry covers fully-backed claim");
     // The principal is forfeited (bucket emptied, status Expired) ...
     assert_eq!(bucket.status, BackingBucketStatusV16::Expired);
     assert_eq!(bucket.fresh_unliened_backing_num, 0);
     assert_eq!(source.fresh_reserved_backing_num, 0);
+    assert_eq!(market.header.payout_snapshot_captured, 0);
+    assert_eq!(market.header.payout_snapshot.get(), 0);
+    assert_eq!(
+        market
+            .header
+            .resolved_payout_ledger
+            .try_to_runtime()
+            .unwrap(),
+        ResolvedPayoutLedgerV16::EMPTY,
+        "pre-snapshot expiry must leave terminal accounting uninitialized"
+    );
     // ... the credit rate collapses to zero (no backing underwrites the claim) ...
     assert_eq!(source.credit_rate_num, 0);
     // ... the bucket is now current (no Stale) so the close can proceed ...
@@ -14465,6 +14464,20 @@ fn proof_v16_expired_backing_yields_zero_realizable_support_after_expiry() {
     );
 }
 
+#[kani::proof]
+#[kani::unwind(40)]
+#[kani::solver(cadical)]
+fn proof_v16_expired_backing_yields_zero_realizable_support_after_expiry() {
+    assert_expired_backing_yields_zero_realizable_support(2);
+}
+
+#[kani::proof]
+#[kani::unwind(40)]
+#[kani::solver(cadical)]
+fn proof_v16_fully_backed_expiry_yields_zero_realizable_support() {
+    assert_expired_backing_yields_zero_realizable_support(3);
+}
+
 // Once the terminal payout ledger exists, expiring Fresh backing changes that
 // principal from a senior provider claim into junior residual. The released
 // atoms must augment the existing snapshot and payout rate; otherwise close
@@ -14473,25 +14486,28 @@ fn proof_v16_expired_backing_yields_zero_realizable_support_after_expiry() {
 #[kani::unwind(40)]
 #[kani::solver(cadical)]
 fn proof_v16_post_snapshot_backing_expiry_credits_junior_pool() {
-    let backing_raw: u8 = kani::any();
-    let junior_raw: u8 = kani::any();
-    let claim_raw: u8 = kani::any();
-    kani::assume((1..=8).contains(&backing_raw));
-    kani::assume(junior_raw <= 8);
-    kani::assume((1..=8).contains(&claim_raw));
-    let backing = backing_raw as u128;
-    let junior = junior_raw as u128;
-    let claim = claim_raw as u128;
-    let claim_num = claim * BOUND_SCALE;
+    let backing_atoms: u16 = kani::any();
+    let junior_atoms: u16 = kani::any();
+    let receipted_atoms: u16 = kani::any();
+    let unreceipted_atoms: u16 = kani::any();
+    let snapshot_slot: u64 = kani::any();
+    let payout_halted: bool = kani::any();
+    let finalized: bool = kani::any();
+    let backing = backing_atoms as u128;
+    let junior = junior_atoms as u128;
+    let receipted_num = (receipted_atoms as u128) * BOUND_SCALE;
+    let unreceipted_num = (unreceipted_atoms as u128) * BOUND_SCALE;
+    let claim_num = receipted_num + unreceipted_num;
+    kani::assume(claim_num > 0);
     let before = ResolvedPayoutLedgerV16 {
         snapshot_residual: junior,
-        terminal_claim_exact_receipts_num: 0,
-        terminal_claim_bound_unreceipted_num: claim_num,
+        terminal_claim_exact_receipts_num: receipted_num,
+        terminal_claim_bound_unreceipted_num: unreceipted_num,
         current_payout_rate_num: (junior * BOUND_SCALE).min(claim_num),
         current_payout_rate_den: claim_num,
-        snapshot_slot: 20,
-        payout_halted: false,
-        finalized: false,
+        snapshot_slot,
+        payout_halted,
+        finalized,
     };
     let (ledger, legacy_snapshot) =
         MarketGroupV16ViewMut::<u64>::kani_kernel_credit_post_snapshot_residual(
@@ -14500,17 +14516,22 @@ fn proof_v16_post_snapshot_backing_expiry_credits_junior_pool() {
         .unwrap();
 
     kani::cover!(
-        junior < claim && junior + backing >= claim,
+        junior * BOUND_SCALE < claim_num && (junior + backing) * BOUND_SCALE >= claim_num,
         "expiry raises a haircut payout rate to full"
     );
     kani::cover!(
-        junior + backing < claim,
+        (junior + backing) * BOUND_SCALE < claim_num,
         "expiry improves but does not eliminate a haircut"
     );
+    kani::cover!(
+        backing > 0 && receipted_num > 0 && unreceipted_num > 0,
+        "expiry preserves a mixed terminal-claim partition"
+    );
+    kani::cover!(backing == 0, "zero release is an exact identity credit");
     assert_eq!(legacy_snapshot, junior + backing);
     assert_eq!(ledger.snapshot_residual, junior + backing);
-    assert_eq!(ledger.terminal_claim_exact_receipts_num, 0);
-    assert_eq!(ledger.terminal_claim_bound_unreceipted_num, claim_num);
+    assert_eq!(ledger.terminal_claim_exact_receipts_num, receipted_num);
+    assert_eq!(ledger.terminal_claim_bound_unreceipted_num, unreceipted_num);
     assert_eq!(ledger.current_payout_rate_den, claim_num);
     assert_eq!(
         ledger.current_payout_rate_num,
@@ -14519,6 +14540,267 @@ fn proof_v16_post_snapshot_backing_expiry_credits_junior_pool() {
     assert_eq!(ledger.snapshot_slot, before.snapshot_slot);
     assert_eq!(ledger.payout_halted, before.payout_halted);
     assert_eq!(ledger.finalized, before.finalized);
+}
+
+fn post_snapshot_expiry_fixture(
+    backing: u128,
+    junior: u128,
+    claim: u128,
+    receipted_num: u128,
+) -> (MarketGroupV16HeaderAccount, [Market<u64>; 1]) {
+    let claim_num = claim * BOUND_SCALE;
+    let unreceipted_num = claim_num - receipted_num;
+    let backing_num = backing * BOUND_SCALE;
+    let (mut header, mut markets, _) = one_market_direct_view_fixture();
+    let market_id = markets[0].engine.asset.market_id.get();
+    header.mode = 1; // Resolved
+    header.current_slot = V16PodU64::new(20);
+    header.vault = V16PodU128::new(junior + backing);
+    header.pnl_pos_tot = V16PodU128::new(claim);
+    header.pnl_matured_pos_tot = V16PodU128::new(claim);
+    header.pnl_pos_bound_tot = V16PodU128::new(claim);
+    header.pnl_pos_bound_tot_num = V16PodU128::new(claim_num);
+    header.source_fresh_backing_total_num = V16PodU128::new(backing_num);
+    header.payout_snapshot_captured = 1;
+    header.payout_snapshot = V16PodU128::new(junior);
+    header.payout_snapshot_pnl_pos_tot = V16PodU128::new(claim);
+    header.resolved_payout_ledger =
+        ResolvedPayoutLedgerV16Account::from_runtime(&ResolvedPayoutLedgerV16 {
+            snapshot_residual: junior,
+            terminal_claim_exact_receipts_num: receipted_num,
+            terminal_claim_bound_unreceipted_num: unreceipted_num,
+            current_payout_rate_num: (junior * BOUND_SCALE).min(claim_num),
+            current_payout_rate_den: claim_num,
+            snapshot_slot: 10,
+            payout_halted: false,
+            finalized: false,
+        });
+    markets[0].engine.backing_long = BackingBucketV16Account::from_runtime(&BackingBucketV16 {
+        market_id,
+        fresh_unliened_backing_num: backing_num,
+        expiry_slot: 5,
+        status: BackingBucketStatusV16::Fresh,
+        ..BackingBucketV16::EMPTY
+    });
+    markets[0].engine.source_credit_long =
+        SourceCreditStateV16Account::from_runtime(&SourceCreditStateV16 {
+            fresh_reserved_backing_num: backing_num,
+            credit_rate_num: CREDIT_RATE_SCALE,
+            ..SourceCreditStateV16::EMPTY
+        });
+    (header, markets)
+}
+
+fn assert_post_snapshot_expiry_route(
+    backing: u128,
+    junior: u128,
+    claim: u128,
+    receipted_num: u128,
+) {
+    let claim_num = claim * BOUND_SCALE;
+    let unreceipted_num = claim_num - receipted_num;
+    let (mut header, mut markets) =
+        post_snapshot_expiry_fixture(backing, junior, claim, receipted_num);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    assert_eq!(market.kani_residual(), junior);
+    let vault_before = market.header.vault.get();
+    let c_tot_before = market.header.c_tot.get();
+    let insurance_before = market.header.insurance.get();
+
+    market
+        .expire_source_backing_bucket_not_atomic(0, 20)
+        .unwrap();
+
+    let bucket = market.markets[0]
+        .engine
+        .backing_long
+        .try_to_runtime()
+        .unwrap();
+    let source = market.markets[0]
+        .engine
+        .source_credit_long
+        .try_to_runtime()
+        .unwrap();
+    let ledger = market
+        .header
+        .resolved_payout_ledger
+        .try_to_runtime()
+        .unwrap();
+    assert_eq!(bucket.status, BackingBucketStatusV16::Expired);
+    assert_eq!(bucket.fresh_unliened_backing_num, 0);
+    assert_eq!(source.fresh_reserved_backing_num, 0);
+    assert_eq!(market.header.source_fresh_backing_total_num.get(), 0);
+    assert_eq!(market.kani_residual(), junior + backing);
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), c_tot_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
+    assert_eq!(market.header.payout_snapshot.get(), junior + backing);
+    assert_eq!(ledger.snapshot_residual, junior + backing);
+    assert_eq!(ledger.terminal_claim_exact_receipts_num, receipted_num);
+    assert_eq!(ledger.terminal_claim_bound_unreceipted_num, unreceipted_num);
+    assert_eq!(
+        ledger.terminal_claim_exact_receipts_num + ledger.terminal_claim_bound_unreceipted_num,
+        claim_num
+    );
+    assert_eq!(ledger.current_payout_rate_den, claim_num);
+    assert_eq!(
+        ledger.current_payout_rate_num,
+        ((junior + backing) * BOUND_SCALE).min(claim_num)
+    );
+}
+
+// These two bounded bindings execute the production zero-copy route for both
+// payout-rate branches. General value conservation and arbitrary claim
+// partitions are proved by the full-width theorem above; these fail if the
+// public caller bypasses that kernel or miscomputes released residual.
+#[kani::proof]
+#[kani::unwind(48)]
+#[kani::solver(cadical)]
+fn proof_v16_public_post_snapshot_expiry_improves_haircut_and_frames_receipts() {
+    assert_post_snapshot_expiry_route(1, 1, 4, BOUND_SCALE);
+}
+
+#[kani::proof]
+#[kani::unwind(48)]
+#[kani::solver(cadical)]
+fn proof_v16_public_post_snapshot_expiry_restores_full_rate() {
+    assert_post_snapshot_expiry_route(3, 1, 3, 0);
+}
+
+// Replaying expiry after the bucket has left Fresh must fail before every
+// market mutation, regardless of whether terminal snapshots exist. This is the
+// no-double-credit half of the post-snapshot value theorem.
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_backing_expiry_kernel_rejects_every_ineligible_bucket() {
+    let status_raw: u8 = kani::any();
+    let now_raw: u16 = kani::any();
+    let expiry_raw: u16 = kani::any();
+    kani::assume(status_raw <= 3);
+    let status = match status_raw {
+        0 => BackingBucketStatusV16::Empty,
+        1 => BackingBucketStatusV16::Fresh,
+        2 => BackingBucketStatusV16::Expired,
+        _ => BackingBucketStatusV16::Impaired,
+    };
+    let now_slot = now_raw as u64;
+    let expiry_slot = expiry_raw as u64;
+    if status == BackingBucketStatusV16::Fresh {
+        kani::assume(now_slot < expiry_slot);
+    }
+    let bucket = BackingBucketV16 {
+        market_id: 1,
+        expiry_slot,
+        status,
+        ..BackingBucketV16::EMPTY
+    };
+    let result = MarketGroupV16ViewMut::<u64>::kani_prepare_counterparty_backing_expiry_delta(
+        bucket,
+        SourceCreditStateV16::EMPTY,
+        now_slot,
+    );
+
+    kani::cover!(status == BackingBucketStatusV16::Empty, "Empty is rejected");
+    kani::cover!(
+        status == BackingBucketStatusV16::Fresh,
+        "not-yet-expired Fresh is rejected"
+    );
+    kani::cover!(
+        status == BackingBucketStatusV16::Expired,
+        "Expired replay is rejected"
+    );
+    kani::cover!(
+        status == BackingBucketStatusV16::Impaired,
+        "Impaired replay is rejected"
+    );
+    assert_eq!(result, Err(V16Error::Stale));
+}
+
+#[kani::proof]
+#[kani::unwind(16)]
+#[kani::solver(cadical)]
+fn proof_v16_public_backing_expiry_replay_is_inert() {
+    let (mut header, mut markets, _) = one_market_direct_view_fixture();
+    let market_id = markets[0].engine.asset.market_id.get();
+    header.payout_snapshot_captured = 1;
+    header.payout_snapshot = V16PodU128::new(3);
+    header.resolved_payout_ledger =
+        ResolvedPayoutLedgerV16Account::from_runtime(&ResolvedPayoutLedgerV16 {
+            snapshot_residual: 3,
+            terminal_claim_exact_receipts_num: BOUND_SCALE,
+            terminal_claim_bound_unreceipted_num: BOUND_SCALE,
+            current_payout_rate_num: 2 * BOUND_SCALE,
+            current_payout_rate_den: 2 * BOUND_SCALE,
+            snapshot_slot: 1,
+            payout_halted: false,
+            finalized: false,
+        });
+    markets[0].engine.backing_long = BackingBucketV16Account::from_runtime(&BackingBucketV16 {
+        market_id,
+        status: BackingBucketStatusV16::Expired,
+        ..BackingBucketV16::EMPTY
+    });
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let bucket_before = market.markets[0]
+        .engine
+        .backing_long
+        .try_to_runtime()
+        .unwrap();
+    let source_before = market.markets[0]
+        .engine
+        .source_credit_long
+        .try_to_runtime()
+        .unwrap();
+    let ledger_before = market
+        .header
+        .resolved_payout_ledger
+        .try_to_runtime()
+        .unwrap();
+    let fresh_total_before = market.header.source_fresh_backing_total_num.get();
+    let risk_epoch_before = market.header.risk_epoch.get();
+    let legacy_snapshot_before = market.header.payout_snapshot.get();
+    let vault_before = market.header.vault.get();
+    let c_tot_before = market.header.c_tot.get();
+    let insurance_before = market.header.insurance.get();
+    let result = market.expire_source_backing_bucket_not_atomic(0, 20);
+
+    assert_eq!(result, Err(V16Error::Stale));
+    assert_eq!(
+        market.markets[0]
+            .engine
+            .backing_long
+            .try_to_runtime()
+            .unwrap(),
+        bucket_before
+    );
+    assert_eq!(
+        market.markets[0]
+            .engine
+            .source_credit_long
+            .try_to_runtime()
+            .unwrap(),
+        source_before
+    );
+    assert_eq!(
+        market
+            .header
+            .resolved_payout_ledger
+            .try_to_runtime()
+            .unwrap(),
+        ledger_before
+    );
+    assert_eq!(
+        market.header.source_fresh_backing_total_num.get(),
+        fresh_total_before
+    );
+    assert_eq!(market.header.risk_epoch.get(), risk_epoch_before);
+    assert_eq!(market.header.payout_snapshot.get(), legacy_snapshot_before);
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), c_tot_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
 }
 
 // First-class engine API for granting source-attributed positive PnL (the


### PR DESCRIPTION
## Impact

Fresh source backing is senior while live. Once it expires after the resolved payout snapshot, those atoms become junior residual but the vulnerable engine never added them to the frozen payout ledger. Ordinary close order could therefore leave user entitlement trapped in the vault and prevent terminal value reconciliation.

The public LiteSVM regression creates two independent winner/loser pairs, captures a 40/80 payout snapshot, then expires a second 40-atom backing bucket. On the vulnerable parent both losers receive 960, both winners receive only 1,020 from four 1,000-atom deposits, and 40 atoms remain undistributable.

## Fix

- Credit residual released after payout-snapshot capture into both persisted payout snapshots.
- Recompute the common payout rate with kernel_recompute_resolved_payout_rate.
- Preserve replay inertness and reject every ineligible bucket.

## TDD evidence

- RED commit a7577b0b carries the exact-parent public regression.
- GREEN commit e35f0f6d adds the production fix and conservation proofs.

## Verification

- cargo test --all-targets --features fuzz: 181 tests pass.
- Five targeted Kani harnesses pass, covering exact post-snapshot credit, public haircut improvement, full-rate restoration, ineligible-bucket rejection, and replay inertness.
- The principal conservation theorem reports 4/4 nonvacuity covers.
- Source proof roster: 266 plain proofs in tests/proofs_v16.rs.

Stacked on #149, which prepares lapsed source state before resolved settlement.