### PR TITLE
[REAL DoS] Align cross-domain source support rounding

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -716,6 +716,31 @@ impl V16Core {
         Ok((required_face_num, required_backing_num))
     }
 
+    #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &V16Result<u128>| match result {
+        Ok(value) => *value <= unliened_claim_num / BOUND_SCALE
+            && *value <= available_backing_num / BOUND_SCALE,
+        Err(_) => true,
+    }))]
+    fn source_credit_consumable_atoms(
+        unliened_claim_num: u128,
+        credit_rate_num: u128,
+        available_backing_num: u128,
+    ) -> V16Result<u128> {
+        if credit_rate_num > CREDIT_RATE_SCALE {
+            return Err(V16Error::InvalidConfig);
+        }
+        if unliened_claim_num == 0 || credit_rate_num == 0 {
+            return Ok(0);
+        }
+        let by_claim = U256::from_u128(unliened_claim_num)
+            .checked_mul(U256::from_u128(credit_rate_num))
+            .and_then(|v| v.checked_div(U256::from_u128(CREDIT_RATE_SCALE)))
+            .and_then(|v| v.checked_div(U256::from_u128(BOUND_SCALE)))
+            .and_then(|v| v.try_into_u128())
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        Ok(by_claim.min(available_backing_num / BOUND_SCALE))
+    }
+
     #[inline]
     fn validate_bound_num_atom_aligned(bound_num: u128) -> V16Result<()> {
         if bound_num == 0 {
@@ -8727,14 +8752,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .min(remaining_num);
             if claim_num != 0 {
                 self.validate_source_domain_ledger_current(d)?;
-                let credited_num = U256::from_u128(claim_num)
-                    .checked_mul(U256::from_u128(
-                        self.source_credit_for_domain(d)?.credit_rate_num,
-                    ))
-                    .and_then(|v| v.checked_div(U256::from_u128(CREDIT_RATE_SCALE)))
-                    .ok_or(V16Error::ArithmeticOverflow)?;
+                let consumable = V16Core::source_credit_consumable_atoms(
+                    claim_num,
+                    self.source_credit_for_domain(d)?.credit_rate_num,
+                    self.source_credit_available_backing_num(d)?,
+                )?;
+                let consumable_num = V16Core::bound_num_from_amount(consumable)?;
                 support_num = support_num
-                    .checked_add(credited_num)
+                    .checked_add(U256::from_u128(consumable_num))
                     .ok_or(V16Error::ArithmeticOverflow)?;
                 remaining_num -= claim_num;
             }
@@ -8770,14 +8795,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             let claim_num = Self::source_claim_unliened_num(account, d)?.min(remaining_num);
             if claim_num != 0 {
                 self.validate_source_domain_ledger_current(d)?;
-                let credited_num = U256::from_u128(claim_num)
-                    .checked_mul(U256::from_u128(
-                        self.source_credit_for_domain(d)?.credit_rate_num,
-                    ))
-                    .and_then(|v| v.checked_div(U256::from_u128(CREDIT_RATE_SCALE)))
-                    .ok_or(V16Error::ArithmeticOverflow)?;
+                let consumable = V16Core::source_credit_consumable_atoms(
+                    claim_num,
+                    self.source_credit_for_domain(d)?.credit_rate_num,
+                    self.source_credit_available_backing_num(d)?,
+                )?;
+                let consumable_num = V16Core::bound_num_from_amount(consumable)?;
                 support_num = support_num
-                    .checked_add(credited_num)
+                    .checked_add(U256::from_u128(consumable_num))
                     .ok_or(V16Error::ArithmeticOverflow)?;
                 remaining_num -= claim_num;
             }
@@ -9461,14 +9486,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             let unliened = Self::source_claim_unliened_num(&account.as_view(), d)?;
             if rate != 0 && unliened != 0 {
                 self.validate_source_domain_ledger_current(d)?;
-                let soft_num = U256::from_u128(unliened)
-                    .checked_mul(U256::from_u128(rate))
-                    .and_then(|v| v.checked_div(U256::from_u128(CREDIT_RATE_SCALE)))
-                    .and_then(|v| v.try_into_u128())
-                    .ok_or(V16Error::ArithmeticOverflow)?;
-                let by_claim = soft_num / BOUND_SCALE;
-                let by_backing = self.source_credit_available_backing_num(d)? / BOUND_SCALE;
-                let take = remaining.min(by_claim).min(by_backing);
+                let consumable = V16Core::source_credit_consumable_atoms(
+                    unliened,
+                    rate,
+                    self.source_credit_available_backing_num(d)?,
+                )?;
+                let take = remaining.min(consumable);
                 if take != 0 {
                     let (face_num, backing_num) =
                         V16Core::source_credit_lien_amounts_for_effective(take, rate)?;

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -692,6 +692,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         V16Core::source_credit_lien_amounts_for_effective(effective_credit, credit_rate_num)
     }
 
+    pub fn kani_source_credit_consumable_atoms(
+        unliened_claim_num: u128,
+        credit_rate_num: u128,
+        available_backing_num: u128,
+    ) -> V16Result<u128> {
+        V16Core::source_credit_consumable_atoms(
+            unliened_claim_num,
+            credit_rate_num,
+            available_backing_num,
+        )
+    }
+
     pub fn kani_counterparty_cure_atoms_from_scaled_backing(amount: u128) -> V16Result<u128> {
         V16Core::validate_bound_num_atom_aligned(amount)?;
         Ok(amount / BOUND_SCALE)

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -12221,6 +12221,55 @@ fn proof_v16_source_credit_lien_face_and_backing_use_scaled_units() {
 #[kani::proof]
 #[kani::unwind(8)]
 #[kani::solver(cadical)]
+fn proof_v16_source_credit_support_is_exactly_consumable_per_domain() {
+    let claim_raw: u8 = kani::any();
+    let backing_raw: u8 = kani::any();
+    let rate_numerator_raw: u8 = kani::any();
+    kani::assume((1..=32).contains(&claim_raw));
+    kani::assume(backing_raw <= 32);
+    kani::assume((1..=63).contains(&rate_numerator_raw));
+
+    let claim_num = claim_raw as u128 * BOUND_SCALE;
+    let available_backing_num = backing_raw as u128 * BOUND_SCALE;
+    let rate = CREDIT_RATE_SCALE * rate_numerator_raw as u128 / 63;
+    let consumable = MarketGroupV16ViewMut::<u64>::kani_source_credit_consumable_atoms(
+        claim_num,
+        rate,
+        available_backing_num,
+    )
+    .unwrap();
+
+    kani::cover!(
+        rate_numerator_raw < 63 && consumable > 0 && consumable < claim_raw as u128,
+        "per-domain support proof covers a fractional haircut"
+    );
+    kani::cover!(
+        (backing_raw as u128) < (claim_raw as u128) && consumable == backing_raw as u128,
+        "per-domain support proof covers the backing cap"
+    );
+    assert!(consumable <= claim_raw as u128);
+    assert!(consumable <= backing_raw as u128);
+
+    if consumable != 0 {
+        let (face_num, backing_num) =
+            MarketGroupV16ViewMut::<u64>::kani_source_credit_lien_amounts_for_effective(
+                consumable, rate,
+            )
+            .unwrap();
+        assert!(face_num <= claim_num);
+        assert!(backing_num <= available_backing_num);
+    }
+
+    let next = consumable + 1;
+    let (next_face_num, next_backing_num) =
+        MarketGroupV16ViewMut::<u64>::kani_source_credit_lien_amounts_for_effective(next, rate)
+            .unwrap();
+    assert!(next_face_num > claim_num || next_backing_num > available_backing_num);
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
 fn proof_v16_residual_reward_credit_is_capped_by_principal_and_crystallized_loss() {
     let crystallized_raw: u8 = kani::any();
     let spent_raw: u8 = kani::any();

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -2626,6 +2626,150 @@ fn v16_risk_increasing_trade_creates_source_credit_lien_for_im() {
 }
 
 #[test]
+fn v16_multi_domain_fractional_source_support_does_not_block_mark_reversal() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    header.config.max_price_move_bps_per_slot = V16PodU64::new(10_000);
+    header.config.max_accrual_dt_slots = V16PodU64::new(1);
+    let mut target_header = account_fixture(2, 50);
+    let mut helper_header = account_fixture(2, 51);
+    let mut target_short_headers = [account_fixture(2, 52), account_fixture(2, 54)];
+    let mut helper_short_headers = [account_fixture(2, 53), account_fixture(2, 55)];
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut target = PortfolioV16ViewMut::new(&mut target_header);
+    let mut helper = PortfolioV16ViewMut::new(&mut helper_header);
+    let [target_short_0, target_short_1] = &mut target_short_headers;
+    let [helper_short_0, helper_short_1] = &mut helper_short_headers;
+    let mut target_shorts = [
+        PortfolioV16ViewMut::new(target_short_0),
+        PortfolioV16ViewMut::new(target_short_1),
+    ];
+    let mut helper_shorts = [
+        PortfolioV16ViewMut::new(helper_short_0),
+        PortfolioV16ViewMut::new(helper_short_1),
+    ];
+
+    market.deposit_not_atomic(&mut target, 10_000).unwrap();
+    market.deposit_not_atomic(&mut helper, 10_000).unwrap();
+    for short in &mut target_shorts {
+        market.deposit_not_atomic(short, 102).unwrap();
+    }
+    for short in &mut helper_shorts {
+        market.deposit_not_atomic(short, 200).unwrap();
+    }
+
+    for asset_index in 0..2 {
+        for pair in 0..2 {
+            let (long, short, size_q) = if pair == 0 {
+                (&mut target, &mut target_shorts[asset_index], POS_SCALE)
+            } else {
+                (&mut helper, &mut helper_shorts[asset_index], 2 * POS_SCALE)
+            };
+            market
+                .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                    long,
+                    short,
+                    TradeRequestV16 {
+                        asset_index,
+                        size_q: signed_q(size_q),
+                        exec_price: 100,
+                        fee_bps: 0,
+                    },
+                )
+                .unwrap_or_else(|err| {
+                    panic!("asset {asset_index} pair {pair} opening trade failed: {err:?}")
+                });
+            if pair == 0 {
+                let next_slot = market.header.current_slot.get() + 1;
+                while market.markets[asset_index].engine.asset.slot_last.get() < next_slot {
+                    market
+                        .accrue_asset_to_not_atomic(asset_index, next_slot, 100, 0, true)
+                        .unwrap();
+                }
+                let observations = [AutoCrankObservationV16 {
+                    asset_index,
+                    effective_price: 100,
+                    funding_rate_e9: 0,
+                }];
+                for account in [long, short] {
+                    for _ in 0..4 {
+                        let result = market
+                            .permissionless_auto_crank_not_atomic(
+                                account,
+                                AutoCrankWorkV16 {
+                                    now_slot: next_slot,
+                                    observations: &observations,
+                                    resolved_close_fee_rate_per_slot: 0,
+                                },
+                            )
+                            .unwrap();
+                        if result.selected == AutoCrankPlanV16::NoAction {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    for gain_price in [200, 300] {
+        let gain_slot = market.header.current_slot.get() + 1;
+        for asset_index in 0..2 {
+            market
+                .set_asset_raw_oracle_target_not_atomic(asset_index, gain_price)
+                .unwrap();
+            while market.markets[asset_index].engine.asset.slot_last.get() < gain_slot {
+                market
+                    .accrue_asset_to_not_atomic(asset_index, gain_slot, gain_price, 0, true)
+                    .unwrap();
+            }
+        }
+    }
+    for short in &mut target_shorts {
+        market.full_account_refresh_not_atomic(short).unwrap();
+    }
+    for short in &mut helper_shorts {
+        market.full_account_refresh_not_atomic(short).unwrap();
+    }
+    market.full_account_refresh_not_atomic(&mut target).unwrap();
+    market.full_account_refresh_not_atomic(&mut helper).unwrap();
+    assert_eq!(target.header.pnl.get(), 400);
+    let expected_rate = CREDIT_RATE_SCALE * 302 / 600;
+    assert_eq!(
+        market.markets[0]
+            .engine
+            .source_credit_short
+            .credit_rate_num
+            .get(),
+        expected_rate,
+    );
+    assert_eq!(
+        market.markets[1]
+            .engine
+            .source_credit_short
+            .credit_rate_num
+            .get(),
+        expected_rate,
+    );
+
+    market.set_asset_raw_oracle_target_not_atomic(0, 1).unwrap();
+    let loss_slot = market.header.current_slot.get() + 1;
+    while market.markets[0].engine.asset.slot_last.get() < loss_slot {
+        market
+            .accrue_asset_to_not_atomic(0, loss_slot, 1, 0, true)
+            .unwrap();
+    }
+    let cert = market
+        .full_account_refresh_not_atomic(&mut target)
+        .expect("cross-domain fractional source support must not block K/F settlement");
+
+    assert!(cert.valid);
+    assert_eq!(target.header.pnl.get(), 0);
+    assert_eq!(target.header.capital.get(), 9_901);
+    market.validate_shape().unwrap();
+    target.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_residual_reward_credit_uses_real_principal_not_notional() {
     let (mut header, mut markets) = market_fixture(1, 1_000);
     header.config.initial_margin_bps = V16PodU64::new(500);


### PR DESCRIPTION
## Impact
A public two-asset lifecycle can leave a live portfolio permanently unable to settle a fair mark reversal. The support estimator floors fractional source support only after summing domains, while the consumer floors each domain independently. The estimator can therefore request one atom that no source domain can supply; both permissionless auto-crank and owner rebalance return `LockActive` forever under honest later-slot retries.

## Reproduction
The first commit is an exact-parent engine RED: two source domains each provide 100 whole atoms plus fractional support, the estimator advertises 201 atoms, and the mutator can consume only 200. No state injection or dishonest oracle is required.

## Fix
Use one per-domain `source_credit_consumable_atoms` calculation in both support estimators and the mutating consumer. This preserves conservative per-domain rounding and available-backing caps.

## Verification
- `cargo test --all-targets --features fuzz --quiet` (159 tests)
- focused Kani estimator/consumer compatibility proof: 458 checks, 2/2 covers, 0 failures
- exact wrapper LiteSVM RED/GREEN is being published separately against this commit

Exact parent: `143e68c4917ed0400a27b952f036a5677047cd84`.