### PR TITLE
[REAL DoS] Route prospective loss after source impairment

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Source-checkable counts in this checkout:
 
 | Class | Count |
 | --- | ---: |
-| Plain Kani proofs in `tests/proofs_v16.rs` | 266 |
+| Plain Kani proofs in `tests/proofs_v16.rs` | 267 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -8107,17 +8107,22 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .residual()
                 .checked_sub(residual_before)
                 .ok_or(V16Error::CounterUnderflow)?;
-            if released != 0 {
-                let (ledger, legacy_snapshot) = V16Core::kernel_credit_post_snapshot_residual(
-                    self.header.resolved_payout_ledger.try_to_runtime()?,
-                    self.header.payout_snapshot.get(),
-                    released,
-                )?;
-                self.header.payout_snapshot = V16PodU128::new(legacy_snapshot);
-                self.header.resolved_payout_ledger =
-                    ResolvedPayoutLedgerV16Account::from_runtime(&ledger);
-            }
+            self.credit_post_snapshot_residual_not_atomic(released)?;
         }
+        Ok(())
+    }
+
+    fn credit_post_snapshot_residual_not_atomic(&mut self, released: u128) -> V16Result<()> {
+        if released == 0 || !decode_bool(self.header.payout_snapshot_captured)? {
+            return Ok(());
+        }
+        let (ledger, legacy_snapshot) = V16Core::kernel_credit_post_snapshot_residual(
+            self.header.resolved_payout_ledger.try_to_runtime()?,
+            self.header.payout_snapshot.get(),
+            released,
+        )?;
+        self.header.payout_snapshot = V16PodU128::new(legacy_snapshot);
+        self.header.resolved_payout_ledger = ResolvedPayoutLedgerV16Account::from_runtime(&ledger);
         Ok(())
     }
 
@@ -11184,8 +11189,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             self.header.vault.get(),
         )?
         .validate()?;
-        let expiry_slot = self.fresh_counterparty_backing_expiry_slot(domain)?;
-        self.add_fresh_counterparty_backing_unchecked(domain, backing_num, expiry_slot)?;
+        let terminal_impaired = decode_market_mode(self.header.mode)? == MarketModeV16::Resolved
+            && self.backing_bucket_for_domain(domain)?.status == BackingBucketStatusV16::Impaired;
+        if terminal_impaired {
+            // Once the provider bucket has defaulted, newly crystallized loss is
+            // terminal junior support, not recoverable provider principal.
+            self.credit_post_snapshot_residual_not_atomic(backing)?;
+        } else {
+            let expiry_slot = self.fresh_counterparty_backing_expiry_slot(domain)?;
+            self.add_fresh_counterparty_backing_unchecked(domain, backing_num, expiry_slot)?;
+        }
         Self::record_account_residual_crystallized_loss(account, backing)?;
         account.header.health_cert.valid = 0;
         Ok(())

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -8164,6 +8164,151 @@ fn proof_v16_capital_backed_loss_reservation_is_value_neutral_and_capital_capped
     assert_eq!(market.kani_residual(), residual_before);
 }
 
