### PR TITLE
[REAL DoS] Expire prospective loss backing before resolved settlement

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -682,6 +682,25 @@ impl V16Core {
             )
     }
 
+    #[inline]
+    fn resolved_prospective_loss_backing_requires_expiry(
+        pending_kf_delta: i128,
+        bucket_status: BackingBucketStatusV16,
+        bucket_expiry_slot: u64,
+        current_slot: u64,
+    ) -> bool {
+        pending_kf_delta < 0
+            && matches!(
+                Self::resolved_source_close_phase(
+                    0,
+                    bucket_status,
+                    bucket_expiry_slot,
+                    current_slot,
+                ),
+                ResolvedSourceClosePhaseV16::ExpireBacking
+            )
+    }
+
     fn loss_stale_trade_scope_allowed(
         market_loss_stale_active: bool,
         trade_asset_loss_stale: bool,
@@ -15542,9 +15561,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(None)
     }
 
-    /// K/F settlement can create a source claim that is not present in the
-    /// account's source roster yet. Expire one lapsed prospective source before
-    /// settlement so valuation cannot reject that claim and roll the close back.
+    /// K/F settlement can create a positive source claim or reserve newly
+    /// negative PnL as same-side capital backing. Expire one lapsed prospective
+    /// domain before either mutation so settlement cannot roll the close back.
     fn prepare_one_prospective_source_domain_for_resolved_close_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
@@ -15560,31 +15579,39 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             if leg.active {
                 let asset_index = leg.asset_index as usize;
                 let asset = self.asset_state(asset_index)?;
-                let domain = self.insurance_domain_index(asset_index, opposite_side(leg.side))?;
+                let (_k_now, _f_now, _k_delta, _f_delta, net) =
+                    Self::leg_kf_delta_components_for_settlement_from_asset(asset, leg)?;
+                let source_side = if net > 0 {
+                    opposite_side(leg.side)
+                } else if net < 0 {
+                    leg.side
+                } else {
+                    slot += 1;
+                    continue;
+                };
+                let domain = self.insurance_domain_index(asset_index, source_side)?;
                 let bucket = self.backing_bucket_for_domain(domain)?;
-                if matches!(
-                    V16Core::resolved_source_close_phase(
-                        0,
-                        bucket.status,
-                        bucket.expiry_slot,
-                        current_slot,
-                    ),
-                    ResolvedSourceClosePhaseV16::ExpireBacking
-                ) {
-                    let (_k_now, _f_now, _k_delta, _f_delta, net) =
-                        Self::leg_kf_delta_components_for_settlement_from_asset(asset, leg)?;
-                    if V16Core::resolved_prospective_source_requires_expiry(
+                let requires_expiry = if net > 0 {
+                    V16Core::resolved_prospective_source_requires_expiry(
                         net,
                         bucket.status,
                         bucket.expiry_slot,
                         current_slot,
-                    ) {
-                        self.expire_source_backing_bucket_not_atomic(domain, current_slot)?;
-                        account.header.health_cert.valid = 0;
-                        self.validate_shape()?;
-                        account.validate_with_market(&self.as_view())?;
-                        return Ok(Some(domain));
-                    }
+                    )
+                } else {
+                    V16Core::resolved_prospective_loss_backing_requires_expiry(
+                        net,
+                        bucket.status,
+                        bucket.expiry_slot,
+                        current_slot,
+                    )
+                };
+                if requires_expiry {
+                    self.expire_source_backing_bucket_not_atomic(domain, current_slot)?;
+                    account.header.health_cert.valid = 0;
+                    self.validate_shape()?;
+                    account.validate_with_market(&self.as_view())?;
+                    return Ok(Some(domain));
                 }
             }
             slot += 1;

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -41,6 +41,20 @@ pub fn kani_resolved_prospective_source_requires_expiry(
     )
 }
 
