### PR TITLE
[BLOCKER LoF] Recredit claim-free terminal overlap

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -717,6 +717,17 @@ impl V16Core {
     }
 
     #[inline]
+    fn terminal_claim_free_overlap_recredit(
+        provider_receivable_atoms: u128,
+        paired_domain_insurance_spent: u128,
+        claim_free_residual_remaining: u128,
+    ) -> u128 {
+        provider_receivable_atoms
+            .min(paired_domain_insurance_spent)
+            .min(claim_free_residual_remaining)
+    }
+
+    #[inline]
     fn validate_bound_num_atom_aligned(bound_num: u128) -> V16Result<()> {
         if bound_num == 0 {
             return Ok(());
@@ -5096,6 +5107,17 @@ impl TokenValueFlowProofV16 {
         Ok(proof)
     }
 
+    fn unallocated_protocol_surplus_to_insurance(
+        amount: u128,
+        vault_before: u128,
+        vault_after: u128,
+    ) -> V16Result<Self> {
+        let mut proof = Self::empty(vault_before, vault_after);
+        proof.debit(TokenValueClassV16::UnallocatedProtocolSurplus, amount)?;
+        proof.credit(TokenValueClassV16::InsuranceCapital, amount)?;
+        Ok(proof)
+    }
+
     pub fn account_capital_to_realized_loss(
         amount: u128,
         vault_before: u128,
@@ -9427,6 +9449,103 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             counterparty_credit_consumed,
             insurance_credit_consumed,
         })
+    }
+
+    fn recredit_terminal_claim_free_overlap_for_source_domain_not_atomic(
+        &mut self,
+        source_domain: usize,
+        claim_free_residual_remaining: &mut u128,
+    ) -> V16Result<u128> {
+        let (asset_index, source_side) = self.domain_asset_side(source_domain)?;
+        let insurance_domain =
+            self.insurance_domain_index(asset_index, opposite_side(source_side))?;
+        let (_, insurance_spent) = self.domain_insurance_budget_spent(insurance_domain)?;
+        let provider_receivable_atoms = self
+            .source_credit_for_domain(source_domain)?
+            .provider_receivable_num
+            / BOUND_SCALE;
+        let recredit = V16Core::terminal_claim_free_overlap_recredit(
+            provider_receivable_atoms,
+            insurance_spent,
+            *claim_free_residual_remaining,
+        );
+        if recredit == 0 {
+            return Ok(0);
+        }
+
+        let vault_before = self.header.vault.get();
+        self.header.insurance = V16PodU128::new(
+            self.header
+                .insurance
+                .get()
+                .checked_add(recredit)
+                .ok_or(V16Error::ArithmeticOverflow)?,
+        );
+        self.set_domain_insurance_spent_core(
+            insurance_domain,
+            insurance_spent
+                .checked_sub(recredit)
+                .ok_or(V16Error::CounterUnderflow)?,
+        )?;
+        *claim_free_residual_remaining = claim_free_residual_remaining
+            .checked_sub(recredit)
+            .ok_or(V16Error::CounterUnderflow)?;
+        TokenValueFlowProofV16::unallocated_protocol_surplus_to_insurance(
+            recredit,
+            vault_before,
+            self.header.vault.get(),
+        )?
+        .validate()?;
+        Ok(recredit)
+    }
+
+    /// Restores one asset's claim-free terminal residual that is also backed by
+    /// both an outstanding counterparty-provider receivable and historical
+    /// insurance spend on the paired side. The final materialized-portfolio gate
+    /// makes the residual unowned by traders before any reclassification occurs.
+    ///
+    /// This operation is intentionally asset-local: wrapper callers can make
+    /// bounded progress even when the market account contains thousands of
+    /// configured slots.
+    pub fn recredit_terminal_claim_free_residual_for_asset_not_atomic(
+        &mut self,
+        asset_index: usize,
+    ) -> V16Result<u128> {
+        self.validate_shape()?;
+        if decode_market_mode(self.header.mode)? != MarketModeV16::Resolved
+            || self.header.materialized_portfolio_count.get() != 0
+            || self.header.c_tot.get() != 0
+            || self.header.pnl_pos_tot.get() != 0
+            || self.header.pnl_matured_pos_tot.get() != 0
+            || self.header.pnl_pos_bound_tot.get() != 0
+            || self.header.pnl_pos_bound_tot_num.get() != 0
+            || self.header.source_claim_bound_total_num.get() != 0
+            || self.header.resolved_payout_blocker_count.get() != 0
+            || self.header.stale_certificate_count.get() != 0
+            || self.header.b_stale_account_count.get() != 0
+            || self.header.negative_pnl_account_count.get() != 0
+        {
+            return Err(V16Error::LockActive);
+        }
+
+        let mut claim_free_residual_remaining = self.residual();
+        let mut recredited_total = 0u128;
+        for side in [SideV16::Long, SideV16::Short] {
+            if claim_free_residual_remaining == 0 {
+                break;
+            }
+            let source_domain = self.insurance_domain_index(asset_index, side)?;
+            let recredited = self
+                .recredit_terminal_claim_free_overlap_for_source_domain_not_atomic(
+                    source_domain,
+                    &mut claim_free_residual_remaining,
+                )?;
+            recredited_total = recredited_total
+                .checked_add(recredited)
+                .ok_or(V16Error::ArithmeticOverflow)?;
+        }
+        self.validate_shape()?;
+        Ok(recredited_total)
     }
 
     fn create_and_consume_account_source_credit_for_effective_not_atomic(

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -210,6 +210,18 @@ pub fn kani_source_credit_state_realizable_support_for_face(
     V16Core::source_credit_state_realizable_support_for_face(state, face_claim)
 }
 
+pub fn kani_terminal_claim_free_overlap_recredit(
+    provider_receivable_atoms: u128,
+    paired_domain_insurance_spent: u128,
+    claim_free_residual_remaining: u128,
+) -> u128 {
+    V16Core::terminal_claim_free_overlap_recredit(
+        provider_receivable_atoms,
+        paired_domain_insurance_spent,
+        claim_free_residual_remaining,
+    )
+}
+
 pub fn kani_backing_utilization_rate_e9_for_source_state(
     config: V16Config,
     source: SourceCreditStateV16,
@@ -535,6 +547,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             budget,
             old_spent,
             new_spent,
+        )
+    }
+
+    pub fn kani_recredit_terminal_claim_free_overlap_for_source_domain_not_atomic(
+        &mut self,
+        source_domain: usize,
+        claim_free_residual_remaining: &mut u128,
+    ) -> V16Result<u128> {
+        self.recredit_terminal_claim_free_overlap_for_source_domain_not_atomic(
+            source_domain,
+            claim_free_residual_remaining,
         )
     }
 

