### PR TITLE
[REAL DoS] Reconcile foreign-expired source liens during resolved close

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 267 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 268 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 268 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 270 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -891,13 +891,11 @@ impl V16Core {
                 .checked_sub(effective)
                 .ok_or(V16Error::CounterUnderflow)?,
         );
-        source.source_lien_impaired_effective_reserved = V16PodU128::new(
-            source
-                .source_lien_impaired_effective_reserved
-                .get()
-                .checked_add(effective)
-                .ok_or(V16Error::CounterOverflow)?,
-        );
+        // Expired counterparty principal already left the recoverable backing
+        // stock. Do not add it to the generic impaired-effective field: that
+        // field is backed by impaired insurance and its burn path releases the
+        // corresponding insurance reservation. Provider audit labels are
+        // retired separately while this account still carries exact provenance.
         source.source_lien_fee_last_slot = V16PodU64::new(0);
         Ok((source, effective))
     }
@@ -2994,6 +2992,51 @@ impl V16Core {
             .impaired_liened_backing_num
             .checked_add(amount)
             .ok_or(V16Error::CounterOverflow)?;
+        Ok((bucket, source))
+    }
+
+    /// Retire provider-backed lien labels after expiry has already forfeited
+    /// their principal into the junior residual pool. The account still carries
+    /// the exact counterparty amount at this point, so this transition preserves
+    /// provenance and remains order-independent across accounts in one domain.
+    #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &V16Result<(BackingBucketV16, SourceCreditStateV16)>| match result {
+        Ok((b, s)) => (amount == 0 && *b == bucket && *s == source)
+            || (b.impaired_liened_backing_num == bucket.impaired_liened_backing_num.wrapping_sub(amount)
+                && s.impaired_liened_backing_num == source.impaired_liened_backing_num.wrapping_sub(amount)
+                && b.fresh_unliened_backing_num == bucket.fresh_unliened_backing_num
+                && b.valid_liened_backing_num == bucket.valid_liened_backing_num
+                && b.consumed_liened_backing_num == bucket.consumed_liened_backing_num
+                && s.fresh_reserved_backing_num == source.fresh_reserved_backing_num
+                && s.valid_liened_backing_num == source.valid_liened_backing_num
+                && s.spent_backing_num == source.spent_backing_num
+                && s.provider_receivable_num == source.provider_receivable_num
+                && s.insurance_credit_reserved_num == source.insurance_credit_reserved_num
+                && s.valid_liened_insurance_num == source.valid_liened_insurance_num
+                && s.impaired_liened_insurance_num == source.impaired_liened_insurance_num),
+        Err(_) => true,
+    }))]
+    fn prepare_counterparty_impaired_lien_retirement_delta(
+        mut bucket: BackingBucketV16,
+        mut source: SourceCreditStateV16,
+        amount: u128,
+    ) -> V16Result<(BackingBucketV16, SourceCreditStateV16)> {
+        if amount == 0 {
+            return Ok((bucket, source));
+        }
+        Self::validate_bound_num_atom_aligned(amount)?;
+        if bucket.status != BackingBucketStatusV16::Impaired
+            || bucket.fresh_unliened_backing_num != 0
+            || bucket.valid_liened_backing_num != 0
+            || bucket.impaired_liened_backing_num < amount
+            || source.impaired_liened_backing_num < amount
+        {
+            return Err(V16Error::CounterUnderflow);
+        }
+        bucket.impaired_liened_backing_num -= amount;
+        source.impaired_liened_backing_num -= amount;
+        if bucket.impaired_liened_backing_num == 0 {
+            bucket.status = BackingBucketStatusV16::Expired;
+        }
         Ok((bucket, source))
     }
 
@@ -8345,6 +8388,37 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Ok(());
         }
         let (bucket, source) = V16Core::prepare_counterparty_lien_terminal_release_delta(
+            self.backing_bucket_for_domain(domain)?,
+            self.source_credit_for_domain(domain)?,
+            amount,
+        )?;
+        let (source, next_risk_epoch) = V16Core::prepare_source_credit_domain_recompute_for_epoch(
+            source,
+            self.header.risk_epoch.get(),
+        )?;
+        self.reservation_encumbrance_proof_for_domain_parts(
+            domain,
+            source,
+            bucket,
+            self.insurance_reservation_for_domain(domain)?,
+        )?
+        .validate()?;
+        self.set_backing_bucket_for_domain(domain, bucket)?;
+        self.set_source_credit_for_domain(domain, source)?;
+        self.header.risk_epoch = V16PodU64::new(next_risk_epoch);
+        self.validate_shape()
+    }
+
+    fn retire_source_credit_lien_from_counterparty_impaired_not_atomic(
+        &mut self,
+        domain: usize,
+        amount: u128,
+    ) -> V16Result<()> {
+        self.domain_asset_side(domain)?;
+        if amount == 0 {
+            return Ok(());
+        }
+        let (bucket, source) = V16Core::prepare_counterparty_impaired_lien_retirement_delta(
             self.backing_bucket_for_domain(domain)?,
             self.source_credit_for_domain(domain)?,
             amount,
@@ -16404,6 +16478,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 }
                 self.collect_account_backing_utilization_fee_for_domain_not_atomic(
                     account, domain,
+                )?;
+                self.retire_source_credit_lien_from_counterparty_impaired_not_atomic(
+                    domain,
+                    account_counterparty_backing,
                 )?;
                 Self::impair_account_source_credit_counterparty_lien_fields(account, domain)?;
                 self.validate_shape()?;

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -820,6 +820,88 @@ impl V16Core {
         ))
     }
 