+// A source domain that has already become Impaired during Resolved wind-down
+// cannot accept new recoverable provider principal. Capital consumed while a
+// pending K/F loss is crystallized must instead become terminal junior
+// residual. If a payout snapshot already exists, the same atoms must augment
+// both persisted snapshots and immediately update the common payout rate.
+#[kani::proof]
+#[kani::unwind(40)]
+#[kani::solver(cadical)]
+fn proof_v16_resolved_impaired_capital_backed_loss_routes_to_residual() {
+    let capital_raw: u8 = kani::any();
+    let loss_raw: u8 = kani::any();
+    let junior_raw: u8 = kani::any();
+    let claim_raw: u8 = kani::any();
+    let snapshot_captured: bool = kani::any();
+    kani::assume((1..=4).contains(&capital_raw));
+    kani::assume((1..=8).contains(&loss_raw));
+    kani::assume(junior_raw <= 8);
+    kani::assume((1..=8).contains(&claim_raw));
+    let capital = capital_raw as u128;
+    let loss = loss_raw as u128;
+    let junior = junior_raw as u128;
+    let claim = claim_raw as u128;
+    let claim_num = claim * BOUND_SCALE;
+
+    let (market_id, _, _) = ids();
+    let cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_id, cfg, 1, 0).unwrap();
+    let mut markets = [Market::new(0u64, EngineAssetSlotV16Account::default())];
+    {
+        let mut view = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        view.activate_empty_market_not_atomic(0, 100, 1).unwrap();
+    }
+    let engine_market_id = markets[0].engine.asset.market_id.get();
+    let impaired_num = BOUND_SCALE;
+    markets[0].engine.backing_long = BackingBucketV16Account::from_runtime(&BackingBucketV16 {
+        market_id: engine_market_id,
+        impaired_liened_backing_num: impaired_num,
+        expiry_slot: 1,
+        status: BackingBucketStatusV16::Impaired,
+        ..BackingBucketV16::EMPTY
+    });
+    markets[0].engine.source_credit_long =
+        SourceCreditStateV16Account::from_runtime(&SourceCreditStateV16 {
+            impaired_liened_backing_num: impaired_num,
+            ..SourceCreditStateV16::EMPTY
+        });
+    header.mode = 1; // Resolved
+    header.resolved_slot = V16PodU64::new(1);
+    header.vault = V16PodU128::new(capital + junior);
+    header.c_tot = V16PodU128::new(capital);
+    header.negative_pnl_account_count = V16PodU64::new(1);
+    header.pnl_pos_tot = V16PodU128::new(claim);
+    header.pnl_matured_pos_tot = V16PodU128::new(claim);
+    header.pnl_pos_bound_tot = V16PodU128::new(claim);
+    header.pnl_pos_bound_tot_num = V16PodU128::new(claim_num);
+    if snapshot_captured {
+        header.payout_snapshot_captured = 1;
+        header.payout_snapshot = V16PodU128::new(junior);
+        header.payout_snapshot_pnl_pos_tot = V16PodU128::new(claim);
+        header.resolved_payout_ledger =
+            ResolvedPayoutLedgerV16Account::from_runtime(&ResolvedPayoutLedgerV16 {
+                snapshot_residual: junior,
+                terminal_claim_exact_receipts_num: 0,
+                terminal_claim_bound_unreceipted_num: claim_num,
+                current_payout_rate_num: (junior * BOUND_SCALE).min(claim_num),
+                current_payout_rate_den: claim_num,
+                snapshot_slot: 1,
+                payout_halted: false,
+                finalized: false,
+            });
+    }
+
+    let mut account_header = PortfolioAccountV16Account::default();
+    account_header.capital = V16PodU128::new(capital);
+    account_header.pnl = V16PodI128::new(-(loss as i128));
+
+    let vault_before = header.vault.get();
+    let bucket_before = markets[0].engine.backing_long;
+    let fresh_total_before = header.source_fresh_backing_total_num.get();
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let residual_before = market.kani_residual();
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market
+        .kani_reserve_new_capital_backed_loss_for_source_domain_not_atomic(&mut account, 0, 0, loss)
+        .unwrap();
+
+    let expected_backing = loss.min(capital);
+    kani::cover!(loss < capital, "terminal residual route covers loss cap");
+    kani::cover!(loss > capital, "terminal residual route covers capital cap");
+    kani::cover!(
+        snapshot_captured && expected_backing > 0,
+        "terminal residual route updates an existing payout snapshot"
+    );
+    kani::cover!(
+        !snapshot_captured && expected_backing > 0,
+        "terminal residual route works before payout snapshot capture"
+    );
+    assert_eq!(market.header.vault.get(), vault_before);
+    assert_eq!(market.header.c_tot.get(), capital - expected_backing);
+    assert_eq!(account.header.capital.get(), capital - expected_backing);
+    assert_eq!(
+        account.header.pnl.get(),
+        -(loss as i128) + expected_backing as i128
+    );
+    assert_eq!(market.kani_residual(), residual_before + expected_backing);
+    assert_eq!(
+        market.header.source_fresh_backing_total_num.get(),
+        fresh_total_before
+    );
+    assert_eq!(market.markets[0].engine.backing_long, bucket_before);
+    assert_eq!(
+        account.header.residual_crystallized_loss_atoms_total.get(),
+        expected_backing
+    );
+    if snapshot_captured {
+        let ledger = market
+            .header
+            .resolved_payout_ledger
+            .try_to_runtime()
+            .unwrap();
+        assert_eq!(
+            market.header.payout_snapshot.get(),
+            junior + expected_backing
+        );
+        assert_eq!(ledger.snapshot_residual, junior + expected_backing);
+        assert_eq!(ledger.terminal_claim_exact_receipts_num, 0);
+        assert_eq!(ledger.terminal_claim_bound_unreceipted_num, claim_num);
+        assert_eq!(ledger.current_payout_rate_den, claim_num);
+        assert_eq!(
+            ledger.current_payout_rate_num,
+            ((junior + expected_backing) * BOUND_SCALE).min(claim_num)
+        );
+    } else {
+        assert_eq!(market.header.payout_snapshot.get(), 0);
+        assert_eq!(
+            market
+                .header
+                .resolved_payout_ledger
+                .try_to_runtime()
+                .unwrap(),
+            ResolvedPayoutLedgerV16::EMPTY
+        );
+    }
+}
+
 // residual() is the JUNIOR (positive-PnL) payout pool and feeds both the resolved
 // payout snapshot and the live haircut. `backing_provider_earnings` (utilization
 // fees owed to LPs) is SENIOR — validate_shape's senior stack includes it — so it

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -2852,6 +2852,115 @@ fn v16_risk_increasing_trade_creates_source_credit_lien_for_im() {
 }
 
 #[test]