--- a/tests/backing_double_claim_fuzz.rs
+++ b/tests/backing_double_claim_fuzz.rs
@@ -267,6 +267,119 @@ proptest! {
     }
 }
 
+#[test]
+fn terminal_source_realization_recredits_paired_insurance_overlap() {
+    const CLAIM: u128 = 30;
+    const BACKING: u128 = 30;
+    const INSURANCE_BUDGET: u128 = 100;
+    const INSURANCE_SPENT: u128 = 20;
+
+    let (mut header, mut markets, mut account_header) =
+        resolved_market_with_backed_winner(CLAIM, BACKING, INSURANCE_SPENT);
+    let insurance_before = INSURANCE_BUDGET - INSURANCE_SPENT;
+    header.insurance = V16PodU128::new(insurance_before);
+    header.vault = V16PodU128::new(header.vault.get() + insurance_before);
+    header.insurance_domain_budget_remaining_total = V16PodU128::new(insurance_before);
+    // The positive claim consumes source domain 0. Its losing counterparty's
+    // insurance was charged to the opposite side of the same asset (domain 1).
+    markets[0].engine.insurance_domain_budget_short = V16PodU128::new(INSURANCE_BUDGET);
+    markets[0].engine.insurance_domain_spent_short = V16PodU128::new(INSURANCE_SPENT);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    assert_eq!(market.validate_shape(), Ok(()));
+    assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
+
+    let outcome = market
+        .close_resolved_account_not_atomic(&mut account, 0)
+        .expect("resolved source realization must close");
+    assert_eq!(outcome, ResolvedCloseOutcomeV16::Closed { payout: CLAIM });
+    assert_eq!(
+        market
+            .recredit_terminal_claim_free_residual_for_asset_not_atomic(0)
+            .expect("claim-free terminal overlap must be recredited"),
+        INSURANCE_SPENT
+    );
+    assert_eq!(market.header.vault.get(), INSURANCE_BUDGET);
+    assert_eq!(market.header.insurance.get(), INSURANCE_BUDGET);
+    assert_eq!(
+        market.header.insurance_domain_budget_remaining_total.get(),
+        INSURANCE_BUDGET
+    );
+    assert_eq!(
+        market.markets[0].engine.insurance_domain_spent_short.get(),
+        0
+    );
+    assert_eq!(
+        market.markets[0]
+            .engine
+            .backing_long
+            .fresh_unliened_backing_num
+            .get(),
+        0
+    );
+    assert_eq!(market.validate_shape(), Ok(()));
+    assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(300))]
+
+    #[test]
+    fn terminal_claim_free_overlap_recredit_is_capped_without_value_drift(
+        claim in 1u128..=1_000_000u128,
+        insurance_spent in 0u128..=1_000_000u128,
+        claim_free_residual in 0u128..=1_000_000u128,
+        insurance_before in 0u128..=1_000_000u128,
+    ) {
+        let insurance_budget = insurance_before + insurance_spent;
+        let expected_recredit = claim.min(insurance_spent).min(claim_free_residual);
+        let (mut header, mut markets, mut account_header) =
+            resolved_market_with_backed_winner(claim, claim, claim_free_residual);
+        header.insurance = V16PodU128::new(insurance_before);
+        header.vault = V16PodU128::new(header.vault.get() + insurance_before);
+        header.insurance_domain_budget_remaining_total = V16PodU128::new(insurance_before);
+        markets[0].engine.insurance_domain_budget_short = V16PodU128::new(insurance_budget);
+        markets[0].engine.insurance_domain_spent_short = V16PodU128::new(insurance_spent);
+
+        let vault_before = header.vault.get();
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut account_header);
+        prop_assert_eq!(market.validate_shape(), Ok(()));
+
+        let outcome = market
+            .close_resolved_account_not_atomic(&mut account, 0)
+            .expect("fully source-backed resolved winner must close");
+        prop_assert_eq!(
+            outcome,
+            ResolvedCloseOutcomeV16::Closed { payout: claim }
+        );
+        let recredited = market
+            .recredit_terminal_claim_free_residual_for_asset_not_atomic(0)
+            .expect("terminal sweep must accept an extinguished claim set");
+        prop_assert_eq!(recredited, expected_recredit);
+        prop_assert_eq!(market.header.vault.get(), vault_before - claim);
+        prop_assert_eq!(
+            market.header.insurance.get(),
+            insurance_before + expected_recredit
+        );
+        prop_assert_eq!(
+            market.header.insurance_domain_budget_remaining_total.get(),
+            insurance_before + expected_recredit
+        );
+        prop_assert_eq!(
+            market.markets[0].engine.insurance_domain_spent_short.get(),
+            insurance_spent - expected_recredit
+        );
+        prop_assert_eq!(
+            market.header.vault.get() - market.header.insurance.get(),
+            claim_free_residual - expected_recredit
+        );
+        prop_assert_eq!(market.validate_shape(), Ok(()));
+        prop_assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
+    }
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(300))]
 
