### PR TITLE
[REAL DoS] Cap B settlement by loss atoms

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -10866,7 +10866,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
         price_override: Option<(usize, u64)>,
-        b_delta_budget: u128,
+        b_loss_atom_budget: u128,
         allow_b_chunk: bool,
     ) -> V16Result<AccountRefreshCertOutcomeV16> {
         self.validate_account_scalar_preflight(&account.as_view())?;
@@ -10950,7 +10950,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 self.mark_leg_b_stale(account, asset_index)?;
                 if allow_b_chunk {
                     let chunk =
-                        self.settle_account_b_chunk(account, asset_index, b_delta_budget)?;
+                        self.settle_account_b_chunk(account, asset_index, b_loss_atom_budget)?;
                     if chunk.remaining_after != 0 {
                         return Ok(AccountRefreshCertOutcomeV16::BChunk(chunk));
                     }
@@ -11199,7 +11199,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         &self,
         leg: PortfolioLegV16,
         target: u128,
-        endpoint_delta_budget: u128,
+        endpoint_loss_atom_budget: u128,
     ) -> V16Result<AccountBSettlementChunkV16> {
         if target < leg.b_snap {
             return Err(V16Error::RecoveryRequired);
@@ -11213,10 +11213,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 remaining_after: 0,
             });
         }
-        if leg.loss_weight == 0 || endpoint_delta_budget == 0 {
+        if leg.loss_weight == 0 || endpoint_loss_atom_budget == 0 {
             return Err(V16Error::RecoveryRequired);
         }
-        let limit = self.header.config.public_b_chunk_atoms.get();
+        // Both limits are collateral atoms. Convert that atom budget to the
+        // corresponding B-index delta exactly once through loss_weight below.
+        let limit = self
+            .header
+            .config
+            .public_b_chunk_atoms
+            .get()
+            .min(endpoint_loss_atom_budget);
         let max_num = limit
             .checked_add(1)
             .and_then(|v| v.checked_mul(SOCIAL_LOSS_DEN))
@@ -11226,9 +11233,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Err(V16Error::RecoveryRequired);
         }
         let max_delta_by_loss = (max_num - leg.b_rem) / leg.loss_weight;
-        let delta_b = b_remaining
-            .min(max_delta_by_loss)
-            .min(endpoint_delta_budget);
+        let delta_b = b_remaining.min(max_delta_by_loss);
         if delta_b == 0 {
             return Err(V16Error::RecoveryRequired);
         }
@@ -11251,7 +11256,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         &self,
         account: &PortfolioV16View<'_>,
         asset_index: usize,