+fn v16_resolved_impaired_source_accepts_prospective_terminal_loss() {
+    const Q: u128 = 1_000 * POS_SCALE;
+    const INCREASE_Q: u128 = POS_SCALE;
+    let (market_id, _, _) = ids();
+    let mut cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
+    cfg.maintenance_margin_bps = 1_000;
+    cfg.initial_margin_bps = 5_000;
+    cfg.max_price_move_bps_per_slot = 500;
+    cfg.max_accrual_dt_slots = 1;
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_id, cfg, 1, 0).unwrap();
+    let mut markets = vec![Market::new(0, EngineAssetSlotV16Account::default())];
+    header
+        .activate_empty_asset_slot_not_atomic(0, &mut markets[0].engine, 100, 1)
+        .unwrap();
+
+    let mut liened_winner_header = account_fixture(1, 40);
+    let mut liened_peer_header = account_fixture(1, 41);
+    let mut expiry_trigger_header = account_fixture(1, 42);
+    let mut prospective_loser_header = account_fixture(1, 43);
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut liened_winner = PortfolioV16ViewMut::new(&mut liened_winner_header);
+    let mut liened_peer = PortfolioV16ViewMut::new(&mut liened_peer_header);
+    let mut expiry_trigger = PortfolioV16ViewMut::new(&mut expiry_trigger_header);
+    let mut prospective_loser = PortfolioV16ViewMut::new(&mut prospective_loser_header);
+
+    market
+        .deposit_fresh_counterparty_backing_not_atomic(1, 100_000, 3)
+        .unwrap();
+    market
+        .deposit_not_atomic(&mut liened_winner, 52_501)
+        .unwrap();
+    market
+        .deposit_not_atomic(&mut liened_peer, 1_000_000)
+        .unwrap();
+    market
+        .deposit_not_atomic(&mut expiry_trigger, 1_000_000)
+        .unwrap();
+    market
+        .deposit_not_atomic(&mut prospective_loser, 1_000_000)
+        .unwrap();
+    for (long, short) in [
+        (&mut liened_winner, &mut liened_peer),
+        (&mut expiry_trigger, &mut prospective_loser),
+    ] {
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                long,
+                short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: signed_q(Q),
+                    exec_price: 100,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+    }
+
+    market
+        .set_asset_raw_oracle_target_not_atomic(0, 105)
+        .unwrap();
+    market
+        .accrue_asset_to_not_atomic(0, 2, 105, 0, true)
+        .unwrap();
+    for account in [&mut liened_peer, &mut liened_winner, &mut expiry_trigger] {
+        market.full_account_refresh_not_atomic(account).unwrap();
+    }
+    assert_eq!(prospective_loser.header.pnl.get(), 0);
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut liened_winner,
+            &mut liened_peer,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: signed_q(INCREASE_Q),
+                exec_price: 105,
+                fee_bps: 0,
+            },
+        )
+        .unwrap();
+
+    market.resolve_market_not_atomic(3).unwrap();
+    assert_eq!(
+        market
+            .close_resolved_account_not_atomic(&mut expiry_trigger, 0)
+            .unwrap(),
+        percolator::ResolvedCloseOutcomeV16::ProgressOnly,
+    );
+    assert_eq!(
+        market.markets[0]
+            .engine
+            .backing_short
+            .try_to_runtime()
+            .unwrap()
+            .status,
+        BackingBucketStatusV16::Impaired,
+    );
+
+    market
+        .close_resolved_account_not_atomic(&mut prospective_loser, 0)
+        .expect("an impaired source bucket must accept a prospective terminal loss");
+    assert_eq!(prospective_loser.header.pnl.get(), 0);
+    market.validate_shape().unwrap();
+    prospective_loser
+        .validate_with_market(&market.as_view())
+        .unwrap();
+}
+
+#[test]
 fn v16_live_mark_reversal_unwinds_source_lien_before_claim_burn() {
     const OPEN_Q: u128 = 1_000 * POS_SCALE;
     const INCREASE_Q: u128 = 50 * POS_SCALE;


### PR DESCRIPTION
## Impact

A publicly reachable resolved market can strand an ordinary losing portfolio. If another account first expires a shared source bucket containing a valid lien, the bucket becomes Impaired. A portfolio with an unsettled adverse K/F delta then tries to crystallize capital-backed loss as new Fresh provider principal. The impaired bucket rejects that transition with LockActive, so every CloseResolved retry rolls back and the portfolio cannot wind down.

## Fix

In Resolved mode only, route newly crystallized loss for an already-Impaired source domain directly into terminal junior residual. Keep the impaired bucket and recoverable provider-principal totals unchanged. If the payout snapshot exists, credit the exact atoms through the post-snapshot payout-ledger kernel from #147.

## TDD evidence

- RED commit 6e0dc19c reproduces LockActive using public engine lifecycle operations on the exact #147 head.
- GREEN commit cc83730b restores bounded CloseResolved progress.
- PR135 independently reaches the state through ordinary wrapper instructions; 16 alternating CloseResolved/crank attempts return Custom(21) with exact rollback on the vulnerable pin.

## Verification

- cargo test --all-targets --features fuzz: 182 tests pass.
- proof_v16_resolved_impaired_capital_backed_loss_routes_to_residual: 6,112 checks, 4/4 nonvacuity covers, PASS.
- The proof frames vault value, capital/c_tot, PnL, residual, provider buckets, fresh totals, crystallized-loss counters, and both snapshot states.

Stacked on #147 because this fix reuses its post-snapshot residual-credit kernel.