@@ -350,7 +463,12 @@ fn realization_after_snapshot_refines_unreceipted_bound() {
     let pnl_a = 1_000u128; // plain junior winner
     let pnl_b = 500u128; // source-backed winner
     let backing = pnl_b; // fully backed
-    let residual = pnl_a; // honest junior pool exactly covers A
+    let insurance_budget = 1_000u128;
+    let insurance_spent = 200u128;
+    let insurance_before = insurance_budget - insurance_spent;
+    // The junior pool exactly covers A. The historical insurance spend is part
+    // of that support, not a surplus overlapping B's paired source backing.
+    let residual = pnl_a;
 
     let cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
     let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_id(), cfg, 1, 0).unwrap();
@@ -361,7 +479,9 @@ fn realization_after_snapshot_refines_unreceipted_bound() {
     header.mode = 1; // Resolved
     header.resolved_slot = V16PodU64::new(1);
     header.current_slot = V16PodU64::new(1);
-    header.vault = V16PodU128::new(residual + backing);
+    header.vault = V16PodU128::new(residual + backing + insurance_before);
+    header.insurance = V16PodU128::new(insurance_before);
+    header.insurance_domain_budget_remaining_total = V16PodU128::new(insurance_before);
     header.pnl_pos_tot = V16PodU128::new(pnl_a + pnl_b);
     header.pnl_matured_pos_tot = V16PodU128::new(pnl_a + pnl_b);
     header.pnl_pos_bound_tot = V16PodU128::new(pnl_a + pnl_b);
@@ -384,6 +504,8 @@ fn realization_after_snapshot_refines_unreceipted_bound() {
             credit_rate_num: CREDIT_RATE_SCALE,
             ..SourceCreditStateV16::EMPTY
         });