+    fn crystallize_source_lien_fee_for_effective(
+        source: &mut PortfolioSourceDomainV16Account,
+        impaired_effective: u128,
+    ) -> V16Result<u128> {
+        let live_effective = source.source_lien_effective_reserved.get();
+        if impaired_effective > live_effective {
+            return Err(V16Error::CounterUnderflow);
+        }
+        let live_fee = source.source_lien_capital_at_risk_fee_revenue.get();
+        let impaired_fee = if impaired_effective == live_effective {
+            live_fee
+        } else if impaired_effective == 0 || live_fee == 0 {
+            0
+        } else {
+            wide_mul_div_floor_u128(live_fee, impaired_effective, live_effective)
+        };
+        source.source_lien_capital_at_risk_fee_revenue = V16PodU128::new(
+            live_fee
+                .checked_sub(impaired_fee)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        source.source_lien_impaired_capital_at_risk_fee_revenue = V16PodU128::new(
+            source
+                .source_lien_impaired_capital_at_risk_fee_revenue
+                .get()
+                .checked_add(impaired_fee)
+                .ok_or(V16Error::CounterOverflow)?,
+        );
+        Ok(impaired_fee)
+    }
+
+    fn prepare_account_counterparty_lien_impairment(
+        mut source: PortfolioSourceDomainV16Account,
+    ) -> V16Result<(PortfolioSourceDomainV16Account, u128)> {
+        let face = source.source_claim_counterparty_liened_num.get();
+        let backing_num = source.source_lien_counterparty_backing_num.get();
+        if face == 0 && backing_num == 0 {
+            return Ok((source, 0));
+        }
+        if face == 0 || backing_num == 0 || backing_num % BOUND_SCALE != 0 {
+            return Err(V16Error::InvalidLeg);
+        }
+        let effective = backing_num / BOUND_SCALE;
+        if effective == 0 {
+            return Err(V16Error::InvalidLeg);
+        }
+
+        Self::crystallize_source_lien_fee_for_effective(&mut source, effective)?;
+        source.source_claim_counterparty_liened_num = V16PodU128::new(0);
+        source.source_claim_liened_num = V16PodU128::new(
+            source
+                .source_claim_liened_num
+                .get()
+                .checked_sub(face)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        source.source_claim_impaired_num = V16PodU128::new(
+            source
+                .source_claim_impaired_num
+                .get()
+                .checked_add(face)
+                .ok_or(V16Error::CounterOverflow)?,
+        );
+        source.source_lien_counterparty_backing_num = V16PodU128::new(0);
+        source.source_lien_effective_reserved = V16PodU128::new(
+            source
+                .source_lien_effective_reserved
+                .get()
+                .checked_sub(effective)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        source.source_lien_impaired_effective_reserved = V16PodU128::new(
+            source
+                .source_lien_impaired_effective_reserved
+                .get()
+                .checked_add(effective)
+                .ok_or(V16Error::CounterOverflow)?,
+        );
+        source.source_lien_fee_last_slot = V16PodU64::new(0);
+        Ok((source, effective))
+    }
+
     fn terminal_claim_free_overlap_recredit(
         provider_receivable_atoms: u128,
         paired_domain_insurance_spent: u128,
@@ -8897,6 +8979,21 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok((impaired_burn, impaired_effective_burn))
     }
 
+    fn impair_account_source_credit_counterparty_lien_fields(
+        account: &mut PortfolioV16ViewMut<'_>,
+        domain: usize,
+    ) -> V16Result<u128> {
+        let slot = account
+            .source_domain_slot(domain)?
+            .ok_or(V16Error::InvalidLeg)?;
+        let (source, effective) = V16Core::prepare_account_counterparty_lien_impairment(
+            account.header.source_domains[slot],
+        )?;
+        account.header.source_domains[slot] = source;
+        account.header.health_cert.valid = 0;
+        Ok(effective)
+    }
+
     #[cfg(any(kani, feature = "fuzz"))]
     fn impair_account_source_credit_insurance_lien_fields(
         account: &mut PortfolioV16ViewMut<'_>,
@@ -11839,12 +11936,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 V16PodU64::new(self.header.current_slot.get());
             return Ok(0);
         }
+        let mut bucket = self.backing_bucket_for_domain(domain)?;
+        let fee_through_slot = if bucket.expiry_slot == 0 {
+            self.header.current_slot.get()
+        } else {
+            self.header.current_slot.get().min(bucket.expiry_slot)
+        };
         let fee = V16Core::backing_utilization_fee_quote_atoms_for_lien(
             self.header.config.try_to_runtime_shape()?,
             self.source_credit_for_domain(domain)?,
             lien_backing_num,
             last_slot,
-            self.header.current_slot.get(),
+            fee_through_slot,
         )?;
         // Carry the floored-away fractional accrual forward: when the rent quote
         // floors to zero this interval, do NOT advance the fee cursor, so a later
@@ -11855,8 +11958,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Ok(0);
         }
         account.header.source_domains[slot].source_lien_fee_last_slot =
-            V16PodU64::new(self.header.current_slot.get());
-        let mut bucket = self.backing_bucket_for_domain(domain)?;
+            V16PodU64::new(fee_through_slot);
         let (charged, next_capital, next_c_tot, next_earnings) =
             apply_backing_utilization_fee_charge(
                 account.header.capital.get(),
@@ -16293,6 +16395,21 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             let domain = source.domain.get() as usize;
             self.domain_asset_side(domain)?;
             let bucket = self.backing_bucket_for_domain(domain)?;
+            let account_counterparty_backing = source.source_lien_counterparty_backing_num.get();
+            if account_counterparty_backing != 0
+                && bucket.status == BackingBucketStatusV16::Impaired
+            {
+                if bucket.impaired_liened_backing_num < account_counterparty_backing {
+                    return Err(V16Error::CounterUnderflow);
+                }
+                self.collect_account_backing_utilization_fee_for_domain_not_atomic(
+                    account, domain,
+                )?;
+                Self::impair_account_source_credit_counterparty_lien_fields(account, domain)?;
+                self.validate_shape()?;
+                account.validate_with_market(&self.as_view())?;
+                return Ok(Some(domain));
+            }
             if bucket.status == BackingBucketStatusV16::Fresh && bucket.expiry_slot <= current_slot
             {
                 if source.source_claim_liened_num.get() != 0 {

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -803,6 +803,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         V16Core::prepare_counterparty_lien_terminal_release_delta(bucket, source, amount)
     }
 
+    pub fn kani_prepare_counterparty_impaired_lien_retirement_delta(
+        bucket: BackingBucketV16,
+        source: SourceCreditStateV16,
+        amount: u128,
+    ) -> V16Result<(BackingBucketV16, SourceCreditStateV16)> {
+        V16Core::prepare_counterparty_impaired_lien_retirement_delta(bucket, source, amount)
+    }
+
     pub fn kani_prepare_counterparty_backing_add_delta(
         bucket: BackingBucketV16,
         source: SourceCreditStateV16,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -910,6 +910,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         )
     }
 
+    pub fn kani_prepare_account_counterparty_lien_impairment(
+        source: PortfolioSourceDomainV16Account,
+    ) -> V16Result<(PortfolioSourceDomainV16Account, u128)> {
+        V16Core::prepare_account_counterparty_lien_impairment(source)
+    }
+
     pub fn kani_counterparty_cure_atoms_from_scaled_backing(amount: u128) -> V16Result<u128> {
         V16Core::validate_bound_num_atom_aligned(amount)?;
         Ok(amount / BOUND_SCALE)

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -17445,13 +17445,14 @@ fn proof_v16_resolved_foreign_expiry_lien_impairment_is_exact_relabel() {
     );
     assert_eq!(
         after.source_lien_impaired_effective_reserved.get(),
-        prior_impaired_effective as u128 + counter_effective as u128
+        prior_impaired_effective as u128
     );
     assert_eq!(
         after.source_lien_effective_reserved.get()
             + after.source_lien_impaired_effective_reserved.get(),
         source.source_lien_effective_reserved.get()
             + source.source_lien_impaired_effective_reserved.get()
+            - counter_effective as u128
     );
     assert_eq!(after.source_lien_fee_last_slot.get(), 0);
     let expected_impaired_fee = (live_fee as u128) * (counter_effective as u128) / live_effective;
@@ -17468,4 +17469,157 @@ fn proof_v16_resolved_foreign_expiry_lien_impairment_is_exact_relabel() {
             + after.source_lien_impaired_capital_at_risk_fee_revenue.get(),
         live_fee as u128 + impaired_fee as u128
     );
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_resolved_foreign_expiry_retires_exact_provider_label_only() {
+    let total_raw: u8 = kani::any();
+    let retired_raw: u8 = kani::any();
+    let consumed_raw: u8 = kani::any();
+    let insurance_reserved_raw: u8 = kani::any();
+    let insurance_valid_raw: u8 = kani::any();
+    let insurance_impaired_raw: u8 = kani::any();
+    kani::assume((1..=8).contains(&total_raw));
+    kani::assume((1..=total_raw).contains(&retired_raw));
+    kani::assume(insurance_valid_raw <= insurance_reserved_raw);
+    kani::assume(insurance_impaired_raw <= insurance_reserved_raw - insurance_valid_raw);
+
+    let total = total_raw as u128 * BOUND_SCALE;
+    let retired = retired_raw as u128 * BOUND_SCALE;
+    let consumed = consumed_raw as u128 * BOUND_SCALE;
+    let insurance_reserved = insurance_reserved_raw as u128 * BOUND_SCALE;
+    let insurance_valid = insurance_valid_raw as u128 * BOUND_SCALE;
+    let insurance_impaired = insurance_impaired_raw as u128 * BOUND_SCALE;
+    let bucket = BackingBucketV16 {
+        market_id: 9,
+        impaired_liened_backing_num: total,
+        consumed_liened_backing_num: consumed,
+        expiry_slot: 7,
+        utilization_fee_earnings: 3,
+        status: BackingBucketStatusV16::Impaired,
+        ..BackingBucketV16::EMPTY
+    };
+    let source = SourceCreditStateV16 {
+        impaired_liened_backing_num: total,
+        spent_backing_num: consumed,
+        provider_receivable_num: consumed,
+        insurance_credit_reserved_num: insurance_reserved,
+        valid_liened_insurance_num: insurance_valid,
+        impaired_liened_insurance_num: insurance_impaired,
+        credit_rate_num: CREDIT_RATE_SCALE,
+        ..SourceCreditStateV16::EMPTY
+    };
+
+    let (after_bucket, after_source) =
+        MarketGroupV16ViewMut::<u64>::kani_prepare_counterparty_impaired_lien_retirement_delta(
+            bucket, source, retired,
+        )
+        .unwrap();
+
+    kani::cover!(
+        retired_raw < total_raw,
+        "one account retires its provider label while sibling labels remain"
+    );
+    kani::cover!(
+        retired_raw == total_raw,
+        "the final account normalizes the impaired bucket to expired"
+    );
+    kani::cover!(
+        insurance_impaired_raw > 0,
+        "provider retirement frames an independent impaired insurance rail"
+    );
+    assert_eq!(after_bucket.impaired_liened_backing_num, total - retired);
+    assert_eq!(after_source.impaired_liened_backing_num, total - retired);
+    assert_eq!(after_bucket.fresh_unliened_backing_num, 0);
+    assert_eq!(after_bucket.valid_liened_backing_num, 0);
+    assert_eq!(after_bucket.consumed_liened_backing_num, consumed);
+    assert_eq!(after_bucket.expiry_slot, bucket.expiry_slot);
+    assert_eq!(
+        after_bucket.utilization_fee_earnings,
+        bucket.utilization_fee_earnings
+    );
+    assert_eq!(after_source.fresh_reserved_backing_num, 0);
+    assert_eq!(after_source.valid_liened_backing_num, 0);
+    assert_eq!(after_source.spent_backing_num, consumed);
+    assert_eq!(after_source.provider_receivable_num, consumed);
+    assert_eq!(
+        after_source.insurance_credit_reserved_num,
+        insurance_reserved
+    );
+    assert_eq!(after_source.valid_liened_insurance_num, insurance_valid);
+    assert_eq!(
+        after_source.impaired_liened_insurance_num,
+        insurance_impaired
+    );
+    assert_eq!(
+        after_bucket.status,
+        if retired == total {
+            BackingBucketStatusV16::Expired
+        } else {
+            BackingBucketStatusV16::Impaired
+        }
+    );
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_resolved_foreign_expiry_provider_retirement_acceptance_is_exact() {
+    let bucket_raw: u8 = kani::any();
+    let source_raw: u8 = kani::any();
+    let amount_raw: u8 = kani::any();
+    let status_raw: u8 = kani::any();
+    let fractional: bool = kani::any();
+    kani::assume(bucket_raw <= 8);
+    kani::assume(source_raw <= 8);
+    kani::assume(amount_raw <= 8);
+    kani::assume(status_raw <= 3);
+
+    let bucket_amount = bucket_raw as u128 * BOUND_SCALE;
+    let source_amount = source_raw as u128 * BOUND_SCALE;
+    let amount = amount_raw as u128 * BOUND_SCALE + u128::from(fractional);
+    let status = match status_raw {
+        0 => BackingBucketStatusV16::Empty,
+        1 => BackingBucketStatusV16::Fresh,
+        2 => BackingBucketStatusV16::Expired,
+        _ => BackingBucketStatusV16::Impaired,
+    };
+    let bucket = BackingBucketV16 {
+        market_id: 9,
+        impaired_liened_backing_num: bucket_amount,
+        status,
+        ..BackingBucketV16::EMPTY
+    };
+    let source = SourceCreditStateV16 {
+        impaired_liened_backing_num: source_amount,
+        credit_rate_num: CREDIT_RATE_SCALE,
+        ..SourceCreditStateV16::EMPTY
+    };
+
+    let result =
+        MarketGroupV16ViewMut::<u64>::kani_prepare_counterparty_impaired_lien_retirement_delta(
+            bucket, source, amount,
+        );
+    let accepted = amount == 0
+        || (!fractional
+            && status == BackingBucketStatusV16::Impaired
+            && amount <= bucket_amount
+            && amount <= source_amount);
+
+    kani::cover!(accepted && amount != 0, "valid provider retirement accepts");
+    kani::cover!(
+        !accepted && fractional,
+        "fractional provider retirement rejects"
+    );
+    kani::cover!(
+        !accepted && !fractional && status != BackingBucketStatusV16::Impaired,
+        "wrong-state provider retirement rejects"
+    );
+    kani::cover!(
+        !accepted && !fractional && amount > bucket_amount,
+        "over-retirement rejects"
+    );
+    assert_eq!(result.is_ok(), accepted);
 }

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -17349,3 +17349,123 @@ fn proof_v16_full_drain_reset_then_prior_epoch_clear_is_total_and_exact() {
     );
     assert_eq!(cleared, expected_clear);
 }
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_resolved_foreign_expiry_lien_impairment_is_exact_relabel() {
+    let counter_face_atoms: u8 = kani::any();
+    let counter_effective: u8 = kani::any();
+    let insurance_face_atoms: u8 = kani::any();
+    let insurance_effective: u8 = kani::any();
+    let prior_impaired_face_atoms: u8 = kani::any();
+    let prior_impaired_effective: u8 = kani::any();
+    let live_fee: u8 = kani::any();
+    let impaired_fee: u8 = kani::any();
+    kani::assume(counter_face_atoms > 0 && counter_face_atoms <= 8);
+    kani::assume(counter_effective > 0 && counter_effective <= counter_face_atoms);
+    kani::assume(insurance_face_atoms <= 8);
+    kani::assume(insurance_effective <= insurance_face_atoms);
+    kani::assume(prior_impaired_face_atoms <= 8);
+    kani::assume(prior_impaired_effective <= prior_impaired_face_atoms);
+
+    let counter_face = (counter_face_atoms as u128) * BOUND_SCALE;
+    let insurance_face = (insurance_face_atoms as u128) * BOUND_SCALE;
+    let prior_impaired_face = (prior_impaired_face_atoms as u128) * BOUND_SCALE;
+    let counter_backing = (counter_effective as u128) * BOUND_SCALE;
+    let insurance_backing = (insurance_effective as u128) * BOUND_SCALE;
+    let live_effective = counter_effective as u128 + insurance_effective as u128;
+    let source = PortfolioSourceDomainV16Account {
+        domain: V16PodU32::new(3),
+        source_claim_market_id: V16PodU64::new(9),
+        source_claim_bound_num: V16PodU128::new(
+            counter_face + insurance_face + prior_impaired_face + BOUND_SCALE,
+        ),
+        source_claim_liened_num: V16PodU128::new(counter_face + insurance_face),
+        source_claim_counterparty_liened_num: V16PodU128::new(counter_face),
+        source_claim_insurance_liened_num: V16PodU128::new(insurance_face),
+        source_lien_effective_reserved: V16PodU128::new(live_effective),
+        source_lien_counterparty_backing_num: V16PodU128::new(counter_backing),
+        source_lien_insurance_backing_num: V16PodU128::new(insurance_backing),
+        source_lien_fee_last_slot: V16PodU64::new(7),
+        source_claim_impaired_num: V16PodU128::new(prior_impaired_face),
+        source_lien_impaired_effective_reserved: V16PodU128::new(prior_impaired_effective as u128),
+        source_lien_capital_at_risk_fee_revenue: V16PodU128::new(live_fee as u128),
+        source_lien_impaired_capital_at_risk_fee_revenue: V16PodU128::new(impaired_fee as u128),
+    };
+
+    let (after, impaired_effective) =
+        MarketGroupV16ViewMut::<u64>::kani_prepare_account_counterparty_lien_impairment(source)
+            .unwrap();
+
+    kani::cover!(
+        insurance_face_atoms > 0,
+        "foreign expiry preserves a mixed insurance-backed lien"
+    );
+    kani::cover!(
+        prior_impaired_face_atoms > 0,
+        "foreign expiry composes with prior impaired face"
+    );
+    kani::cover!(
+        live_fee > 0 && insurance_effective > 0,
+        "foreign expiry splits mixed-lien fee revenue"
+    );
+    assert_eq!(impaired_effective, counter_effective as u128);
+    assert_eq!(after.domain.get(), source.domain.get());
+    assert_eq!(
+        after.source_claim_market_id.get(),
+        source.source_claim_market_id.get()
+    );
+    assert_eq!(
+        after.source_claim_bound_num.get(),
+        source.source_claim_bound_num.get()
+    );
+    assert_eq!(after.source_claim_liened_num.get(), insurance_face);
+    assert_eq!(after.source_claim_counterparty_liened_num.get(), 0);
+    assert_eq!(
+        after.source_claim_insurance_liened_num.get(),
+        source.source_claim_insurance_liened_num.get()
+    );
+    assert_eq!(
+        after.source_claim_impaired_num.get(),
+        prior_impaired_face + counter_face
+    );
+    assert_eq!(
+        after.source_claim_liened_num.get() + after.source_claim_impaired_num.get(),
+        source.source_claim_liened_num.get() + source.source_claim_impaired_num.get()
+    );
+    assert_eq!(
+        after.source_lien_effective_reserved.get(),
+        insurance_effective as u128
+    );
+    assert_eq!(after.source_lien_counterparty_backing_num.get(), 0);
+    assert_eq!(
+        after.source_lien_insurance_backing_num.get(),
+        source.source_lien_insurance_backing_num.get()
+    );
+    assert_eq!(
+        after.source_lien_impaired_effective_reserved.get(),
+        prior_impaired_effective as u128 + counter_effective as u128
+    );
+    assert_eq!(
+        after.source_lien_effective_reserved.get()
+            + after.source_lien_impaired_effective_reserved.get(),
+        source.source_lien_effective_reserved.get()
+            + source.source_lien_impaired_effective_reserved.get()
+    );
+    assert_eq!(after.source_lien_fee_last_slot.get(), 0);
+    let expected_impaired_fee = (live_fee as u128) * (counter_effective as u128) / live_effective;
+    assert_eq!(
+        after.source_lien_capital_at_risk_fee_revenue.get(),
+        live_fee as u128 - expected_impaired_fee
+    );
+    assert_eq!(
+        after.source_lien_impaired_capital_at_risk_fee_revenue.get(),
+        impaired_fee as u128 + expected_impaired_fee
+    );
+    assert_eq!(
+        after.source_lien_capital_at_risk_fee_revenue.get()
+            + after.source_lien_impaired_capital_at_risk_fee_revenue.get(),
+        live_fee as u128 + impaired_fee as u128
+    );
+}

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -2961,6 +2961,163 @@ fn v16_resolved_impaired_source_accepts_prospective_terminal_loss() {
 }
 
 #[test]
+fn v16_resolved_foreign_expiry_impairs_account_lien_before_release() {
+    const Q: u128 = 1_000 * POS_SCALE;
+    const INCREASE_Q: u128 = POS_SCALE;
+    let (market_id, _, _) = ids();
+    let mut cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
+    cfg.maintenance_margin_bps = 1_000;
+    cfg.initial_margin_bps = 5_000;
+    cfg.max_price_move_bps_per_slot = 500;
+    cfg.max_accrual_dt_slots = 1;
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_id, cfg, 1, 0).unwrap();
+    let mut markets = vec![Market::new(0, EngineAssetSlotV16Account::default())];
+    header
+        .activate_empty_asset_slot_not_atomic(0, &mut markets[0].engine, 100, 1)
+        .unwrap();
+
+    let mut target_header = account_fixture(1, 44);
+    let mut target_peer_header = account_fixture(1, 45);
+    let mut expiry_trigger_header = account_fixture(1, 46);
+    let mut trigger_peer_header = account_fixture(1, 47);
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut target = PortfolioV16ViewMut::new(&mut target_header);
+    let mut target_peer = PortfolioV16ViewMut::new(&mut target_peer_header);
+    let mut expiry_trigger = PortfolioV16ViewMut::new(&mut expiry_trigger_header);
+    let mut trigger_peer = PortfolioV16ViewMut::new(&mut trigger_peer_header);
+
+    market
+        .deposit_fresh_counterparty_backing_not_atomic(1, 100_000, 3)
+        .unwrap();
+    market.deposit_not_atomic(&mut target, 52_501).unwrap();
+    market
+        .deposit_not_atomic(&mut target_peer, 1_000_000)
+        .unwrap();
+    market
+        .deposit_not_atomic(&mut expiry_trigger, 1_000_000)
+        .unwrap();
+    market
+        .deposit_not_atomic(&mut trigger_peer, 1_000_000)
+        .unwrap();
+    for (long, short) in [
+        (&mut target, &mut target_peer),
+        (&mut expiry_trigger, &mut trigger_peer),
+    ] {
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                long,
+                short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: signed_q(Q),
+                    exec_price: 100,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+    }
+
+    market
+        .set_asset_raw_oracle_target_not_atomic(0, 105)
+        .unwrap();
+    market
+        .accrue_asset_to_not_atomic(0, 2, 105, 0, true)
+        .unwrap();
+    for account in [
+        &mut target_peer,
+        &mut trigger_peer,
+        &mut target,
+        &mut expiry_trigger,
+    ] {
+        market.full_account_refresh_not_atomic(account).unwrap();
+    }
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut target,
+            &mut target_peer,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: signed_q(INCREASE_Q),
+                exec_price: 105,
+                fee_bps: 0,
+            },
+        )
+        .unwrap();
+    let lien_before = target.header.source_domains[0];
+    assert!(lien_before.source_claim_counterparty_liened_num.get() > 0);
+    assert!(lien_before.source_lien_counterparty_backing_num.get() > 0);
+    assert_eq!(lien_before.source_claim_impaired_num.get(), 0);
+    assert!(
+        expiry_trigger.header.source_domains[0]
+            .source_claim_bound_num
+            .get()
+            > 0
+    );
+    assert_eq!(
+        expiry_trigger.header.source_domains[0]
+            .source_claim_liened_num
+            .get(),
+        0
+    );
+
+    market.resolve_market_not_atomic(3).unwrap();
+    assert_eq!(
+        market
+            .close_resolved_account_not_atomic(&mut expiry_trigger, 0)
+            .unwrap(),
+        percolator::ResolvedCloseOutcomeV16::ProgressOnly,
+    );
+    let bucket_before = market.markets[0]
+        .engine
+        .backing_short
+        .try_to_runtime()
+        .unwrap();
+    assert_eq!(bucket_before.status, BackingBucketStatusV16::Impaired);
+
+    let mut relabeled = false;
+    for _ in 0..4 {
+        assert_eq!(
+            market
+                .close_resolved_account_not_atomic(&mut target, 0)
+                .expect("foreign bucket expiry must leave bounded lien-impairment continuations",),
+            percolator::ResolvedCloseOutcomeV16::ProgressOnly,
+        );
+        if target.header.source_domains[0]
+            .source_claim_counterparty_liened_num
+            .get()
+            == 0
+        {
+            relabeled = true;
+            break;
+        }
+    }
+    assert!(relabeled, "the account-local lien never became impaired");
+    let impaired = target.header.source_domains[0];
+    assert_eq!(impaired.source_claim_liened_num.get(), 0);
+    assert_eq!(impaired.source_claim_counterparty_liened_num.get(), 0);
+    assert_eq!(impaired.source_lien_counterparty_backing_num.get(), 0);
+    assert_eq!(
+        impaired.source_claim_impaired_num.get(),
+        lien_before.source_claim_counterparty_liened_num.get()
+    );
+    assert_eq!(
+        impaired.source_lien_impaired_effective_reserved.get(),
+        lien_before.source_lien_effective_reserved.get()
+    );
+    assert_eq!(
+        market.markets[0]
+            .engine
+            .backing_short
+            .try_to_runtime()
+            .unwrap(),
+        bucket_before,
+        "account-local relabel must not mutate the already-impaired aggregate bucket"
+    );
+    market.validate_shape().unwrap();
+    target.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_live_mark_reversal_unwinds_source_lien_before_claim_burn() {
     const OPEN_Q: u128 = 1_000 * POS_SCALE;
     const INCREASE_Q: u128 = 50 * POS_SCALE;

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3113,6 +3113,51 @@ fn v16_resolved_foreign_expiry_impairs_account_lien_before_release() {
         bucket_before,
         "account-local relabel must not mutate the already-impaired aggregate bucket"
     );
+
+    let mut all_closed = false;
+    let mut last_outcomes = Vec::new();
+    for _ in 0..16 {
+        last_outcomes.clear();
+        for account in [
+            &mut target_peer,
+            &mut trigger_peer,
+            &mut expiry_trigger,
+            &mut target,
+        ] {
+            last_outcomes.push(
+                market
+                    .close_resolved_account_not_atomic(account, 0)
+                    .expect("foreign-expired source claims must retain a terminal continuation"),
+            );
+        }
+        all_closed = [&target_peer, &trigger_peer, &expiry_trigger, &target]
+            .iter()
+            .all(|account| {
+                account.header.capital.get() == 0
+                    && account.header.pnl.get() == 0
+                    && active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get))
+            });
+        if all_closed {
+            break;
+        }
+    }
+    assert!(
+        all_closed,
+        "foreign-expired source claims did not terminate: last={last_outcomes:?}"
+    );
+    let bucket_after = market.markets[0]
+        .engine
+        .backing_short
+        .try_to_runtime()
+        .unwrap();
+    let source_after = market.markets[0]
+        .engine
+        .source_credit_short
+        .try_to_runtime()
+        .unwrap();
+    assert_eq!(bucket_after.status, BackingBucketStatusV16::Expired);
+    assert_eq!(bucket_after.impaired_liened_backing_num, 0);
+    assert_eq!(source_after.impaired_liened_backing_num, 0);
     market.validate_shape().unwrap();
     target.validate_with_market(&market.as_view()).unwrap();
 }

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -2980,11 +2980,15 @@ fn v16_resolved_foreign_expiry_impairs_account_lien_before_release() {
     let mut target_peer_header = account_fixture(1, 45);
     let mut expiry_trigger_header = account_fixture(1, 46);
     let mut trigger_peer_header = account_fixture(1, 47);
+    let mut sibling_target_header = account_fixture(1, 48);
+    let mut sibling_peer_header = account_fixture(1, 49);
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
     let mut target = PortfolioV16ViewMut::new(&mut target_header);
     let mut target_peer = PortfolioV16ViewMut::new(&mut target_peer_header);
     let mut expiry_trigger = PortfolioV16ViewMut::new(&mut expiry_trigger_header);
     let mut trigger_peer = PortfolioV16ViewMut::new(&mut trigger_peer_header);
+    let mut sibling_target = PortfolioV16ViewMut::new(&mut sibling_target_header);
+    let mut sibling_peer = PortfolioV16ViewMut::new(&mut sibling_peer_header);
 
     market
         .deposit_fresh_counterparty_backing_not_atomic(1, 100_000, 3)
@@ -2999,9 +3003,16 @@ fn v16_resolved_foreign_expiry_impairs_account_lien_before_release() {
     market
         .deposit_not_atomic(&mut trigger_peer, 1_000_000)
         .unwrap();
+    market
+        .deposit_not_atomic(&mut sibling_target, 52_501)
+        .unwrap();
+    market
+        .deposit_not_atomic(&mut sibling_peer, 1_000_000)
+        .unwrap();
     for (long, short) in [
         (&mut target, &mut target_peer),
         (&mut expiry_trigger, &mut trigger_peer),
+        (&mut sibling_target, &mut sibling_peer),
     ] {
         market
             .execute_trade_with_fee_loss_stale_scoped_not_atomic(
@@ -3026,26 +3037,40 @@ fn v16_resolved_foreign_expiry_impairs_account_lien_before_release() {
     for account in [
         &mut target_peer,
         &mut trigger_peer,
+        &mut sibling_peer,
         &mut target,
         &mut expiry_trigger,
+        &mut sibling_target,
     ] {
         market.full_account_refresh_not_atomic(account).unwrap();
     }
-    market
-        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
-            &mut target,
-            &mut target_peer,
-            TradeRequestV16 {
-                asset_index: 0,
-                size_q: signed_q(INCREASE_Q),
-                exec_price: 105,
-                fee_bps: 0,
-            },
-        )
-        .unwrap();
+    for (long, short) in [
+        (&mut target, &mut target_peer),
+        (&mut sibling_target, &mut sibling_peer),
+    ] {
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                long,
+                short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: signed_q(INCREASE_Q),
+                    exec_price: 105,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+    }
     let lien_before = target.header.source_domains[0];
+    let sibling_lien_before = sibling_target.header.source_domains[0];
     assert!(lien_before.source_claim_counterparty_liened_num.get() > 0);
     assert!(lien_before.source_lien_counterparty_backing_num.get() > 0);
+    assert!(
+        sibling_lien_before
+            .source_lien_counterparty_backing_num
+            .get()
+            > 0
+    );
     assert_eq!(lien_before.source_claim_impaired_num.get(), 0);
     assert!(
         expiry_trigger.header.source_domains[0]
@@ -3102,16 +3127,26 @@ fn v16_resolved_foreign_expiry_impairs_account_lien_before_release() {
     );
     assert_eq!(
         impaired.source_lien_impaired_effective_reserved.get(),
-        lien_before.source_lien_effective_reserved.get()
+        0,
+        "expired provider principal must not be reclassified as impaired insurance"
     );
+    let bucket_after_target_relabel = market.markets[0]
+        .engine
+        .backing_short
+        .try_to_runtime()
+        .unwrap();
     assert_eq!(
-        market.markets[0]
-            .engine
-            .backing_short
-            .try_to_runtime()
-            .unwrap(),
-        bucket_before,
-        "account-local relabel must not mutate the already-impaired aggregate bucket"
+        bucket_after_target_relabel.impaired_liened_backing_num,
+        bucket_before.impaired_liened_backing_num
+            - lien_before.source_lien_counterparty_backing_num.get(),
+        "the target must retire exactly its own expired provider-lien label"
+    );
+    assert!(
+        bucket_after_target_relabel.impaired_liened_backing_num
+            >= sibling_lien_before
+                .source_lien_counterparty_backing_num
+                .get(),
+        "the first relabel must preserve its sibling's provider-lien label"
     );
 
     let mut all_closed = false;
@@ -3121,8 +3156,10 @@ fn v16_resolved_foreign_expiry_impairs_account_lien_before_release() {
         for account in [
             &mut target_peer,
             &mut trigger_peer,
+            &mut sibling_peer,
             &mut expiry_trigger,
             &mut target,
+            &mut sibling_target,
         ] {
             last_outcomes.push(
                 market
@@ -3130,13 +3167,20 @@ fn v16_resolved_foreign_expiry_impairs_account_lien_before_release() {
                     .expect("foreign-expired source claims must retain a terminal continuation"),
             );
         }
-        all_closed = [&target_peer, &trigger_peer, &expiry_trigger, &target]
-            .iter()
-            .all(|account| {
-                account.header.capital.get() == 0
-                    && account.header.pnl.get() == 0
-                    && active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get))
-            });
+        all_closed = [
+            &target_peer,
+            &trigger_peer,
+            &sibling_peer,
+            &expiry_trigger,
+            &target,
+            &sibling_target,
+        ]
+        .iter()
+        .all(|account| {
+            account.header.capital.get() == 0
+                && account.header.pnl.get() == 0
+                && active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get))
+        });
         if all_closed {
             break;
         }


### PR DESCRIPTION
## Impact

A publicly reachable resolved market can permanently strand a source-backed winner. Account A creates a legitimate source-credit IM lien through ordinary trades. A lien-free account B closes first after authenticated expiry and moves the shared aggregate bucket to Impaired. A still records its account-local lien as live, so its terminal release debits an aggregate live-lien counter that is already zero and returns CounterUnderflow. SVM rollback restores the same state; direct CloseResolved and the sole public crank repeat the failure.

The first version of this fix restored only the initial live-to-impaired relabel. PR135's full public lifecycle found a second CounterUnderflow: that relabel placed expired provider backing into the generic impaired-effective field, whose burn path correctly assumes impaired insurance and tries to release an insurance reservation that does not exist.

## Fix

Before resolved settlement releases a source lien:

1. Charge utilization only through the authenticated bucket expiry.
2. While the account still carries its exact counterparty amount, retire exactly that amount from the aggregate provider-impaired bucket/source ledgers.
3. Convert the account claim face from live to zero-credit impaired face.
4. Do not add expired provider principal to the insurance-backed impaired-effective reserve.
5. Normalize the shared bucket from Impaired to Expired only when the final provider label is retired.

This is order-independent across accounts: one account cannot consume a sibling's provider label, and all insurance reservation fields are framed.

## TDD evidence

- RED `dfd7eed4`: public engine lifecycle reproduces the foreign-expiry live-lien mismatch.
- Partial green `1e0d952e`: restores the first bounded relabel.
- RED `c30540df`: strengthens the regression through complete terminal settlement and exposes the downstream insurance CounterUnderflow.
- GREEN `0a23b5f5`: preserves provider/insurance provenance and closes the full lifecycle.
- The runtime regression uses two independently liened winners sharing one expired bucket. The first leaves the sibling label intact; all six funded accounts terminate and the final aggregate impaired provider label reaches zero.

PR135 independently reaches the state through public SBF instructions. On `1e0d952e`, the first relabel succeeds and every later direct CloseResolved/public-crank retry returns Custom(25) with exact SVM rollback.

## Verification

- `cargo test --all-targets --features fuzz`: 183 tests pass.
- `proof_v16_resolved_foreign_expiry_lien_impairment_is_exact_relabel`: 422 checks, 3/3 covers, PASS.
- `proof_v16_resolved_foreign_expiry_retires_exact_provider_label_only`: 108 checks, 3/3 covers, PASS.
- `proof_v16_resolved_foreign_expiry_provider_retirement_acceptance_is_exact`: 36 checks, 4/4 covers, PASS.
- Source proof roster: 270 plain v16 Kani harnesses.

Stacked on #153 because that fix removes the earlier impaired-domain prospective-loss blocker and exposes this terminal rank failure.