### PR TITLE
[REAL LoF] Preserve bankruptcy loss domains across leg exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 241 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 246 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 244 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 241 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -743,6 +743,24 @@ impl V16Core {
     }
 
     #[inline]
+    fn negative_pnl_accrual_step(attributed: u128, amount: u128) -> V16Result<u128> {
+        attributed
+            .checked_add(amount)
+            .ok_or(V16Error::ArithmeticOverflow)
+    }
+
+    #[inline]
+    fn negative_pnl_reduction_step(attributed: u128, reduction: u128) -> (u128, u128) {
+        let reduced = attributed.min(reduction);
+        (attributed - reduced, reduction - reduced)
+    }
+
+    #[inline]
+    fn negative_pnl_targeted_reduction(attributed: u128, amount: u128) -> V16Result<u128> {
+        attributed.checked_sub(amount).ok_or(V16Error::InvalidLeg)
+    }
+
+    #[inline]
     fn accrual_activity_for_asset_segment(
         old: AssetStateV16,
         segment_dt: u64,
@@ -4298,9 +4316,9 @@ impl<'a> PortfolioV16View<'a> {
         while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
             let source = self.source_domains()[slot];
             let amount = source.negative_pnl_atoms.get();
-            let reduced = amount.min(reduction);
-            reduction -= reduced;
-            let remaining = amount - reduced;
+            let (remaining, next_reduction) =
+                V16Core::negative_pnl_reduction_step(amount, reduction);
+            reduction = next_reduction;
             if remaining != 0 {
                 return Ok(Some((source.domain.get() as usize, remaining)));
             }
@@ -10051,13 +10069,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         self.ensure_account_source_claim_market_id(account, domain)?;
         let source = account.source_domain_mut_or_insert(domain)?;
-        source.negative_pnl_atoms = V16PodU128::new(
-            source
-                .negative_pnl_atoms
-                .get()
-                .checked_add(amount)
-                .ok_or(V16Error::ArithmeticOverflow)?,
-        );
+        source.negative_pnl_atoms = V16PodU128::new(V16Core::negative_pnl_accrual_step(
+            source.negative_pnl_atoms.get(),
+            amount,
+        )?);
         Ok(())
     }
 
@@ -10074,11 +10089,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .source_domain_slot(domain)?
                 .ok_or(V16Error::InvalidLeg)?;
             let attributed = account.header.source_domains[slot].negative_pnl_atoms.get();
-            if attributed < amount {
-                return Err(V16Error::InvalidLeg);
-            }
-            account.header.source_domains[slot].negative_pnl_atoms =
-                V16PodU128::new(attributed - amount);
+            account.header.source_domains[slot].negative_pnl_atoms = V16PodU128::new(
+                V16Core::negative_pnl_targeted_reduction(attributed, amount)?,
+            );
             account.reset_source_domain_slot_if_empty(slot);
             account.compact_source_domains();
             return Ok(());
@@ -10087,12 +10100,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let mut slot = 0usize;
         while slot < PORTFOLIO_SOURCE_DOMAIN_CAP && amount != 0 {
             let attributed = account.header.source_domains[slot].negative_pnl_atoms.get();
-            let reduced = attributed.min(amount);
-            if reduced != 0 {
+            let (next_attributed, next_amount) =
+                V16Core::negative_pnl_reduction_step(attributed, amount);
+            if next_attributed != attributed {
                 account.header.source_domains[slot].negative_pnl_atoms =
-                    V16PodU128::new(attributed - reduced);
-                amount -= reduced;
+                    V16PodU128::new(next_attributed);
             }
+            amount = next_amount;
             slot += 1;
         }
         if amount != 0 {

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -27,8 +27,8 @@ pub type V16ActiveBitmap = [u64; V16_ACTIVE_BITMAP_WORDS];
 pub const V16_EMPTY_ACTIVE_BITMAP: V16ActiveBitmap = [0; V16_ACTIVE_BITMAP_WORDS];
 pub const V16_BACKING_BUCKETS_PER_DOMAIN: usize = 1;
 // Bump whenever the on-chain account/header Pod layout changes (see the
-// PortfolioAccountV16Account size assertion). 17: added funding flow counters.
-pub const V16_LAYOUT_DISCRIMINATOR: u16 = 17;
+// PortfolioAccountV16Account size assertion). 18: persist per-domain negative-PnL provenance.
+pub const V16_LAYOUT_DISCRIMINATOR: u16 = 18;
 pub const V16_ACCOUNT_VERSION: u16 = 1;
 pub const BACKING_FEE_RATE_DEN_E9: u128 = 1_000_000_000;
 pub const MAX_BACKING_FEE_RATE_E9_PER_SLOT: u64 = 1_000_000_000;
@@ -4075,6 +4075,9 @@ impl<'a> PortfolioV16View<'a> {
         if source_claim_sum_num != 0 {
             V16Core::validate_positive_pnl_source_attribution(pnl, source_claim_sum_num)?;
         }
+        if self.negative_pnl_sum_atoms()? != pnl.min(0).unsigned_abs() {
+            return Err(V16Error::InvalidLeg);
+        }
         Self::validate_resolved_payout_receipt_static(
             self.header.resolved_payout_receipt.try_to_runtime()?,
         )?;
@@ -4182,6 +4185,9 @@ impl<'a> PortfolioV16View<'a> {
                 return Err(V16Error::HiddenLeg);
             }
             let slot = market.markets[asset_index].engine_slot();
+            if source.negative_pnl_atoms.get() != 0 && source.source_claim_bound_num.get() != 0 {
+                return Err(V16Error::InvalidLeg);
+            }
             let domain_credit = if d % 2 == 0 {
                 slot.source_credit_long.try_to_runtime()?
             } else {
@@ -4266,6 +4272,41 @@ impl<'a> PortfolioV16View<'a> {
             d += 1;
         }
         Ok(sum)
+    }
+
+    fn negative_pnl_sum_atoms(&self) -> V16Result<u128> {
+        let mut sum = 0u128;
+        let mut d = 0usize;
+        while d < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            sum = sum
+                .checked_add(self.source_domains()[d].negative_pnl_atoms.get())
+                .ok_or(V16Error::ArithmeticOverflow)?;
+            d += 1;
+        }
+        Ok(sum)
+    }
+
+    fn first_negative_pnl_domain(&self) -> V16Result<Option<(usize, u128)>> {
+        self.first_negative_pnl_domain_after_reduction(0)
+    }
+
+    fn first_negative_pnl_domain_after_reduction(
+        &self,
+        mut reduction: u128,
+    ) -> V16Result<Option<(usize, u128)>> {
+        let mut slot = 0usize;
+        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let source = self.source_domains()[slot];
+            let amount = source.negative_pnl_atoms.get();
+            let reduced = amount.min(reduction);
+            reduction -= reduced;
+            let remaining = amount - reduced;
+            if remaining != 0 {
+                return Ok(Some((source.domain.get() as usize, remaining)));
+            }
+            slot += 1;
+        }
+        Ok(None)
     }
 
     fn validate_resolved_payout_receipt_static(receipt: ResolvedPayoutReceiptV16) -> V16Result<()> {
@@ -9232,19 +9273,38 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
     ) -> V16Result<u128> {
         let domain = self.insurance_domain_index(asset_index, opposite_side(bankrupt_side))?;
+        self.consume_attributed_domain_insurance_for_negative_pnl(domain, account)
+    }
+
+    fn consume_attributed_domain_insurance_for_negative_pnl(
+        &mut self,
+        domain: usize,
+        account: &mut PortfolioV16ViewMut<'_>,
+    ) -> V16Result<u128> {
         if account.header.pnl.get() >= 0 {
+            return Ok(0);
+        }
+        let attributed = account
+            .as_view()
+            .source_domain(domain)?
+            .negative_pnl_atoms
+            .get();
+        if attributed == 0 {
             return Ok(0);
         }
         self.header.bankruptcy_hlock_active = 1;
         let domain_available = self.available_domain_insurance(domain)?;
         let (_, spent_before) = self.domain_insurance_budget_spent(domain)?;
+        let attributed_pnl = i128::try_from(attributed)
+            .map(|v| -v)
+            .map_err(|_| V16Error::ArithmeticOverflow)?;
         // PRODUCTION KERNEL: insurance-draw core (capped by deficit AND domain
         // budget; conserves pool -> spent).
-        let (used, next_insurance, next_spent, new_pnl) = V16Core::kernel_consume_insurance_layer(
+        let (used, next_insurance, next_spent, _) = V16Core::kernel_consume_insurance_layer(
             domain_available,
             self.header.insurance.get(),
             spent_before,
-            account.header.pnl.get(),
+            attributed_pnl,
         )?;
         if used == 0 {
             return Ok(0);
@@ -9252,7 +9312,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let vault_before = self.header.vault.get();
         self.header.insurance = V16PodU128::new(next_insurance);
         self.set_domain_insurance_spent_core(domain, next_spent)?;
-        self.set_account_pnl(account, new_pnl)?;
+        let used_i128 = i128::try_from(used).map_err(|_| V16Error::ArithmeticOverflow)?;
+        let new_pnl = account
+            .header
+            .pnl
+            .get()
+            .checked_add(used_i128)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        self.set_account_pnl_reducing_loss_domain(account, new_pnl, domain)?;
         TokenValueFlowProofV16::validate_insurance_to_close_insurance_spent(
             used,
             vault_before,
@@ -9262,24 +9329,15 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(used)
     }
 
-    fn preflight_liquidation_residual_durability(
+    fn preflight_attributed_liquidation_residual_durability(
         &mut self,
         asset_index: usize,
         bankrupt_side: SideV16,
-        account: &PortfolioV16View<'_>,
+        attributed_loss_after_principal: u128,
     ) -> V16Result<()> {
         let domain = self.insurance_domain_index(asset_index, opposite_side(bankrupt_side))?;
-        let residual_after_principal_and_insurance = if account.header.pnl.get() < 0 {
-            account
-                .header
-                .pnl
-                .get()
-                .unsigned_abs()
-                .saturating_sub(account.header.capital.get())
-                .saturating_sub(self.available_domain_insurance(domain)?)
-        } else {
-            0
-        };
+        let residual_after_principal_and_insurance = attributed_loss_after_principal
+            .saturating_sub(self.available_domain_insurance(domain)?);
         if residual_after_principal_and_insurance == 0 {
             return Ok(());
         }
@@ -9949,7 +10007,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
         new_pnl: i128,
     ) -> V16Result<()> {
-        self.set_account_pnl_inner(account, new_pnl, None)
+        self.set_account_pnl_inner(account, new_pnl, None, None, None)
     }
 
     fn set_account_pnl_with_source(
@@ -9959,7 +10017,94 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         source_domain: usize,
     ) -> V16Result<()> {
         self.domain_asset_side(source_domain)?;
-        self.set_account_pnl_inner(account, new_pnl, Some(source_domain))
+        self.set_account_pnl_inner(account, new_pnl, Some(source_domain), None, None)
+    }
+
+    fn set_account_pnl_with_loss_source(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        new_pnl: i128,
+        loss_source_domain: usize,
+    ) -> V16Result<()> {
+        self.domain_asset_side(loss_source_domain)?;
+        self.set_account_pnl_inner(account, new_pnl, None, Some(loss_source_domain), None)
+    }
+
+    fn set_account_pnl_reducing_loss_domain(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        new_pnl: i128,
+        loss_source_domain: usize,
+    ) -> V16Result<()> {
+        self.domain_asset_side(loss_source_domain)?;
+        self.set_account_pnl_inner(account, new_pnl, None, None, Some(loss_source_domain))
+    }
+
+    fn increase_account_negative_pnl_attribution(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        domain: usize,
+        amount: u128,
+    ) -> V16Result<()> {
+        if amount == 0 {
+            return Ok(());
+        }
+        self.ensure_account_source_claim_market_id(account, domain)?;
+        let source = account.source_domain_mut_or_insert(domain)?;
+        source.negative_pnl_atoms = V16PodU128::new(
+            source
+                .negative_pnl_atoms
+                .get()
+                .checked_add(amount)
+                .ok_or(V16Error::ArithmeticOverflow)?,
+        );
+        Ok(())
+    }
+
+    fn reduce_account_negative_pnl_attribution(
+        account: &mut PortfolioV16ViewMut<'_>,
+        mut amount: u128,
+        specific_domain: Option<usize>,
+    ) -> V16Result<()> {
+        if amount == 0 {
+            return Ok(());
+        }
+        if let Some(domain) = specific_domain {
+            let slot = account
+                .source_domain_slot(domain)?
+                .ok_or(V16Error::InvalidLeg)?;
+            let attributed = account.header.source_domains[slot].negative_pnl_atoms.get();
+            if attributed < amount {
+                return Err(V16Error::InvalidLeg);
+            }
+            account.header.source_domains[slot].negative_pnl_atoms =
+                V16PodU128::new(attributed - amount);
+            account.reset_source_domain_slot_if_empty(slot);
+            account.compact_source_domains();
+            return Ok(());
+        }
+
+        let mut slot = 0usize;
+        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP && amount != 0 {
+            let attributed = account.header.source_domains[slot].negative_pnl_atoms.get();
+            let reduced = attributed.min(amount);
+            if reduced != 0 {
+                account.header.source_domains[slot].negative_pnl_atoms =
+                    V16PodU128::new(attributed - reduced);
+                amount -= reduced;
+            }
+            slot += 1;
+        }
+        if amount != 0 {
+            return Err(V16Error::InvalidLeg);
+        }
+        let mut slot = 0usize;
+        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            account.reset_source_domain_slot_if_empty(slot);
+            slot += 1;
+        }
+        account.compact_source_domains();
+        Ok(())
     }
 
     /// Grants source-attributed positive PnL to an account — the first-class
@@ -10000,8 +10145,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
         new_pnl: i128,
         source_domain: Option<usize>,
+        negative_source_domain: Option<usize>,
+        negative_reduction_domain: Option<usize>,
     ) -> V16Result<()> {
         validate_non_min_i128(new_pnl)?;
+        let old_pnl = account.header.pnl.get();
         let old_pos = account.header.pnl.get().max(0) as u128;
         let new_pos = new_pnl.max(0) as u128;
         if new_pos >= old_pos {
@@ -10087,7 +10235,24 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             self.header.pnl_pos_bound_tot_num.get(),
         )?);
 
-        let old_negative = account.header.pnl.get() < 0;
+        let old_negative_abs = old_pnl.min(0).unsigned_abs();
+        let new_negative_abs = new_pnl.min(0).unsigned_abs();
+        if new_negative_abs > old_negative_abs {
+            let domain = negative_source_domain.ok_or(V16Error::InvalidLeg)?;
+            self.increase_account_negative_pnl_attribution(
+                account,
+                domain,
+                new_negative_abs - old_negative_abs,
+            )?;
+        } else if old_negative_abs > new_negative_abs {
+            Self::reduce_account_negative_pnl_attribution(
+                account,
+                old_negative_abs - new_negative_abs,
+                negative_reduction_domain,
+            )?;
+        }
+
+        let old_negative = old_pnl < 0;
         let new_negative = new_pnl < 0;
         match (old_negative, new_negative) {
             (false, true) => {
@@ -10143,6 +10308,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
         loss_abs: u128,
+        loss_source_domain: usize,
     ) -> V16Result<SupportLossApplicationV16> {
         if loss_abs == 0 {
             return Ok(SupportLossApplicationV16 {
@@ -10159,7 +10325,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .get()
                 .checked_sub(loss_i128)
                 .ok_or(V16Error::ArithmeticOverflow)?;
-            self.set_account_pnl(account, new_pnl)?;
+            self.set_account_pnl_with_loss_source(account, new_pnl, loss_source_domain)?;
             return Ok(SupportLossApplicationV16 {
                 support_consumed: 0,
                 junior_face_burned: 0,
@@ -10218,7 +10384,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .get()
                 .min(new_pnl.max(0) as u128),
         );
-        self.set_account_pnl(account, new_pnl)?;
+        self.set_account_pnl_with_loss_source(account, new_pnl, loss_source_domain)?;
         Ok(SupportLossApplicationV16 {
             support_consumed,
             junior_face_burned,
@@ -10239,7 +10405,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             });
         }
         if delta < 0 {
-            return self.apply_haircut_bounded_close_loss_to_pnl(account, delta.unsigned_abs());
+            let loss_source_domain = source_domain.ok_or(V16Error::InvalidLeg)?;
+            return self.apply_haircut_bounded_close_loss_to_pnl(
+                account,
+                delta.unsigned_abs(),
+                loss_source_domain,
+            );
         }
         if account.header.pnl.get() >= 0 {
             if source_domain.is_none()
@@ -10587,7 +10758,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 self.apply_signed_kf_delta_to_pnl(account, net, source_domain)?;
             } else {
                 let negative_before = account.header.pnl.get().min(0).unsigned_abs();
-                self.apply_signed_kf_delta_to_pnl(account, net, None)?;
+                let bankruptcy_domain =
+                    self.insurance_domain_index(asset_index, opposite_side(leg.side))?;
+                self.apply_signed_kf_delta_to_pnl(account, net, Some(bankruptcy_domain))?;
                 let negative_after = account.header.pnl.get().min(0).unsigned_abs();
                 let loss_source_domain = self.insurance_domain_index(asset_index, leg.side)?;
                 self.reserve_new_capital_backed_loss_for_source_domain_not_atomic(
@@ -11135,6 +11308,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             .ok_or(V16Error::ArithmeticOverflow)?;
         let leg_slot = Self::require_active_leg_slot_for_asset(&account.as_view(), asset_index)?;
         let leg = account.header.legs[leg_slot].try_to_runtime()?;
+        let loss_source_domain =
+            self.insurance_domain_index(asset_index, opposite_side(leg.side))?;
         let leg = V16Core::kernel_advance_leg_b_snap(
             leg,
             chunk.delta_b,
@@ -11142,7 +11317,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             chunk.remaining_after,
         )?;
         account.header.legs[leg_slot] = PortfolioLegV16Account::from_runtime(&leg);
-        self.set_account_pnl(account, new_pnl)?;
+        self.set_account_pnl_with_loss_source(account, new_pnl, loss_source_domain)?;
         if chunk.remaining_after != 0 {
             self.mark_account_b_stale(account)?;
         } else if !Self::has_b_stale_leg(&account.as_view())? {
@@ -13258,11 +13433,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             SideV16::Short => asset.loss_weight_sum_short,
         };
         let resolved = decode_market_mode(self.header.mode)? == MarketModeV16::Resolved;
-        // Determine whether a chunk can be booked (and the recovery reason if not).
-        // weight_sum==0 -> no loss-side to absorb (ActiveBankruptClose); engine
-        // chunk 0 / apply None -> no B-headroom (BIndexHeadroomExhausted). The
-        // booked asset is written back only when a chunk is actually booked.
-        let (booked, new_asset, recovery_reason) = if weight_sum == 0 {
+        // Resolved payouts already haircut positive claims to realizable backing, so applying B
+        // there would charge the same terminal shortfall twice. Live markets still book B so
+        // continued trading observes the socialized loss.
+        let (booked, new_asset, recovery_reason) = if resolved || weight_sum == 0 {
             (
                 None,
                 None,
@@ -13575,6 +13749,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // when possible, otherwise close the selected leg fully.
         let (close_q, close_delta) =
             V16Core::kernel_reduce_position_delta(leg.basis_pos_q, leg.side, close_request_q)?;
+        let preflight_target = account
+            .as_view()
+            .first_negative_pnl_domain_after_reduction(account.header.capital.get())?;
         if self.position_delta_touches_pending_domain_loss_barrier(
             &account.as_view(),
             request.asset_index,
@@ -13595,11 +13772,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             )?;
             return Err(V16Error::RecoveryRequired);
         }
-        self.preflight_liquidation_residual_durability(
-            request.asset_index,
-            leg.side,
-            &account.as_view(),
-        )?;
+        if let Some((domain, amount)) = preflight_target {
+            let (debt_asset_index, domain_side) = self.domain_asset_side(domain)?;
+            self.preflight_attributed_liquidation_residual_durability(
+                debt_asset_index,
+                opposite_side(domain_side),
+                amount,
+            )?;
+        }
         let fee_notional = liquidation_risk_notional_ceil(close_q, asset.effective_price)?;
         let fee = liquidation_fee_for_close(
             fee_notional,
@@ -13610,61 +13790,66 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         )?;
         let charged_fee = self.charge_account_fee_not_atomic(account, fee)?;
         self.settle_negative_pnl_from_principal_core_not_atomic(account)?;
-        let gross_bankruptcy_residual = if account.header.pnl.get() < 0 {
-            account.header.pnl.get().unsigned_abs()
-        } else {
-            0
-        };
-        if gross_bankruptcy_residual != 0 {
-            self.begin_close_progress_ledger(
-                account,
-                request.asset_index,
-                opposite_side(leg.side),
-                gross_bankruptcy_residual,
-            )?;
-        }
-        let insurance_used =
-            self.consume_domain_insurance_for_negative_pnl(request.asset_index, leg.side, account)?;
-        if insurance_used != 0 {
-            self.advance_close_progress_ledger(account, 0, 0, insurance_used, 0, 0)?;
-        }
-        let residual = if account.header.pnl.get() < 0 {
-            account.header.pnl.get().unsigned_abs()
-        } else {
-            0
-        };
+        let debt_target = account.as_view().first_negative_pnl_domain()?;
+        let mut insurance_used = 0u128;
         let mut booked = 0u128;
         let mut explicit = 0u128;
-        if residual != 0 {
-            let outcome = self.book_bankruptcy_residual_chunk_for_account_core(
+        if let Some((domain, gross_bankruptcy_residual)) = debt_target {
+            let (debt_asset_index, domain_side) = self.domain_asset_side(domain)?;
+            let bankrupt_side = opposite_side(domain_side);
+            self.begin_close_progress_ledger(
                 account,
-                request.asset_index,
-                leg.side,
-                residual,
+                debt_asset_index,
+                domain_side,
+                gross_bankruptcy_residual,
             )?;
-            booked = outcome.booked_loss;
-            explicit = outcome.explicit_loss;
-            let cleared = booked
-                .checked_add(explicit)
-                .ok_or(V16Error::ArithmeticOverflow)?
-                .min(residual);
-            let cleared_i128 = i128::try_from(cleared).map_err(|_| V16Error::ArithmeticOverflow)?;
-            let new_pnl = account
-                .header
-                .pnl
-                .get()
-                .checked_add(cleared_i128)
-                .ok_or(V16Error::ArithmeticOverflow)?;
-            self.set_account_pnl(account, new_pnl)?;
-            self.header.bankruptcy_hlock_active = 1;
+            insurance_used =
+                self.consume_attributed_domain_insurance_for_negative_pnl(domain, account)?;
+            if insurance_used != 0 {
+                self.advance_close_progress_ledger(account, 0, 0, insurance_used, 0, 0)?;
+            }
+            let residual = account
+                .as_view()
+                .source_domain(domain)?
+                .negative_pnl_atoms
+                .get();
+            if residual != 0 {
+                let outcome = self.book_bankruptcy_residual_chunk_for_account_core(
+                    account,
+                    debt_asset_index,
+                    bankrupt_side,
+                    residual,
+                )?;
+                booked = outcome.booked_loss;
+                explicit = outcome.explicit_loss;
+                let cleared = booked
+                    .checked_add(explicit)
+                    .ok_or(V16Error::ArithmeticOverflow)?
+                    .min(residual);
+                let cleared_i128 =
+                    i128::try_from(cleared).map_err(|_| V16Error::ArithmeticOverflow)?;
+                let new_pnl = account
+                    .header
+                    .pnl
+                    .get()
+                    .checked_add(cleared_i128)
+                    .ok_or(V16Error::ArithmeticOverflow)?;
+                self.set_account_pnl_reducing_loss_domain(account, new_pnl, domain)?;
+                self.header.bankruptcy_hlock_active = 1;
+            }
         }
-        self.reduce_position(account, request.asset_index, close_q)?;
+        let closed_q = if account.header.pnl.get() < 0 {
+            0
+        } else {
+            self.reduce_position(account, request.asset_index, close_q)?;
+            close_q
+        };
         self.certify_account_after_local_settlement_with_price_override(account, None)?;
         self.validate_liquidation_progress_from_score(before_score, &account.as_view())?;
         self.validate_shape_audit_scan()?;
         self.validate_account_audit_scan(&account.as_view())?;
         Ok(LiquidationOutcomeV16 {
-            closed_q: close_q,
+            closed_q,
             insurance_used,
             residual_booked: booked,
             explicit_loss: explicit,
@@ -14143,17 +14328,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if old_pnl >= 0 || new_pnl > 0 || new_pnl < old_pnl {
             return Err(V16Error::InvalidConfig);
         }
-        if old_pnl < 0 && new_pnl == 0 {
-            self.header.negative_pnl_account_count = V16PodU64::new(
-                self.header
-                    .negative_pnl_account_count
-                    .get()
-                    .checked_sub(1)
-                    .ok_or(V16Error::CounterUnderflow)?,
-            );
-        }
-        account.header.pnl = V16PodI128::new(new_pnl);
-        Ok(())
+        self.set_account_pnl(account, new_pnl)
     }
 
     fn resolved_bankruptcy_attribution(
@@ -14167,21 +14342,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             self.validate_configured_asset_index(asset_index)?;
             return Ok(Some((asset_index, opposite_side(ledger.domain_side))));
         }
-
-        let mut out = None;
-        let mut slot = 0usize;
-        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
-            let leg = account.header.legs[slot].try_to_runtime()?;
-            if leg.active && !leg.stale && !leg.b_stale {
-                let candidate = (leg.asset_index as usize, leg.side);
-                self.validate_configured_asset_index(candidate.0)?;
-                if out.replace(candidate).is_some() {
-                    return Ok(None);
-                }
-            }
-            slot += 1;
-        }
-        Ok(out)
+        let Some((domain, _)) = account.first_negative_pnl_domain()? else {
+            return Ok(None);
+        };
+        let (asset_index, domain_side) = self.domain_asset_side(domain)?;
+        Ok(Some((asset_index, opposite_side(domain_side))))
     }
 
     fn clear_resolved_unattributed_negative_pnl(
@@ -14191,10 +14356,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if account.header.pnl.get() >= 0 {
             return Ok(());
         }
-        self.header.bankruptcy_hlock_active = 1;
-        self.set_account_pnl(account, 0)?;
-        account.header.health_cert.valid = 0;
-        Ok(())
+        Err(V16Error::InvalidLeg)
     }
 
     fn settle_resolved_bankruptcy_negative_pnl(
@@ -14214,8 +14376,21 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         };
 
         self.header.bankruptcy_hlock_active = 1;
-        let gross_residual = account.header.pnl.get().unsigned_abs();
-        if !account.header.close_progress.try_to_runtime()?.active {
+        let domain = self.insurance_domain_index(asset_index, opposite_side(bankrupt_side))?;
+        let gross_residual = account
+            .as_view()
+            .source_domain(domain)?
+            .negative_pnl_atoms
+            .get();
+        if gross_residual == 0 {
+            return Err(V16Error::InvalidLeg);
+        }
+        if !account
+            .header
+            .close_progress
+            .try_to_runtime()?
+            .has_pending_residual()
+        {
             self.begin_close_progress_ledger(
                 account,
                 asset_index,
@@ -14230,11 +14405,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             self.advance_close_progress_ledger(account, 0, 0, insurance_used, 0, 0)?;
         }
 
-        let residual = if account.header.pnl.get() < 0 {
-            account.header.pnl.get().unsigned_abs()
-        } else {
-            0
-        };
+        let residual = account
+            .as_view()
+            .source_domain(domain)?
+            .negative_pnl_atoms
+            .get();
         if residual == 0 {
             account.header.health_cert.valid = 0;
             return Ok(());
@@ -14255,7 +14430,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             outcome.booked_loss,
             outcome.explicit_loss,
         )?;
-        self.set_account_pnl(account, new_pnl)?;
+        self.set_account_pnl_reducing_loss_domain(account, new_pnl, domain)?;
         account.header.health_cert.valid = 0;
         Ok(())
     }
@@ -15645,7 +15820,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let mut positive_pnl_forfeited = 0u128;
         if net < 0 {
             loss_settled = net.unsigned_abs();
-            let support = self.apply_haircut_bounded_close_loss_to_pnl(account, loss_settled)?;
+            let loss_source_domain =
+                self.insurance_domain_index(asset_index, opposite_side(leg.side))?;
+            let support = self.apply_haircut_bounded_close_loss_to_pnl(
+                account,
+                loss_settled,
+                loss_source_domain,
+            )?;
             support_consumed = support.support_consumed;
             junior_face_burned = support.junior_face_burned;
         } else {
@@ -16106,6 +16287,9 @@ impl ResolvedPayoutReceiptV16Account {
 pub struct PortfolioSourceDomainV16Account {
     pub domain: V16PodU32,
     pub source_claim_market_id: V16PodU64,
+    // Uncovered account debt attributed to this domain. Unlike an active leg, this survives a
+    // risk-reducing full close so bankruptcy settlement cannot be redirected through another leg.
+    pub negative_pnl_atoms: V16PodU128,
     pub source_claim_bound_num: V16PodU128,
     pub source_claim_liened_num: V16PodU128,
     pub source_claim_counterparty_liened_num: V16PodU128,
@@ -16127,7 +16311,8 @@ pub struct PortfolioSourceDomainV16Account {
 impl PortfolioSourceDomainV16Account {
     #[inline]
     pub fn is_occupied(self) -> bool {
-        self.source_claim_bound_num.get() != 0
+        self.negative_pnl_atoms.get() != 0
+            || self.source_claim_bound_num.get() != 0
             || self.source_claim_liened_num.get() != 0
             || self.source_claim_counterparty_liened_num.get() != 0
             || self.source_claim_insurance_liened_num.get() != 0
@@ -16192,7 +16377,7 @@ pub struct PortfolioAccountV16Account {
 // Gated to non-kani: under `cfg(kani)` PORTFOLIO_SOURCE_DOMAIN_CAP is reduced for
 // proof tractability, so the production on-chain layout is the non-kani one.
 #[cfg(not(kani))]
-const _: () = assert!(core::mem::size_of::<PortfolioAccountV16Account>() == 9291);
+const _: () = assert!(core::mem::size_of::<PortfolioAccountV16Account>() == 9803);
 
 impl Default for PortfolioAccountV16Account {
     fn default() -> Self {

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -610,15 +610,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.consume_domain_insurance_for_negative_pnl(asset_index, bankrupt_side, account)
     }
 
-    pub fn kani_preflight_liquidation_residual_durability(
-        &mut self,
-        asset_index: usize,
-        bankrupt_side: SideV16,
-        account: &PortfolioV16View<'_>,
-    ) -> V16Result<()> {
-        self.preflight_liquidation_residual_durability(asset_index, bankrupt_side, account)
-    }
-
     pub fn kani_apply_counterparty_source_credit_lien_delta(
         source: &mut PortfolioSourceDomainV16Account,
         required_face_num: u128,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -169,6 +169,18 @@ pub fn kani_validate_positive_pnl_source_attribution(
     V16Core::validate_positive_pnl_source_attribution(pnl, source_claim_sum_num)
 }
 
+pub fn kani_negative_pnl_accrual_step(attributed: u128, amount: u128) -> V16Result<u128> {
+    V16Core::negative_pnl_accrual_step(attributed, amount)
+}
+
+pub fn kani_negative_pnl_reduction_step(attributed: u128, reduction: u128) -> (u128, u128) {
+    V16Core::negative_pnl_reduction_step(attributed, reduction)
+}
+
+pub fn kani_negative_pnl_targeted_reduction(attributed: u128, amount: u128) -> V16Result<u128> {
+    V16Core::negative_pnl_targeted_reduction(attributed, amount)
+}
+
 pub fn kani_expected_source_credit_rate_num_for_state(
     state: SourceCreditStateV16,
 ) -> V16Result<u128> {
@@ -418,6 +430,17 @@ impl<'a> PortfolioV16View<'a> {
     pub fn kani_active_leg_slot_for_asset(&self, asset_index: usize) -> V16Result<Option<usize>> {
         self.active_leg_slot_for_asset(asset_index)
     }
+
+    pub fn kani_first_negative_pnl_domain(&self) -> V16Result<Option<(usize, u128)>> {
+        self.first_negative_pnl_domain()
+    }
+
+    pub fn kani_first_negative_pnl_domain_after_reduction(
+        &self,
+        reduction: u128,
+    ) -> V16Result<Option<(usize, u128)>> {
+        self.first_negative_pnl_domain_after_reduction(reduction)
+    }
 }
 
 impl<'a> PortfolioV16ViewMut<'a> {
@@ -454,6 +477,14 @@ impl MarketGroupV16HeaderAccount {
 }
 
 impl<'a, T> MarketGroupV16ViewMut<'a, T> {
+    pub fn kani_reduce_account_negative_pnl_attribution(
+        account: &mut PortfolioV16ViewMut<'_>,
+        amount: u128,
+        specific_domain: Option<usize>,
+    ) -> V16Result<()> {
+        Self::reduce_account_negative_pnl_attribution(account, amount, specific_domain)
+    }
+
     pub fn kani_clear_leg(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -14,15 +14,17 @@ use percolator::v16::{
     kani_liquidation_engine_close_request_q, kani_liquidation_fee_from_raw_fee,
     kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
-    kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
-    kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
-    kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
-    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
-    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
-    BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
-    CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
-    HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
-    Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
+    kani_negative_pnl_accrual_step, kani_negative_pnl_reduction_step,
+    kani_negative_pnl_targeted_reduction, kani_pending_domain_loss_barrier_blocks_position_change,
+    kani_position_delta_increases_risk, kani_prepare_asset_recovery_transition,
+    kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
+    kani_trade_preexisting_oi_reduction_gate, kani_trade_preflight_risk_gate,
+    kani_validate_positive_pnl_source_attribution, AssetLifecycleV16, AssetStateV16,
+    AssetStateV16Account, BackingBucketStatusV16, BackingBucketV16, BackingBucketV16Account,
+    BatchTradeOutcomeV16, CloseProgressLedgerV16, CloseProgressLedgerV16Account,
+    EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16, HealthCertV16Account,
+    InsuranceCreditReservationV16, InsuranceCreditReservationV16Account, Market,
+    MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
     PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
@@ -90,6 +92,23 @@ fn seed_negative_pnl(
     account.source_domains[0].source_claim_market_id =
         V16PodU64::new(markets[domain / 2].engine.asset.market_id.get());
     account.source_domains[0].negative_pnl_atoms = V16PodU128::new(amount);
+}
+
+fn seed_sparse_negative_pnl_domains(
+    account: &mut PortfolioAccountV16Account,
+    first_is_a: bool,
+    loss_a: u128,
+    loss_b: u128,
+) {
+    let ordered = if first_is_a {
+        [(0u32, loss_a), (2u32, loss_b)]
+    } else {
+        [(2u32, loss_b), (0u32, loss_a)]
+    };
+    for (slot, (domain, loss)) in ordered.into_iter().enumerate() {
+        account.source_domains[slot].domain = V16PodU32::new(domain);
+        account.source_domains[slot].negative_pnl_atoms = V16PodU128::new(loss);
+    }
 }
 
 fn two_market_view_fixture() -> (
@@ -8741,6 +8760,299 @@ fn proof_v16_resolved_bankruptcy_attribution_uses_recorded_loss_domain() {
         "recorded asset-1 debt survives an unrelated asset-0 leg"
     );
     assert_eq!(attribution, Some((1, SideV16::Short)));
+}
+
+// The three production transition theorems below are inductive: accrual creates
+// exact provenance, fungible principal preserves it, and a domain-funded cure
+// frames every unrelated domain. Their shared invariant is
+// sum(domain debt) == |negative PnL|.
+#[kani::proof]
+#[kani::solver(cadical)]
+fn proof_v16_negative_pnl_accrual_is_inductive_and_domain_exact() {
+    let target_before: u128 = kani::any();
+    let unrelated_before: u128 = kani::any();
+    let added: u128 = kani::any();
+    let target_is_a: bool = kani::any();
+    let Some(total_before) = target_before.checked_add(unrelated_before) else {
+        kani::assume(false);
+        return;
+    };
+    let Some(total_after) = total_before.checked_add(added) else {
+        kani::assume(false);
+        return;
+    };
+    let target_after = kani_negative_pnl_accrual_step(target_before, added).unwrap();
+    let (loss_a_after, loss_b_after) = if target_is_a {
+        (target_after, unrelated_before)
+    } else {
+        (unrelated_before, target_after)
+    };
+
+    assert_eq!(target_after.checked_sub(target_before), Some(added));
+    assert_eq!(loss_a_after.checked_add(loss_b_after), Some(total_after));
+
+    kani::cover!(
+        total_before == 0 && added > 0,
+        "first loss creates attributed debt"
+    );
+    kani::cover!(
+        added > 0 && target_before == 0 && unrelated_before > 0,
+        "a new loss domain is inserted beside unrelated debt"
+    );
+    kani::cover!(
+        added > 0 && target_before > 0 && unrelated_before > 0,
+        "an existing loss domain grows while unrelated debt is framed"
+    );
+    kani::cover!(target_is_a && added > 0, "asset-0 debt accrues");
+    kani::cover!(!target_is_a && added > 0, "asset-1 debt accrues");
+    kani::cover!(
+        target_before > u64::MAX as u128 && added > 0,
+        "the theorem covers debt above machine-sized test fixtures"
+    );
+    kani::cover!(
+        total_before > 0 && added == 0,
+        "zero accrual is an exact identity transition"
+    );
+}
+
+#[kani::proof]
+#[kani::solver(cadical)]
+fn proof_v16_principal_reduction_is_conservative_across_two_domains() {
+    let first_before: u128 = kani::any();
+    let second_before: u128 = kani::any();
+    let principal: u128 = kani::any();
+    let first_is_a: bool = kani::any();
+    let Some(total_before) = first_before.checked_add(second_before) else {
+        kani::assume(false);
+        return;
+    };
+    kani::assume(principal <= total_before);
+
+    let (first_after, remainder) = kani_negative_pnl_reduction_step(first_before, principal);
+    let (second_after, final_remainder) =
+        kani_negative_pnl_reduction_step(second_before, remainder);
+    let (loss_a_after, loss_b_after) = if first_is_a {
+        (first_after, second_after)
+    } else {
+        (second_after, first_after)
+    };
+    let expected_total_after = total_before - principal;
+
+    assert_eq!(final_remainder, 0);
+    assert!(first_after <= first_before);
+    assert!(second_after <= second_before);
+    assert_eq!(
+        loss_a_after.checked_add(loss_b_after),
+        Some(expected_total_after)
+    );
+    if principal <= first_before {
+        assert_eq!(first_after, first_before - principal);
+        assert_eq!(second_after, second_before);
+    } else {
+        assert_eq!(first_after, 0);
+        assert_eq!(second_after, total_before - principal);
+    }
+
+    kani::cover!(
+        principal > 0 && principal < first_before,
+        "principal partially retires the first domain"
+    );
+    kani::cover!(
+        principal > first_before && principal < total_before,
+        "principal crosses a domain boundary"
+    );
+    kani::cover!(
+        total_before > 0 && principal == total_before,
+        "principal clears all attributed debt"
+    );
+    kani::cover!(first_is_a, "asset-0 debt occupies the first sparse slot");
+    kani::cover!(!first_is_a, "asset-1 debt occupies the first sparse slot");
+    kani::cover!(
+        first_before > u64::MAX as u128 && principal > 0,
+        "the theorem covers full-width principal settlement"
+    );
+}
+
+#[kani::proof]
+#[kani::solver(cadical)]
+fn proof_v16_domain_cure_reduces_only_its_attributed_debt() {
+    let target_before: u128 = kani::any();
+    let unrelated_before: u128 = kani::any();
+    let cure: u128 = kani::any();
+    let target_is_a: bool = kani::any();
+    let Some(total_before) = target_before.checked_add(unrelated_before) else {
+        kani::assume(false);
+        return;
+    };
+    kani::assume(cure <= target_before);
+    let target_after = kani_negative_pnl_targeted_reduction(target_before, cure).unwrap();
+    let (loss_a_after, loss_b_after) = if target_is_a {
+        (target_after, unrelated_before)
+    } else {
+        (unrelated_before, target_after)
+    };
+    let total_after = total_before - cure;
+
+    assert_eq!(target_after, target_before - cure);
+    assert_eq!(loss_a_after.checked_add(loss_b_after), Some(total_after));
+
+    kani::cover!(
+        target_is_a && cure > 0 && unrelated_before > 0,
+        "asset-0 cure frames live asset-1 debt"
+    );
+    kani::cover!(
+        !target_is_a && cure > 0 && unrelated_before > 0,
+        "asset-1 cure frames live asset-0 debt"
+    );
+    kani::cover!(
+        cure > 0 && cure < target_before,
+        "partial cure preserves target debt"
+    );
+    kani::cover!(
+        cure > 0 && cure == target_before && unrelated_before > 0,
+        "target exhaustion compacts without touching unrelated debt"
+    );
+    kani::cover!(
+        total_before > 0 && total_after == 0,
+        "final cure clears all debt"
+    );
+    kani::cover!(
+        target_before > u64::MAX as u128 && cure > 0,
+        "the theorem covers full-width domain cures"
+    );
+    kani::cover!(
+        total_before > 0 && cure == 0,
+        "zero cure is an exact identity transition"
+    );
+}
+
+#[kani::proof]
+#[kani::unwind(40)]
+#[kani::solver(cadical)]
+fn proof_v16_sparse_principal_binding_matches_preflight_and_kernel() {
+    let loss_a_raw: u8 = kani::any();
+    let loss_b_raw: u8 = kani::any();
+    let principal_raw: u8 = kani::any();
+    let first_is_a: bool = kani::any();
+    kani::assume((1..=16).contains(&loss_a_raw));
+    kani::assume((1..=16).contains(&loss_b_raw));
+    let loss_a = loss_a_raw as u128;
+    let loss_b = loss_b_raw as u128;
+    let total = loss_a + loss_b;
+    let principal = principal_raw as u128;
+    kani::assume(principal <= total);
+
+    let mut account_header = empty_account_fixture([1; 32], 2);
+    seed_sparse_negative_pnl_domains(&mut account_header, first_is_a, loss_a, loss_b);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let predicted = account
+        .as_view()
+        .kani_first_negative_pnl_domain_after_reduction(principal)
+        .unwrap();
+
+    MarketGroupV16ViewMut::<u64>::kani_reduce_account_negative_pnl_attribution(
+        &mut account,
+        principal,
+        None,
+    )
+    .unwrap();
+
+    let actual = account.as_view().kani_first_negative_pnl_domain().unwrap();
+    let loss_a_after = account
+        .as_view()
+        .kani_source_domain(0)
+        .unwrap()
+        .negative_pnl_atoms
+        .get();
+    let loss_b_after = account
+        .as_view()
+        .kani_source_domain(2)
+        .unwrap()
+        .negative_pnl_atoms
+        .get();
+    assert_eq!(actual, predicted);
+    assert_eq!(loss_a_after + loss_b_after, total - principal);
+    assert!(loss_a_after <= loss_a);
+    assert!(loss_b_after <= loss_b);
+
+    kani::cover!(
+        principal > 0 && principal < if first_is_a { loss_a } else { loss_b },
+        "sparse principal reduction partially consumes the first slot"
+    );
+    kani::cover!(
+        principal > if first_is_a { loss_a } else { loss_b } && principal < total,
+        "sparse principal reduction crosses a slot boundary"
+    );
+    kani::cover!(
+        principal == total,
+        "sparse principal reduction compacts both exhausted domains"
+    );
+    kani::cover!(first_is_a, "asset-0 occupies the first sparse slot");
+    kani::cover!(!first_is_a, "asset-1 occupies the first sparse slot");
+}
+
+#[kani::proof]
+#[kani::unwind(40)]
+#[kani::solver(cadical)]
+fn proof_v16_sparse_targeted_cure_binding_frames_unrelated_domain() {
+    let loss_a_raw: u8 = kani::any();
+    let loss_b_raw: u8 = kani::any();
+    let cure_raw: u8 = kani::any();
+    let first_is_a: bool = kani::any();
+    let target_is_a: bool = kani::any();
+    kani::assume((1..=16).contains(&loss_a_raw));
+    kani::assume((1..=16).contains(&loss_b_raw));
+    kani::assume(cure_raw != 0);
+    let loss_a = loss_a_raw as u128;
+    let loss_b = loss_b_raw as u128;
+    let cure = cure_raw as u128;
+    let (target_domain, target_before, unrelated_domain, unrelated_before) = if target_is_a {
+        (0usize, loss_a, 2usize, loss_b)
+    } else {
+        (2usize, loss_b, 0usize, loss_a)
+    };
+    kani::assume(cure <= target_before);
+
+    let mut account_header = empty_account_fixture([1; 32], 2);
+    seed_sparse_negative_pnl_domains(&mut account_header, first_is_a, loss_a, loss_b);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    MarketGroupV16ViewMut::<u64>::kani_reduce_account_negative_pnl_attribution(
+        &mut account,
+        cure,
+        Some(target_domain),
+    )
+    .unwrap();
+
+    assert_eq!(
+        account
+            .as_view()
+            .kani_source_domain(target_domain)
+            .unwrap()
+            .negative_pnl_atoms
+            .get(),
+        target_before - cure
+    );
+    assert_eq!(
+        account
+            .as_view()
+            .kani_source_domain(unrelated_domain)
+            .unwrap()
+            .negative_pnl_atoms
+            .get(),
+        unrelated_before
+    );
+
+    kani::cover!(target_is_a, "asset-0 debt is cured");
+    kani::cover!(!target_is_a, "asset-1 debt is cured");
+    kani::cover!(cure < target_before, "targeted cure is partial");
+    kani::cover!(
+        cure == target_before && unrelated_before > 0,
+        "target exhaustion compacts while unrelated debt survives"
+    );
+    kani::cover!(
+        first_is_a != target_is_a,
+        "targeting is independent from sparse slot order"
+    );
 }
 
 #[kani::proof]

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -79,6 +79,19 @@ fn one_market_view_fixture() -> (
     (header, markets, account_header)
 }
 
+fn seed_negative_pnl(
+    account: &mut PortfolioAccountV16Account,
+    markets: &[Market<u64>],
+    domain: usize,
+    amount: u128,
+) {
+    account.pnl = V16PodI128::new(-i128::try_from(amount).unwrap());
+    account.source_domains[0].domain = V16PodU32::new(u32::try_from(domain).unwrap());
+    account.source_domains[0].source_claim_market_id =
+        V16PodU64::new(markets[domain / 2].engine.asset.market_id.get());
+    account.source_domains[0].negative_pnl_atoms = V16PodU128::new(amount);
+}
+
 fn two_market_view_fixture() -> (
     MarketGroupV16HeaderAccount,
     [Market<u64>; 2],
@@ -3019,7 +3032,7 @@ fn proof_v16_withdraw_settles_flat_negative_pnl_before_value_exit() {
     header.insurance = V16PodU128::new(insurance);
     header.negative_pnl_account_count = V16PodU64::new(1);
     account_header.capital = V16PodU128::new(start_capital);
-    account_header.pnl = V16PodI128::new(-(loss as i128));
+    seed_negative_pnl(&mut account_header, &markets, 0, loss);
 
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
     let mut account = PortfolioV16ViewMut::new(&mut account_header);
@@ -4789,7 +4802,7 @@ fn proof_v16_trade_fee_helper_does_not_charge_negative_pnl_account() {
     header.c_tot = V16PodU128::new(capital);
     header.insurance = V16PodU128::new(insurance);
     account_header.capital = V16PodU128::new(capital);
-    account_header.pnl = V16PodI128::new(-loss);
+    seed_negative_pnl(&mut account_header, &markets, 0, loss as u128);
     let vault_before = header.vault;
     let c_tot_before = header.c_tot;
     let insurance_before = header.insurance;
@@ -4886,7 +4899,7 @@ fn proof_v16_negative_pnl_settlement_consumes_principal_before_residual() {
     header.c_tot = V16PodU128::new(capital);
     header.negative_pnl_account_count = V16PodU64::new(1);
     account_header.capital = V16PodU128::new(capital);
-    account_header.pnl = V16PodI128::new(-(loss as i128));
+    seed_negative_pnl(&mut account_header, &markets, 0, loss);
     let vault_before = header.vault.get();
 
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
@@ -5612,6 +5625,7 @@ fn proof_v16_backing_utilization_collection_negative_pnl_never_draws_capital() {
     account_header.source_domains[0] = PortfolioSourceDomainV16Account {
         domain: V16PodU32::new(0),
         source_claim_market_id: V16PodU64::new(market_id),
+        negative_pnl_atoms: V16PodU128::new(1),
         source_lien_counterparty_backing_num: V16PodU128::new(lien_num),
         source_lien_fee_last_slot: V16PodU64::new(last_slot),
         source_lien_capital_at_risk_fee_revenue: V16PodU128::new(revenue_before),
@@ -7645,7 +7659,7 @@ fn proof_v16_capital_backed_loss_reservation_is_value_neutral_and_capital_capped
 
     let mut acct_header = PortfolioAccountV16Account::default();
     acct_header.capital = V16PodU128::new(capital);
-    acct_header.pnl = V16PodI128::new(-(loss as i128));
+    seed_negative_pnl(&mut acct_header, &markets, 0, loss);
 
     let vault_before = header.vault.get();
     let c_tot_before = header.c_tot.get();
@@ -8188,7 +8202,7 @@ fn proof_v16_live_positive_kf_delta_without_source_rejects() {
     let loss = loss_raw as i128;
     let (mut header, mut markets, mut account_header) = one_market_view_fixture();
     if start_negative {
-        account_header.pnl = V16PodI128::new(-loss);
+        seed_negative_pnl(&mut account_header, &markets, 0, loss as u128);
         header.negative_pnl_account_count = V16PodU64::new(1);
     } else {
         account_header.pnl = V16PodI128::new(0);
@@ -8680,16 +8694,17 @@ fn proof_v16_public_resolved_close_flat_account_pays_only_capital_and_vault() {
 #[kani::proof]
 #[kani::unwind(40)]
 #[kani::solver(cadical)]
-fn proof_v16_resolved_two_active_legs_are_unattributed_for_bankruptcy() {
+fn proof_v16_resolved_bankruptcy_attribution_uses_recorded_loss_domain() {
     let (mut header, mut markets, mut account_header) = two_market_view_fixture();
     header.mode = 1; // Resolved
     header.current_slot = V16PodU64::new(2);
     header.resolved_slot = V16PodU64::new(2);
     header.slot_last = V16PodU64::new(2);
+    header.negative_pnl_account_count = V16PodU64::new(1);
+    seed_negative_pnl(&mut account_header, &markets, 2, 5);
 
     let mut bitmap = account_header.active_bitmap.map(V16PodU64::get);
     active_bitmap_set(&mut bitmap, 0).unwrap();
-    active_bitmap_set(&mut bitmap, 1).unwrap();
     account_header.active_bitmap = bitmap.map(V16PodU64::new);
 
     let mut asset0 = markets[0].engine.asset.try_to_runtime().unwrap();
@@ -8715,70 +8730,36 @@ fn proof_v16_resolved_two_active_legs_are_unattributed_for_bankruptcy() {
         stale: false,
     });
 
-    let mut asset1 = markets[1].engine.asset.try_to_runtime().unwrap();
-    asset1.oi_eff_short_q = POS_SCALE;
-    asset1.stored_pos_count_short = 1;
-    asset1.loss_weight_sum_short = POS_SCALE;
-    markets[1].engine.asset = AssetStateV16Account::from_runtime(&asset1);
-    account_header.legs[1] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
-        active: true,
-        asset_index: 1,
-        market_id: asset1.market_id,
-        side: SideV16::Short,
-        basis_pos_q: -(POS_SCALE as i128),
-        a_basis: ADL_ONE,
-        k_snap: asset1.k_short,
-        f_snap: asset1.f_short_num,
-        epoch_snap: asset1.epoch_short,
-        loss_weight: POS_SCALE,
-        b_snap: asset1.b_short_num,
-        b_rem: 0,
-        b_epoch_snap: asset1.epoch_short,
-        b_stale: false,
-        stale: false,
-    });
-
     let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
     let account = PortfolioV16ViewMut::new(&mut account_header);
     let attribution = market
         .kani_resolved_bankruptcy_attribution(&account.as_view())
         .unwrap();
 
-    kani::cover!(true, "resolved bankruptcy attribution sees two active legs");
-    assert_eq!(attribution, None);
+    kani::cover!(
+        true,
+        "recorded asset-1 debt survives an unrelated asset-0 leg"
+    );
+    assert_eq!(attribution, Some((1, SideV16::Short)));
 }
 
 #[kani::proof]
 #[kani::unwind(40)]
 #[kani::solver(cadical)]
-fn proof_v16_resolved_unattributed_bad_debt_clears_without_recovery() {
+fn proof_v16_validator_rejects_unattributed_negative_pnl() {
     let loss_raw: u8 = kani::any();
     kani::assume((1..=8).contains(&loss_raw));
-    let loss = loss_raw as i128;
     let (mut header, mut markets, mut account_header) = one_market_view_fixture();
-    header.mode = 1; // Resolved
-    header.current_slot = V16PodU64::new(2);
-    header.resolved_slot = V16PodU64::new(2);
-    header.slot_last = V16PodU64::new(2);
-    header.negative_pnl_account_count = V16PodU64::new(1);
-    account_header.pnl = V16PodI128::new(-loss);
-    account_header.last_fee_slot = V16PodU64::new(2);
+    account_header.pnl = V16PodI128::new(-(loss_raw as i128));
 
-    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
-    let mut account = PortfolioV16ViewMut::new(&mut account_header);
-    let result = market.kani_settle_resolved_bankruptcy_negative_pnl(&mut account);
+    let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let account = PortfolioV16ViewMut::new(&mut account_header);
 
-    kani::cover!(
-        loss > 3,
-        "resolved close covers nontrivial unattributed terminal bad debt"
+    kani::cover!(loss_raw > 3, "validator sees nontrivial unattributed debt");
+    assert_eq!(
+        account.validate_with_market(&market.as_view()),
+        Err(V16Error::InvalidLeg)
     );
-    assert_ne!(result, Err(V16Error::RecoveryRequired));
-    assert_eq!(result, Ok(()));
-    assert_eq!(account.header.pnl.get(), 0);
-    assert!(active_bitmap_is_empty(
-        account.header.active_bitmap.map(V16PodU64::get)
-    ));
-    assert_eq!(market.header.negative_pnl_account_count.get(), 0);
 }
 
 #[kani::proof]
@@ -9446,93 +9427,6 @@ fn proof_v16_bankruptcy_residual_capacity_is_nonzero_and_bounded_with_headroom()
 #[kani::proof]
 #[kani::unwind(48)]
 #[kani::solver(cadical)]
-fn proof_v16_liquidation_preflight_accepts_only_fully_durable_residual() {
-    let residual_raw: u8 = kani::any();
-    kani::assume((1..=8).contains(&residual_raw));
-    let residual = residual_raw as u128;
-    let (mut header, mut markets, mut account_header) = one_market_view_fixture();
-    header.config.public_b_chunk_atoms = V16PodU128::new(residual);
-    header.vault = V16PodU128::new(0);
-    header.insurance = V16PodU128::new(0);
-    account_header.pnl = V16PodI128::new(-(residual as i128));
-    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
-    asset.oi_eff_long_q = POS_SCALE;
-    asset.oi_eff_short_q = POS_SCALE;
-    asset.stored_pos_count_long = 1;
-    asset.stored_pos_count_short = 1;
-    asset.loss_weight_sum_long = SOCIAL_LOSS_DEN;
-    asset.loss_weight_sum_short = SOCIAL_LOSS_DEN;
-    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
-    let header_before = header;
-    let market_before = markets[0];
-
-    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
-    market.refresh_header_aggregate_totals_for_test().unwrap();
-    let account = PortfolioV16ViewMut::new(&mut account_header);
-    let result =
-        market.kani_preflight_liquidation_residual_durability(0, SideV16::Long, &account.as_view());
-
-    kani::cover!(
-        residual > 1,
-        "liquidation residual preflight proof covers nontrivial residual"
-    );
-    assert_eq!(result, Ok(()));
-    assert_eq!(market.header.mode, header_before.mode);
-    assert_eq!(market.header.recovery_reason, header_before.recovery_reason);
-    assert_eq!(market.header.vault, header_before.vault);
-    assert_eq!(market.header.c_tot, header_before.c_tot);
-    assert_eq!(market.header.insurance, header_before.insurance);
-    assert_eq!(market.markets[0], market_before);
-}
-
-#[kani::proof]
-#[kani::unwind(48)]
-#[kani::solver(cadical)]
-fn proof_v16_liquidation_preflight_routes_insufficient_residual_capacity_to_recovery() {
-    let residual_raw: u8 = kani::any();
-    kani::assume((2..=8).contains(&residual_raw));
-    let residual = residual_raw as u128;
-    let (mut header, mut markets, mut account_header) = one_market_view_fixture();
-    header.config.public_b_chunk_atoms = V16PodU128::new(residual - 1);
-    header.vault = V16PodU128::new(0);
-    header.insurance = V16PodU128::new(0);
-    account_header.pnl = V16PodI128::new(-(residual as i128));
-    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
-    asset.oi_eff_long_q = POS_SCALE;
-    asset.oi_eff_short_q = POS_SCALE;
-    asset.stored_pos_count_long = 1;
-    asset.stored_pos_count_short = 1;
-    asset.loss_weight_sum_long = SOCIAL_LOSS_DEN;
-    asset.loss_weight_sum_short = SOCIAL_LOSS_DEN;
-    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
-    let vault_before = header.vault;
-    let c_tot_before = header.c_tot;
-    let insurance_before = header.insurance;
-
-    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
-    market.refresh_header_aggregate_totals_for_test().unwrap();
-    let account = PortfolioV16ViewMut::new(&mut account_header);
-    let result =
-        market.kani_preflight_liquidation_residual_durability(0, SideV16::Long, &account.as_view());
-
-    kani::cover!(
-        residual > 2,
-        "liquidation residual preflight proof covers nontrivial recovery residual"
-    );
-    assert_eq!(result, Err(V16Error::RecoveryRequired));
-    assert_eq!(market.header.mode, 2);
-    assert_eq!(
-        market.header.recovery_reason.try_to_runtime().unwrap(),
-        Some(PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress)
-    );
-    assert_eq!(market.header.vault, vault_before);
-    assert_eq!(market.header.c_tot, c_tot_before);
-    assert_eq!(market.header.insurance, insurance_before);
-}
-
-#[kani::proof]
-#[kani::unwind(48)]
-#[kani::solver(cadical)]
 fn proof_v16_view_fee_sync_settles_negative_pnl_before_fee() {
     let capital_raw: u8 = kani::any();
     let loss_raw: u8 = kani::any();
@@ -9552,7 +9446,7 @@ fn proof_v16_view_fee_sync_settles_negative_pnl_before_fee() {
     header.current_slot = V16PodU64::new(10);
     header.slot_last = V16PodU64::new(10);
     account_header.capital = V16PodU128::new(capital);
-    account_header.pnl = V16PodI128::new(-(loss as i128));
+    seed_negative_pnl(&mut account_header, &markets, 0, loss);
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
     let mut account = PortfolioV16ViewMut::new(&mut account_header);
 
@@ -9570,81 +9464,6 @@ fn proof_v16_view_fee_sync_settles_negative_pnl_before_fee() {
     assert_eq!(market.header.c_tot.get(), capital - loss - expected_fee);
     assert_eq!(market.header.insurance.get(), expected_fee);
     assert_eq!(market.header.vault.get(), capital);
-}
-
-#[kani::proof]
-#[kani::unwind(48)]
-#[kani::solver(cadical)]
-fn proof_v16_loss_senior_fee_ordering_consumes_kf_loss_before_fee() {
-    let capital_raw: u8 = kani::any();
-    let hidden_loss_raw: u8 = kani::any();
-    let requested_fee_raw: u8 = kani::any();
-    kani::assume(hidden_loss_raw > 0);
-
-    let (mut header, mut markets, mut account_header) = one_market_view_fixture();
-    let capital = capital_raw as u128;
-    let hidden_loss = hidden_loss_raw as u128;
-    let requested_fee = requested_fee_raw as u128;
-    header.vault = V16PodU128::new(capital);
-    header.c_tot = V16PodU128::new(capital);
-    account_header.capital = V16PodU128::new(capital);
-    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
-    let mut account = PortfolioV16ViewMut::new(&mut account_header);
-
-    market
-        .kani_apply_signed_kf_delta_to_pnl(&mut account, -(hidden_loss as i128), None)
-        .unwrap();
-    let paid = market
-        .kani_settle_negative_pnl_from_principal_core_not_atomic(&mut account)
-        .unwrap();
-    let charged = market
-        .kani_charge_account_fee_current_not_atomic(&mut account, requested_fee)
-        .unwrap();
-
-    let expected_paid = capital.min(hidden_loss);
-    let expected_pnl = if hidden_loss > capital {
-        -((hidden_loss - capital) as i128)
-    } else {
-        0
-    };
-    let expected_fee = if expected_pnl < 0 {
-        0
-    } else {
-        requested_fee.min(capital - expected_paid)
-    };
-    kani::cover!(
-        capital > 10 && hidden_loss < capital && requested_fee > capital - hidden_loss,
-        "loss-senior fee ordering covers wide fee capped after K/F loss"
-    );
-    kani::cover!(
-        capital > 10 && hidden_loss > capital && requested_fee > 10,
-        "loss-senior fee ordering covers wide no-fee bankrupt K/F loss"
-    );
-    assert_eq!(paid, expected_paid);
-    assert_eq!(charged, expected_fee);
-    assert_eq!(
-        account.header.capital.get(),
-        capital - expected_paid - expected_fee
-    );
-    assert_eq!(account.header.pnl.get(), expected_pnl);
-    assert_eq!(
-        market.header.c_tot.get(),
-        capital - expected_paid - expected_fee
-    );
-    assert_eq!(market.header.insurance.get(), expected_fee);
-    assert_eq!(market.header.vault.get(), capital);
-    assert_eq!(
-        market.header.c_tot.get() + market.header.insurance.get(),
-        capital - expected_paid
-    );
-    if hidden_loss > capital {
-        assert_eq!(expected_fee, 0);
-        assert_eq!(market.header.bankruptcy_hlock_active, 1);
-        assert_eq!(market.header.negative_pnl_account_count.get(), 1);
-    } else {
-        assert_eq!(account.header.pnl.get(), 0);
-        assert_eq!(market.header.negative_pnl_account_count.get(), 0);
-    }
 }
 
 #[kani::proof]
@@ -9671,7 +9490,7 @@ fn proof_v16_view_domain_budget_caps_bankruptcy_insurance_spend() {
     header.negative_pnl_account_count = V16PodU64::new(1);
     markets[0].engine.insurance_domain_budget_short = V16PodU128::new(budget);
     markets[0].engine.insurance_domain_budget_long = V16PodU128::new(other_budget);
-    account_header.pnl = V16PodI128::new(-(loss as i128));
+    seed_negative_pnl(&mut account_header, &markets, 1, loss);
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
     market.refresh_header_aggregate_totals_for_test().unwrap();
     let remaining_before = market.header.insurance_domain_budget_remaining_total.get();
@@ -9768,7 +9587,7 @@ fn proof_v16_reserved_domain_insurance_cannot_be_double_spent_by_bankruptcy() {
             credit_rate_num: CREDIT_RATE_SCALE,
             ..SourceCreditStateV16::EMPTY
         });
-    account_header.pnl = V16PodI128::new(-(loss as i128));
+    seed_negative_pnl(&mut account_header, &markets, 1, loss);
     let reservation_before = markets[0].engine.insurance_reservation_short;
     let source_before = markets[0].engine.source_credit_short;
 
@@ -9859,7 +9678,8 @@ fn proof_v16_new_unfunded_domain_cannot_consume_shared_insurance() {
     header.insurance = V16PodU128::new(shared_insurance);
     header.insurance_domain_budget_remaining_total = V16PodU128::new(funded_remaining);
     header.negative_pnl_account_count = V16PodU64::new(1);
-    account_header.pnl = V16PodI128::new(-(residual_loss as i128));
+    let target_domain = if target_short_domain { 1 } else { 0 };
+    seed_negative_pnl(&mut account_header, &markets, target_domain, residual_loss);
     if target_short_domain {
         markets[0].engine.insurance_domain_budget_long = V16PodU128::new(funded_budget);
         markets[0].engine.insurance_domain_spent_long = V16PodU128::new(funded_spent);
@@ -12827,7 +12647,7 @@ fn proof_v16_inductive_settle_negative_pnl_preserves_senior_solvency() {
 
     let mut acct_header = PortfolioAccountV16Account::default();
     acct_header.capital = V16PodU128::new(capital);
-    acct_header.pnl = V16PodI128::new(pnl);
+    seed_negative_pnl(&mut acct_header, &markets, 0, pnl.unsigned_abs());
 
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
     let mut account = PortfolioV16ViewMut::new(&mut acct_header);
@@ -15221,6 +15041,9 @@ fn proof_v16_validator_sound_account_reserves() {
     kani::assume(pnl > i128::MIN);
     let (header, markets, mut account_header) = one_market_view_fixture();
     account_header.pnl = V16PodI128::new(pnl);
+    if pnl < 0 {
+        seed_negative_pnl(&mut account_header, &markets, 0, pnl.unsigned_abs());
+    }
     account_header.reserved_pnl = V16PodU128::new(reserved_pnl);
     account_header.residual_spent_principal_atoms_total = V16PodU128::new(residual_spent);
     account_header.residual_crystallized_loss_atoms_total = V16PodU128::new(residual_crystallized);

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -10,10 +10,11 @@ use percolator::{
     PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
-    ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedPayoutLedgerV16,
-    ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16, ResolvedPayoutReceiptV16Account,
-    SideModeV16, SideV16, SourceCreditStateV16, SourceCreditStateV16Account, TradeRequestV16,
-    V16Config, V16Error, V16PodI128, V16PodU128, V16PodU32, V16PodU64, V16_EMPTY_ACTIVE_BITMAP,
+    ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedCloseOutcomeV16,
+    ResolvedPayoutLedgerV16, ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16,
+    ResolvedPayoutReceiptV16Account, SideModeV16, SideV16, SourceCreditStateV16,
+    SourceCreditStateV16Account, TradeRequestV16, V16Config, V16Error, V16PodI128, V16PodU128,
+    V16PodU32, V16PodU64, V16_EMPTY_ACTIVE_BITMAP,
 };
 use percolator::{ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, POS_SCALE};
 
@@ -82,6 +83,20 @@ fn account_fixture(market_slots: u32, account_seed: u8) -> PortfolioAccountV16Ac
     let mut account = PortfolioAccountV16Account::default();
     account.init_empty_in_place(header).unwrap();
     account
+}
+
+fn seed_negative_pnl(
+    account: &mut PortfolioAccountV16Account,
+    markets: &[Market<u64>],
+    domain: usize,
+    amount: u128,
+) {
+    let asset_index = domain / 2;
+    let market_id = markets[asset_index].engine.asset.market_id.get();
+    account.pnl = V16PodI128::new(-i128::try_from(amount).unwrap());
+    account.source_domains[0].domain = V16PodU32::new(u32::try_from(domain).unwrap());
+    account.source_domains[0].source_claim_market_id = V16PodU64::new(market_id);
+    account.source_domains[0].negative_pnl_atoms = V16PodU128::new(amount);
 }
 
 fn signed_q(q: u128) -> i128 {
@@ -458,7 +473,7 @@ fn v16_view_fee_sync_settles_flat_loss_before_fee() {
     header.current_slot = V16PodU64::new(10);
     header.slot_last = V16PodU64::new(10);
     account_header.capital = V16PodU128::new(100);
-    account_header.pnl = V16PodI128::new(-40);
+    seed_negative_pnl(&mut account_header, &markets, 0, 40);
 
     let mut market_view = MarketGroupV16ViewMut::new(&mut header, &mut markets);
     let mut account_view = PortfolioV16ViewMut::new(&mut account_header);
@@ -2098,7 +2113,7 @@ fn v16_public_liquidation_on_unfunded_domain_cannot_drain_shared_insurance() {
     markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
     header.resolved_payout_blocker_count = V16PodU64::new(4);
 
-    account_header.pnl = V16PodI128::new(-5);
+    seed_negative_pnl(&mut account_header, &markets, 1, 5);
     account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
         active: true,
         asset_index: 0,
@@ -2135,6 +2150,126 @@ fn v16_public_liquidation_on_unfunded_domain_cannot_drain_shared_insurance() {
         0
     );
     assert!(out.residual_booked > 0);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_liquidation_uses_recorded_loss_domain_not_selected_leg_domain() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut account_header = account_fixture(2, 32);
+    header.vault = V16PodU128::new(5);
+    header.insurance = V16PodU128::new(5);
+    header.insurance_domain_budget_remaining_total = V16PodU128::new(5);
+    header.negative_pnl_account_count = V16PodU64::new(1);
+    markets[0].engine.insurance_domain_budget_short = V16PodU128::new(5);
+
+    let mut asset0 = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset0.oi_eff_long_q = 2 * POS_SCALE;
+    asset0.oi_eff_short_q = 2 * POS_SCALE;
+    asset0.loss_weight_sum_long = 2 * POS_SCALE;
+    asset0.loss_weight_sum_short = 2 * POS_SCALE;
+    asset0.stored_pos_count_long = 2;
+    asset0.stored_pos_count_short = 2;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset0);
+    let mut asset1 = markets[1].engine.asset.try_to_runtime().unwrap();
+    asset1.oi_eff_long_q = 2 * POS_SCALE;
+    asset1.oi_eff_short_q = 2 * POS_SCALE;
+    asset1.loss_weight_sum_long = 2 * POS_SCALE;
+    asset1.loss_weight_sum_short = 2 * POS_SCALE;
+    asset1.stored_pos_count_long = 2;
+    asset1.stored_pos_count_short = 2;
+    markets[1].engine.asset = AssetStateV16Account::from_runtime(&asset1);
+    header.resolved_payout_blocker_count = V16PodU64::new(6);
+
+    // The debt belongs to asset 1's long domain, while liquidation selects an
+    // unrelated asset 0 long leg whose opposite-side insurance is funded.
+    seed_negative_pnl(&mut account_header, &markets, 2, 5);
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset0.market_id,
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset0.k_long,
+        f_snap: asset0.f_long_num,
+        epoch_snap: asset0.epoch_long,
+        loss_weight: POS_SCALE,
+        b_snap: asset0.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset0.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(1);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let out = market
+        .liquidate_account_not_atomic(&mut account, LiquidationRequestV16 { asset_index: 0 })
+        .expect("recorded asset-1 debt must progress without asset-0 insurance");
+
+    assert_eq!(out.insurance_used, 0);
+    assert_eq!(market.header.insurance.get(), 5);
+    assert_eq!(
+        market.markets[0].engine.insurance_domain_spent_short.get(),
+        0
+    );
+    assert_eq!(market.markets[0].engine.asset.b_short_num.get(), 0);
+    assert!(market.markets[1].engine.asset.b_long_num.get() > 0);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_resolved_close_rotates_finalized_ledger_across_loss_domains() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut account_header = account_fixture(2, 33);
+    header.mode = 1; // Resolved
+    header.resolved_slot = header.current_slot;
+    header.negative_pnl_account_count = V16PodU64::new(1);
+    header.bankruptcy_hlock_active = 1;
+    account_header.pnl = V16PodI128::new(-7);
+    account_header.source_domains[0].domain = V16PodU32::new(0);
+    account_header.source_domains[0].source_claim_market_id = markets[0].engine.asset.market_id;
+    account_header.source_domains[0].negative_pnl_atoms = V16PodU128::new(3);
+    account_header.source_domains[1].domain = V16PodU32::new(2);
+    account_header.source_domains[1].source_claim_market_id = markets[1].engine.asset.market_id;
+    account_header.source_domains[1].negative_pnl_atoms = V16PodU128::new(4);
+    for market_slot in &mut markets {
+        let mut asset = market_slot.engine.asset.try_to_runtime().unwrap();
+        asset.oi_eff_long_q = POS_SCALE;
+        asset.loss_weight_sum_long = POS_SCALE;
+        asset.stored_pos_count_long = 1;
+        market_slot.engine.asset = AssetStateV16Account::from_runtime(&asset);
+    }
+    header.resolved_payout_blocker_count = V16PodU64::new(2);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    assert_eq!(market.validate_shape(), Ok(()));
+    assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
+
+    let first = market
+        .close_resolved_account_not_atomic(&mut account, 0)
+        .expect("first domain must settle");
+    assert_eq!(first, ResolvedCloseOutcomeV16::ProgressOnly);
+    assert_eq!(account.header.pnl.get(), -4);
+    let first_ledger = account.header.close_progress.try_to_runtime().unwrap();
+    assert!(first_ledger.active && first_ledger.finalized && !first_ledger.canceled);
+    assert_eq!(first_ledger.residual_remaining, 0);
+    assert_eq!(first_ledger.asset_index, 0);
+    assert_eq!(first_ledger.explicit_loss_assigned, 3);
+    assert_eq!(market.markets[0].engine.asset.b_long_num.get(), 0);
+
+    let second = market
+        .close_resolved_account_not_atomic(&mut account, 0)
+        .expect("finalized ledger must rotate to the second domain");
+    assert_eq!(second, ResolvedCloseOutcomeV16::Closed { payout: 0 });
+    assert_eq!(account.header.pnl.get(), 0);
+    assert_eq!(market.header.negative_pnl_account_count.get(), 0);
+    assert_eq!(market.markets[1].engine.asset.b_long_num.get(), 0);
     market.validate_shape().unwrap();
     account.validate_with_market(&market.as_view()).unwrap();
 }
@@ -2323,7 +2458,7 @@ fn v16_permissionless_liquidation_progresses_when_unrelated_asset_is_loss_stale(
     markets[1].engine.asset = AssetStateV16Account::from_runtime(&asset1);
     header.resolved_payout_blocker_count = V16PodU64::new(6);
 
-    account_header.pnl = V16PodI128::new(-5);
+    seed_negative_pnl(&mut account_header, &markets, 1, 5);
     account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
         active: true,
         asset_index: 0,
@@ -2721,7 +2856,7 @@ fn v16_principal_loss_crystallizes_residual_budget_monotonically() {
     header.c_tot = V16PodU128::new(100);
     header.negative_pnl_account_count = V16PodU64::new(1);
     account_header.capital = V16PodU128::new(100);
-    account_header.pnl = V16PodI128::new(-40);
+    seed_negative_pnl(&mut account_header, &markets, 0, 40);
     account_header.residual_crystallized_loss_atoms_total = V16PodU128::new(7);
 
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
@@ -3066,7 +3201,7 @@ fn v16_auto_crank_drives_stale_underwater_account_to_derisked_fixed_point() {
     markets[1].engine.asset = AssetStateV16Account::from_runtime(&asset1);
     header.resolved_payout_blocker_count = V16PodU64::new(6);
 
-    account_header.pnl = V16PodI128::new(-5);
+    seed_negative_pnl(&mut account_header, &markets, 1, 5);
     account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
         active: true,
         asset_index: 0,
@@ -3173,7 +3308,7 @@ fn v16_auto_crank_liquidates_current_account_without_observation() {
     markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
     header.resolved_payout_blocker_count = V16PodU64::new(4);
 
-    account_header.pnl = V16PodI128::new(-5);
+    seed_negative_pnl(&mut account_header, &markets, 1, 5);
     account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
         active: true,
         asset_index: 0,
@@ -3654,7 +3789,7 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
             asset.stored_pos_count_short = 2;
             markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
             header.resolved_payout_blocker_count = V16PodU64::new(4);
-            account_header.pnl = V16PodI128::new(-5);
+            seed_negative_pnl(&mut account_header, &markets, 1, 5);
             account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
                 active: true,
                 asset_index: 0,


### PR DESCRIPTION
## Finding

A public cross-margin sequence could realize a loss on one asset, flatten that loss-bearing leg, and leave an unrelated leg active. The aggregate negative PnL retained no source-domain provenance, so later liquidation inferred the bankruptcy domain from the unrelated surviving leg and spent that domain's insurance.

The exact-parent wrapper LiteSVM regression demonstrates an independent asset-0 insurance provider losing `100100` atoms while the attacker receives `115300` atoms and nets `95100` atoms from an asset-1 loss. It uses only normal market initialization, trades, authenticated mark updates, maintenance, liquidation, and close instructions; it does not inject account state.

## Fix

- Persist negative-PnL atoms by insurance domain in each portfolio.
- Require the per-domain total to equal aggregate negative PnL.
- Attribute every loss-producing settlement path and consume offsets in lockstep.
- Route live and resolved bankruptcy settlement through the recorded domain, including multi-domain close progression.
- In Resolved mode, record each remaining terminal debt domain as explicit loss after the payout haircut instead of adding a second social-loss charge to winners.
- Bump the portfolio layout discriminator from 17 to 18. There are no deployed markets requiring migration.

This preserves the rule that one asset's insolvency cannot consume an independent asset's insurance after the originating leg exits.

## Verification

- `cargo test --all-targets --features fuzz`: 160 tests passed.
- Native regressions cover live liquidation domain selection and resolved multi-domain rotation.
- Eleven focused Kani harnesses passed on head `ab111c7e` with zero failures and all cover goals reached:
  - unattributed negative PnL is rejected
  - resolved bankruptcy uses recorded provenance
  - domain insurance spending remains budget-bounded
  - principal settles before bankruptcy residual
  - negative PnL settles before fee extraction
  - an unfunded domain cannot consume shared insurance
  - loss accrual creates exact domain provenance inductively
  - principal reduction conserves provenance across two domains
  - a domain cure frames unrelated debt
  - sparse principal preflight agrees with the production kernel
  - sparse targeted cure binding frames the unrelated domain

The complete 246-harness Kani roster was not rerun in this PR; three obsolete or redundant harnesses were removed after the new persisted invariant made their old fixtures unreachable or duplicated an existing ordering theorem. The resolved rotation regression uses live nonzero loss weights on both domains and asserts that neither domain's B index is incremented.

## Scope

The public regression can also encounter the already-reported SVM-rollback liveness issue when `RecoveryRequired` attempts to persist recovery state and the instruction rollback erases it. That is the separate wrapper #190 / engine #114 issue and is not duplicated here.