+    markets[0].engine.insurance_domain_budget_short = V16PodU128::new(insurance_budget);
+    markets[0].engine.insurance_domain_spent_short = V16PodU128::new(insurance_spent);
 
     let mut a_header = winner_account(0, pnl_a);
     let mut b_header = winner_account(0, pnl_b);
@@ -422,7 +544,19 @@ fn realization_after_snapshot_refines_unreceipted_bound() {
         "stale unreceipted bound left A unfinalizable"
     );
     assert!(topped > 0);
-    assert_eq!(market.header.vault.get(), 0);
+    assert_eq!(
+        market
+            .recredit_terminal_claim_free_residual_for_asset_not_atomic(0)
+            .expect("mixed exact support is terminal and claim-free"),
+        0,
+        "ordinary winner support must not be reclassified as insurance"
+    );
+    assert_eq!(market.header.vault.get(), insurance_before);
+    assert_eq!(market.header.insurance.get(), insurance_before);
+    assert_eq!(
+        market.markets[0].engine.insurance_domain_spent_short.get(),
+        insurance_spent
+    );
     assert_eq!(market.validate_shape(), Ok(()));
 }
 

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -16,13 +16,14 @@ use percolator::v16::{
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
     kani_pending_domain_loss_barrier_blocks_position_change, kani_position_delta_increases_risk,
     kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
-    kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
-    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
-    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
-    BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
-    CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
-    HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
-    Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
+    kani_target_effective_lag_adverse_delta, kani_terminal_claim_free_overlap_recredit,
+    kani_trade_preexisting_oi_reduction_gate, kani_trade_preflight_risk_gate,
+    kani_validate_positive_pnl_source_attribution, AssetLifecycleV16, AssetStateV16,
+    AssetStateV16Account, BackingBucketStatusV16, BackingBucketV16, BackingBucketV16Account,
+    BatchTradeOutcomeV16, CloseProgressLedgerV16, CloseProgressLedgerV16Account,
+    EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16, HealthCertV16Account,
+    InsuranceCreditReservationV16, InsuranceCreditReservationV16Account, Market,
+    MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
     PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
@@ -12425,6 +12426,119 @@ fn proof_v16_counterparty_credit_consumption_reports_atoms_not_scaled_backing() 
     assert_eq!(source_after_consume.spent_backing_num, backing_num);
     assert_eq!(source_after_consume.provider_receivable_num, backing_num);
     assert_eq!(source_after_consume.credit_rate_num, rate);
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_v16_terminal_claim_free_overlap_recredit_is_exactly_bounded() {
+    let receivable_raw: u16 = kani::any();
+    let spent_raw: u16 = kani::any();
+    let residual_raw: u16 = kani::any();
+    let receivable = receivable_raw as u128;
+    let spent = spent_raw as u128;
+    let residual = residual_raw as u128;
+
+    let recredit = kani_terminal_claim_free_overlap_recredit(receivable, spent, residual);
+
+    kani::cover!(
+        receivable > 8 && spent > receivable && residual > receivable,
+        "terminal overlap recredit covers provider-receivable cap"
+    );
+    kani::cover!(
+        spent > 8 && receivable > spent && residual > spent,
+        "resolved overlap recredit covers paired-insurance-spend cap"
+    );
+    kani::cover!(
+        residual > 8 && receivable > residual && spent > residual,
+        "resolved overlap recredit covers claim-free-residual cap"
+    );
+
+    assert_eq!(recredit, receivable.min(spent).min(residual));
+    assert!(recredit <= receivable);
+    assert!(recredit <= spent);
+    assert!(recredit <= residual);
+
+    let insurance_before: u128 = kani::any();
+    kani::assume(insurance_before <= u128::MAX - residual);
+    let insurance_after = insurance_before + recredit;
+    let spent_after = spent - recredit;
+    let residual_after = residual - recredit;
+    assert_eq!(
+        insurance_after + residual_after,
+        insurance_before + residual
+    );
+    assert_eq!(spent_after + recredit, spent);
+}
+
+#[kani::proof]
+#[kani::unwind(32)]
+#[kani::solver(cadical)]
+fn proof_v16_terminal_claim_free_overlap_recredit_updates_only_paired_insurance_domain() {
+    let budget_raw: u8 = kani::any();
+    let spent_raw: u8 = kani::any();
+    let receivable_raw: u8 = kani::any();
+    let residual_raw: u8 = kani::any();
+    kani::assume(spent_raw <= budget_raw);
+
+    let budget = budget_raw as u128;
+    let spent = spent_raw as u128;
+    let receivable = receivable_raw as u128;
+    let residual_before = residual_raw as u128;
+    let insurance_before = budget - spent;
+    let expected = receivable.min(spent).min(residual_before);
+
+    let (mut header, mut markets, _) = one_market_view_fixture();
+    header.insurance = V16PodU128::new(insurance_before);
+    header.vault = V16PodU128::new(insurance_before + residual_before);
+    header.insurance_domain_budget_remaining_total = V16PodU128::new(insurance_before);
+    markets[0].engine.insurance_domain_budget_short = V16PodU128::new(budget);
+    markets[0].engine.insurance_domain_spent_short = V16PodU128::new(spent);
+    let receivable_num = receivable * BOUND_SCALE;
+    let mut source = markets[0]
+        .engine
+        .source_credit_long
+        .try_to_runtime()
+        .unwrap();
+    source.spent_backing_num = receivable_num;
+    source.provider_receivable_num = receivable_num;
+    markets[0].engine.source_credit_long = SourceCreditStateV16Account::from_runtime(&source);
+    let mut bucket = markets[0].engine.backing_long.try_to_runtime().unwrap();
+    bucket.consumed_liened_backing_num = receivable_num;
+    markets[0].engine.backing_long = BackingBucketV16Account::from_runtime(&bucket);
+    let long_spent_before = markets[0].engine.insurance_domain_spent_long;
+    let vault_before = header.vault;
+    let mut residual_remaining = residual_before;
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let result = market
+        .kani_recredit_terminal_claim_free_overlap_for_source_domain_not_atomic(
+            0,
+            &mut residual_remaining,
+        )
+        .unwrap();
+
+    kani::cover!(
+        expected > 2 && expected < receivable,
+        "transition covers a nontrivial paired-domain partial recredit"
+    );
+    assert_eq!(result, expected);
+    assert_eq!(market.header.vault, vault_before);
+    assert_eq!(market.header.insurance.get(), insurance_before + expected);
+    assert_eq!(
+        market.header.insurance_domain_budget_remaining_total.get(),
+        insurance_before + expected
+    );
+    assert_eq!(
+        market.markets[0].engine.insurance_domain_spent_short.get(),
+        spent - expected
+    );
+    assert_eq!(
+        market.markets[0].engine.insurance_domain_spent_long,
+        long_spent_before
+    );
+    assert_eq!(residual_remaining, residual_before - expected);
+    assert_eq!(market.kani_residual(), residual_before - expected);
 }
 
 #[kani::proof]

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -2747,7 +2747,11 @@ fn v16_source_backed_conversion_clears_sparse_source_domain_slot() {
     let mut account_header = account_fixture(1, 18);
     let claim = 20u128;
     let claim_num = claim * BOUND_SCALE;
-    header.vault = V16PodU128::new(claim);
+    // Keep an unrelated live residual and historical opposite-domain insurance
+    // spend present. Only the claim-free terminal sweep may recredit an overlap.
+    header.vault = V16PodU128::new(claim + 10);
+    header.insurance = V16PodU128::new(5);
+    header.insurance_domain_budget_remaining_total = V16PodU128::new(5);
     header.pnl_pos_tot = V16PodU128::new(claim);
     header.pnl_pos_bound_tot_num = V16PodU128::new(claim_num);
     header.pnl_pos_bound_tot = V16PodU128::new(claim);
@@ -2772,6 +2776,8 @@ fn v16_source_backed_conversion_clears_sparse_source_domain_slot() {
         status: BackingBucketStatusV16::Fresh,
         ..BackingBucketV16::EMPTY
     });
+    markets[0].engine.insurance_domain_budget_short = V16PodU128::new(10);
+    markets[0].engine.insurance_domain_spent_short = V16PodU128::new(5);
 
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
     let mut account = PortfolioV16ViewMut::new(&mut account_header);
@@ -2785,6 +2791,15 @@ fn v16_source_backed_conversion_clears_sparse_source_domain_slot() {
     assert_eq!(converted, claim);
     assert_eq!(account.header.pnl.get(), 0);
     assert_eq!(account.header.capital.get(), claim);
+    assert_eq!(
+        market.header.insurance.get(),
+        5,
+        "live conversion must not recredit historical insurance spend"
+    );
+    assert_eq!(
+        market.markets[0].engine.insurance_domain_spent_short.get(),
+        5
+    );
     assert_eq!(
         account.header.source_domains[0],
         PortfolioSourceDomainV16Account::default()


### PR DESCRIPTION
## Finding

A public liquidation can spend directional insurance for a bankrupt account while the resolved winner later consumes counterparty backing for the same loss. After every portfolio exits, the provider is short by the overlapping amount, the residual is ownerless, and terminal close is blocked.

Tracked by aeyakovenko/percolator-prog#289.

## Fix

- Add an asset-local terminal sweep gated on resolution, zero materialized portfolios, and zero outstanding trader claim/blocker counters.
- Reclassify residual to the paired insurance domain only up to all three independent caps: claim-free residual, historical paired-domain insurance spend, and outstanding source-provider receivable.
- Preserve vault custody while restoring insurance and reducing the paired domain spend.
- Keep live and per-winner source conversion unchanged, so close order cannot reclassify support still owed to another winner.
- Keep the API asset-local so one recovery call touches exactly two source domains instead of scanning a maximal market slab.

## Verification

- Full engine matrix: 50 unit, 11 backing fuzz, 15 reference, 2 insolvent, 9 rounding, 1 rollback fuzz, and 72 spec tests green.
- Deterministic terminal-overlap, mixed exact-support, and live-conversion regressions green; the mixed-order case proves ordinary winner support is not recredited.
- Kani pure cap proof: 0/25 failed, all 3 cap branches covered.
- Kani whole-mutation proof: 0/3579 failed, required nonzero mutation covered.
- Exact-parent public LiteSVM RED/GREEN is in the linked wrapper PR; the final provider recovery consumes 126,863 CU on a 5,834-slot market.