-        endpoint_delta_budget: u128,
+        endpoint_loss_atom_budget: u128,
     ) -> V16Result<AccountBSettlementChunkV16> {
         account.validate_with_market(&self.as_view())?;
         let leg = Self::active_leg_for_asset(account, asset_index)?;
@@ -11262,19 +11267,19 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if target < leg.b_snap {
             return Err(V16Error::RecoveryRequired);
         }
-        self.account_b_settlement_chunk_from_leg(leg, target, endpoint_delta_budget)
+        self.account_b_settlement_chunk_from_leg(leg, target, endpoint_loss_atom_budget)
     }
 
     fn settle_account_b_chunk(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
         asset_index: usize,
-        endpoint_delta_budget: u128,
+        endpoint_loss_atom_budget: u128,
     ) -> V16Result<AccountBSettlementChunkV16> {
         let chunk = self.account_b_settlement_chunk(
             &account.as_view(),
             asset_index,
-            endpoint_delta_budget,
+            endpoint_loss_atom_budget,
         )?;
         if chunk.delta_b == 0 {
             if !Self::has_b_stale_leg(&account.as_view())? {
@@ -11310,7 +11315,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     fn settle_account_side_effects_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
-        b_delta_budget: u128,
+        b_loss_atom_budget: u128,
     ) -> V16Result<PermissionlessProgressOutcomeV16> {
         account.validate_with_market(&self.as_view())?;
         let mut slot = 0usize;
@@ -11324,7 +11329,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 if target > refreshed.b_snap {
                     self.mark_leg_b_stale(account, asset_index)?;
                     let chunk =
-                        self.settle_account_b_chunk(account, asset_index, b_delta_budget)?;
+                        self.settle_account_b_chunk(account, asset_index, b_loss_atom_budget)?;
                     if chunk.remaining_after != 0 {
                         return Ok(PermissionlessProgressOutcomeV16::AccountBChunk(chunk));
                     }
@@ -15822,12 +15827,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
         asset_index: usize,
-        b_delta_budget: u128,
+        b_loss_atom_budget: u128,
     ) -> V16Result<DeadLegForfeitOutcomeV16> {
         account.validate_with_market(&self.as_view())?;
         if asset_index >= self.header.config.max_market_slots.get() as usize
             || asset_index >= self.markets.len()
-            || b_delta_budget == 0
+            || b_loss_atom_budget == 0
         {
             return Err(V16Error::InvalidLeg);
         }
@@ -15872,7 +15877,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let refreshed = Self::active_leg_for_asset(&account.as_view(), asset_index)?;
         if self.b_target_for_leg(asset_index, refreshed)? > refreshed.b_snap {
             self.mark_leg_b_stale(account, asset_index)?;
-            let chunk = self.settle_account_b_chunk(account, asset_index, b_delta_budget)?;
+            let chunk = self.settle_account_b_chunk(account, asset_index, b_loss_atom_budget)?;
             total_loss_settled = total_loss_settled
                 .checked_add(chunk.loss)
                 .ok_or(V16Error::ArithmeticOverflow)?;

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -912,6 +912,15 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         )
     }
 
+    pub fn kani_account_b_settlement_chunk_from_leg(
+        &self,
+        leg: PortfolioLegV16,
+        target: u128,
+        loss_atom_budget: u128,
+    ) -> V16Result<AccountBSettlementChunkV16> {
+        self.account_b_settlement_chunk_from_leg(leg, target, loss_atom_budget)
+    }
+
     pub fn kani_book_bankruptcy_residual_chunk_internal(
         &mut self,
         asset_index: usize,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -79,6 +79,33 @@ fn one_market_view_fixture() -> (
     (header, markets, account_header)
 }
 
+#[kani::proof]
+#[kani::solver(cadical)]
+fn proof_v16_b_settlement_atom_budget_clears_public_scale_gap() {
+    const TARGET_B: u128 = 107_486_458_947_473_684_210_526_315;
+    const LOSS_WEIGHT: u128 = 19_000_000;
+
+    let (mut header, mut markets, _) = one_market_view_fixture();
+    header.config.public_b_chunk_atoms = V16PodU128::new(MAX_VAULT_TVL);
+    let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let leg = PortfolioLegV16 {
+        active: true,
+        loss_weight: LOSS_WEIGHT,
+        ..PortfolioLegV16::default()
+    };
+    let full_loss = LOSS_WEIGHT.checked_mul(TARGET_B).unwrap() / SOCIAL_LOSS_DEN;
+    assert!(full_loss > 0 && full_loss < MAX_VAULT_TVL);
+
+    let chunk = market
+        .kani_account_b_settlement_chunk_from_leg(leg, TARGET_B, MAX_VAULT_TVL)
+        .unwrap();
+
+    assert_eq!(chunk.delta_b, TARGET_B);
+    assert_eq!(chunk.loss, full_loss);
+    assert!(chunk.loss <= MAX_VAULT_TVL);
+    assert_eq!(chunk.remaining_after, 0);
+}
+
 fn two_market_view_fixture() -> (
     MarketGroupV16HeaderAccount,
     [Market<u64>; 2],

--- a/tests/v16_fuzzing.rs
+++ b/tests/v16_fuzzing.rs
@@ -3,9 +3,9 @@
 use percolator::{
     EngineAssetSlotV16Account, LiquidationRequestV16, Market, MarketGroupV16HeaderAccount,
     MarketGroupV16ViewMut, PermissionlessCrankActionV16, PermissionlessCrankRequestV16,
-    PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioV16View,
+    PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16, PortfolioV16View,
     PortfolioV16ViewMut, ProvenanceHeaderV16, ProvenanceHeaderV16Account, TradeRequestV16,
-    V16Config, V16Error,
+    V16Config, V16Error, MAX_VAULT_TVL, SOCIAL_LOSS_DEN,
 };
 use proptest::prelude::*;
 
@@ -34,6 +34,34 @@ fn fuzz_account(account_id: [u8; 32]) -> PortfolioAccountV16Account {
     let mut account = PortfolioAccountV16Account::default();
     account.init_empty_in_place(header).unwrap();
     account
+}
+
+#[test]
+fn v16_b_settlement_budget_is_loss_atoms_not_index_delta() {
+    const TARGET_B: u128 = 107_486_458_947_473_684_210_526_315;
+    const LOSS_WEIGHT: u128 = 19_000_000;
+
+    let (market_id, _, _, _) = ids();
+    let cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
+    assert_eq!(cfg.public_b_chunk_atoms, MAX_VAULT_TVL);
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_id, cfg, 1, 0).unwrap();
+    let mut markets = vec![Market::new(0u64, EngineAssetSlotV16Account::default())];
+    let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let leg = PortfolioLegV16 {
+        active: true,
+        loss_weight: LOSS_WEIGHT,
+        ..PortfolioLegV16::default()
+    };
+    let full_loss = LOSS_WEIGHT.checked_mul(TARGET_B).unwrap() / SOCIAL_LOSS_DEN;
+    assert!(full_loss > 0 && full_loss < MAX_VAULT_TVL);
+
+    let chunk = market
+        .kani_account_b_settlement_chunk_from_leg(leg, TARGET_B, MAX_VAULT_TVL)
+        .unwrap();
+
+    assert_eq!(chunk.delta_b, TARGET_B);
+    assert_eq!(chunk.loss, full_loss);
+    assert_eq!(chunk.remaining_after, 0);
 }
 
 fn assert_fuzz_invariants(


### PR DESCRIPTION
## Finding

`account_b_settlement_chunk_from_leg` derived an atom-bounded B-index delta, then also capped that delta directly by `public_b_chunk_atoms`. The configuration and endpoint budgets are collateral atoms, not B-index units.

A valid public market lifecycle at the maximum supported quote scale produces a B target of `107486458947473684210526315` with survivor loss weight `19000000`. The total realizable loss is about `2.042e12` atoms, safely below the default `1e16` atom budget, but the old implementation advanced B by only `1e16` per successful close. Terminal settlement therefore required more than 10.7 billion transactions and stranded survivor funds despite an honest cranker.

## Fix

- Treat both configured and endpoint limits as loss-atom budgets.
- Take their minimum before converting once through `loss_weight`.
- Remove the dimensionally invalid direct B-index cap.
- Rename internal budget parameters to make the unit explicit.

The first commit is the exact-parent RED regression. The second commit is the narrow fix plus a focused Kani regression.

## Verification

- `cargo test --all-targets --features fuzz --quiet`
- `cargo kani --features fuzz --harness proof_v16_b_settlement_atom_budget_clears_public_scale_gap`
  - 2,843 checks, 0 failures

## Dependency

This is intentionally stacked on #115. Exact `master` reaches the independent ADL terminal-close blocker from #115 first; applying only #115 exposes this B-settlement unit bug through the public wrapper lifecycle.