+pub fn kani_resolved_prospective_loss_backing_requires_expiry(
+    pending_kf_delta: i128,
+    bucket_status: BackingBucketStatusV16,
+    bucket_expiry_slot: u64,
+    current_slot: u64,
+) -> bool {
+    V16Core::resolved_prospective_loss_backing_requires_expiry(
+        pending_kf_delta,
+        bucket_status,
+        bucket_expiry_slot,
+        current_slot,
+    )
+}
+
 pub fn kani_auto_crank_lifecycle_dispatchable(lifecycle: AssetLifecycleV16) -> bool {
     V16Core::kernel_auto_crank_lifecycle_dispatchable(lifecycle)
 }

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -16,20 +16,21 @@ use percolator::v16::{
     kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
     kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
-    kani_prepare_asset_recovery_transition, kani_resolved_prospective_source_requires_expiry,
-    kani_resolved_source_close_phase, kani_select_auto_crank_plan,
-    kani_should_clear_prior_reset_obligation, kani_source_credit_state_realizable_support_for_face,
-    kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
-    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
-    ActionableSummaryV16, AssetLifecycleV16, AssetStateV16, AssetStateV16Account, AutoCrankPlanV16,
-    BackingBucketStatusV16, BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16,
-    CloseProgressLedgerV16, CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16,
-    HealthCertV16, HealthCertV16Account, InsuranceCreditReservationV16,
-    InsuranceCreditReservationV16Account, Market, MarketGroupV16HeaderAccount,
-    MarketGroupV16ViewMut, PermissionlessCrankActionV16, PermissionlessCrankRequestV16,
-    PermissionlessProgressOutcomeV16, PermissionlessRecoveryReasonV16, PortfolioAccountV16Account,
-    PortfolioLegV16, PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View,
-    PortfolioV16ViewMut, ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedPayoutLedgerV16,
+    kani_prepare_asset_recovery_transition, kani_resolved_prospective_loss_backing_requires_expiry,
+    kani_resolved_prospective_source_requires_expiry, kani_resolved_source_close_phase,
+    kani_select_auto_crank_plan, kani_should_clear_prior_reset_obligation,
+    kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
+    kani_trade_preexisting_oi_reduction_gate, kani_trade_preflight_risk_gate,
+    kani_validate_positive_pnl_source_attribution, ActionableSummaryV16, AssetLifecycleV16,
+    AssetStateV16, AssetStateV16Account, AutoCrankPlanV16, BackingBucketStatusV16,
+    BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
+    CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
+    HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
+    Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
+    PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
+    PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
+    PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
+    ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedPayoutLedgerV16,
     ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16, ResolvedPayoutReceiptV16Account,
     SideModeV16, SideV16, SourceCreditStateV16, SourceCreditStateV16Account,
     StockReconciliationProofV16, TokenValueClassV16, TokenValueFlowProofV16, V16Config,
@@ -8810,6 +8811,59 @@ fn proof_v16_resolved_prospective_source_expiry_strictly_decreases_rank() {
         let rank_before = u8::from(pending_positive && lapsed);
         let rank_after = u8::from(
             pending_positive
+                && status_after == BackingBucketStatusV16::Fresh
+                && expiry_slot <= current_slot,
+        );
+        assert_eq!(rank_before, 1);
+        assert_eq!(rank_after, 0);
+        assert!(rank_after < rank_before);
+    }
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_resolved_prospective_loss_backing_expiry_strictly_decreases_rank() {
+    let pending_kf_delta: i64 = kani::any();
+    let status_raw: u8 = kani::any();
+    let expiry_slot: u8 = kani::any();
+    let current_slot: u8 = kani::any();
+    kani::assume(status_raw <= 3);
+
+    let status = match status_raw {
+        0 => BackingBucketStatusV16::Empty,
+        1 => BackingBucketStatusV16::Fresh,
+        2 => BackingBucketStatusV16::Expired,
+        _ => BackingBucketStatusV16::Impaired,
+    };
+    let pending_loss = pending_kf_delta < 0;
+    let lapsed = status == BackingBucketStatusV16::Fresh && expiry_slot <= current_slot;
+    let requires_expiry = kani_resolved_prospective_loss_backing_requires_expiry(
+        pending_kf_delta as i128,
+        status,
+        expiry_slot as u64,
+        current_slot as u64,
+    );
+
+    kani::cover!(
+        requires_expiry,
+        "a pending negative K/F delta selects its lapsed capital-backing domain"
+    );
+    kani::cover!(
+        pending_loss && !lapsed,
+        "a usable prospective loss-backing domain needs no preparatory expiry"
+    );
+    kani::cover!(
+        !pending_loss && lapsed,
+        "a lapsed loss domain is not touched without a prospective negative delta"
+    );
+
+    assert_eq!(requires_expiry, pending_loss && lapsed);
+    if requires_expiry {
+        let status_after = BackingBucketStatusV16::Expired;
+        let rank_before = u8::from(pending_loss && lapsed);
+        let rank_after = u8::from(
+            pending_loss
                 && status_after == BackingBucketStatusV16::Fresh
                 && expiry_slot <= current_slot,
         );

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3118,6 +3118,101 @@ fn v16_resolved_close_expires_lapsed_prospective_kf_sources() {
 }
 
 #[test]
+fn v16_resolved_close_expires_lapsed_prospective_loss_backing_domain() {
+    let (market_id, _, _) = ids();
+    let mut cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
+    cfg.max_price_move_bps_per_slot = 200;
+    cfg.max_accrual_dt_slots = 1;
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_id, cfg, 1, 0).unwrap();
+    let mut markets = vec![Market::new(0, EngineAssetSlotV16Account::default())];
+    header
+        .activate_empty_asset_slot_not_atomic(0, &mut markets[0].engine, 100, 1)
+        .unwrap();
+    let mut long_header = account_fixture(1, 27);
+    let mut short_header = account_fixture(1, 28);
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+
+    market.deposit_not_atomic(&mut long, 1_000).unwrap();
+    market.deposit_not_atomic(&mut short, 1_000).unwrap();
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: signed_q(POS_SCALE),
+                exec_price: 100,
+                fee_bps: 0,
+            },
+        )
+        .unwrap();
+    market
+        .deposit_fresh_counterparty_backing_not_atomic(0, 93, 8)
+        .unwrap();
+
+    market
+        .accrue_asset_to_not_atomic(0, 2, 98, 0, true)
+        .unwrap();
+    for slot in 3..=9 {
+        market
+            .accrue_asset_to_not_atomic(0, slot, 98, 0, true)
+            .unwrap();
+    }
+    assert_eq!(long.header.pnl.get(), 0);
+    assert!(long
+        .header
+        .source_domains
+        .iter()
+        .all(|source| !source.is_occupied()));
+    assert_eq!(
+        market.markets[0]
+            .engine
+            .backing_long
+            .try_to_runtime()
+            .unwrap()
+            .status,
+        BackingBucketStatusV16::Fresh
+    );
+    market.resolve_market_not_atomic(9).unwrap();
+
+    let mut long_closed = false;
+    let mut short_closed = false;
+    for _ in 0..16 {
+        if !long_closed {
+            long_closed = matches!(
+                market
+                    .close_resolved_account_not_atomic(&mut long, 0)
+                    .expect("the lapsed prospective loss domain must make bounded progress"),
+                percolator::ResolvedCloseOutcomeV16::Closed { .. }
+            );
+        }
+        if !short_closed {
+            short_closed = matches!(
+                market
+                    .close_resolved_account_not_atomic(&mut short, 0)
+                    .expect("the counterparty must retain a bounded resolved-close path"),
+                percolator::ResolvedCloseOutcomeV16::Closed { .. }
+            );
+        }
+    }
+
+    assert!(long_closed && short_closed);
+    assert!(percolator::active_bitmap_is_empty(
+        long.header.active_bitmap.map(V16PodU64::get)
+    ));
+    assert!(percolator::active_bitmap_is_empty(
+        short.header.active_bitmap.map(V16PodU64::get)
+    ));
+    assert_eq!(long.header.capital.get(), 0);
+    assert_eq!(short.header.capital.get(), 0);
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+    short.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_grant_source_positive_pnl_attributes_claims_and_aggregates_in_lockstep() {
     let (mut header, mut markets) = market_fixture(1, 1);
     let mut account_header = account_fixture(1, 31);


### PR DESCRIPTION
## What changed

- Extend resolved-close prospective-domain preflight to inspect both K/F polarities.
- For a pending negative K/F delta, select the leg's same-side capital-backing domain and expire one lapsed `Fresh` bucket before settlement.
- Add a production-route regression and a Kani rank-decrease proof for the new branch.

## Root cause and impact

This is stacked on #150. That fix preflights a pending positive K/F source claim, but a pending negative K/F delta can also mutate source-domain state: settlement reserves newly negative PnL as same-side capital backing.

If that same-side bucket is still marked `Fresh` after its expiry, settlement attempts to add backing with a new expiry and returns `LockActive`. In a resolved market the account cannot trade, rebalance, or use live crank routes, so every bounded public `CloseResolved` retry rolls back and the portfolio's capital remains locked. A public two-market LiteSVM lifecycle on the exact parent reproduces this without state injection; other portfolios reach their terminal paths while the victim repeatedly returns `EngineLockActive`.

The fix performs one bounded, value-neutral expiry step and returns progress. A later close settles the loss normally.

## Validation

- `cargo fmt --check`
- `cargo test --all-targets` (50 unit, 11 backing, 2 resolved-insolvent, 78 spec tests)
- `cargo kani --tests --features fuzz --harness proof_v16_resolved_prospective_loss_backing_expiry_strictly_decreases_rank` (0/16 failed; 3/3 covers)
- Stacked wrapper LiteSVM RED/GREEN reproduction and 14-leg max-shape CU test
