### PR TITLE
[BLOCKER LoF] Settle authenticated mark loss before fee sync

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -12306,13 +12306,36 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     fn account_has_target_effective_lag(&self, account: &PortfolioV16View<'_>) -> V16Result<bool> {
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
-            let leg = account.header.legs[slot].try_to_runtime()?;
-            if leg.active && self.asset_has_target_effective_lag(leg.asset_index as usize)? {
+            let leg = &account.header.legs[slot];
+            if decode_bool(leg.active)?
+                && self.asset_has_target_effective_lag(leg.asset_index.get() as usize)?
+            {
                 return Ok(true);
             }
             slot += 1;
         }
         Ok(false)
+    }
+
+    fn preflight_fee_sync_target_lag(
+        &self,
+        account: &PortfolioV16View<'_>,
+        market_mode: MarketModeV16,
+        nonflat: bool,
+    ) -> V16Result<()> {
+        let target_effective_lag = if market_mode == MarketModeV16::Live && nonflat {
+            self.account_has_target_effective_lag(account)?
+        } else {
+            false
+        };
+        if V16Core::fee_sync_target_lag_blocked(
+            market_mode == MarketModeV16::Live,
+            nonflat,
+            target_effective_lag,
+        ) {
+            return Err(V16Error::LockActive);
+        }
+        Ok(())
     }
 
     fn ensure_favorable_action_allowed(&self, account: &PortfolioV16View<'_>) -> V16Result<()> {
@@ -14884,18 +14907,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Err(V16Error::Stale);
         }
         let nonflat = !active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get));
-        let target_effective_lag = if market_mode == MarketModeV16::Live && nonflat {
-            self.account_has_target_effective_lag(&account.as_view())?
-        } else {
-            false
-        };
-        if V16Core::fee_sync_target_lag_blocked(
-            market_mode == MarketModeV16::Live,
-            nonflat,
-            target_effective_lag,
-        ) {
-            return Err(V16Error::LockActive);
-        }
+        self.preflight_fee_sync_target_lag(&account.as_view(), market_mode, nonflat)?;
         let fee_anchor = if market_mode == MarketModeV16::Live && nonflat {
             self.account_fee_anchor_for_loss_currentness(&account.as_view(), now_slot)?
         } else if market_mode == MarketModeV16::Resolved {

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -638,6 +638,13 @@ pub fn active_bitmap_count_ones(bitmap: V16ActiveBitmap) -> u32 {
 struct V16Core;
 
 impl V16Core {
+    #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|blocked: &bool| {
+        *blocked == (live && nonflat && target_effective_lag)
+    }))]
+    fn fee_sync_target_lag_blocked(live: bool, nonflat: bool, target_effective_lag: bool) -> bool {
+        live && nonflat && target_effective_lag
+    }
+
     fn loss_stale_trade_scope_allowed(
         market_loss_stale_active: bool,
         trade_asset_loss_stale: bool,
@@ -14869,17 +14876,29 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         fee_rate_per_slot: u128,
     ) -> V16Result<u128> {
         account.validate_with_market(&self.as_view())?;
-        if decode_market_mode(self.header.mode)? == MarketModeV16::Recovery {
+        let market_mode = decode_market_mode(self.header.mode)?;
+        if market_mode == MarketModeV16::Recovery {
             return Err(V16Error::LockActive);
         }
         if now_slot < account.header.last_fee_slot.get() {
             return Err(V16Error::Stale);
         }
         let nonflat = !active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get));
-        let fee_anchor = if decode_market_mode(self.header.mode)? == MarketModeV16::Live && nonflat
-        {
+        let target_effective_lag = if market_mode == MarketModeV16::Live && nonflat {
+            self.account_has_target_effective_lag(&account.as_view())?
+        } else {
+            false
+        };
+        if V16Core::fee_sync_target_lag_blocked(
+            market_mode == MarketModeV16::Live,
+            nonflat,
+            target_effective_lag,
+        ) {
+            return Err(V16Error::LockActive);
+        }
+        let fee_anchor = if market_mode == MarketModeV16::Live && nonflat {
             self.account_fee_anchor_for_loss_currentness(&account.as_view(), now_slot)?
-        } else if decode_market_mode(self.header.mode)? == MarketModeV16::Resolved {
+        } else if market_mode == MarketModeV16::Resolved {
             self.header.resolved_slot.get()
         } else {
             now_slot
@@ -14892,7 +14911,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             .checked_mul(U256::from_u64(dt))
             .ok_or(V16Error::ArithmeticOverflow)?;
         let requested_fee = raw_fee.try_into_u128().unwrap_or(u128::MAX);
-        if decode_market_mode(self.header.mode)? == MarketModeV16::Live && nonflat {
+        if market_mode == MarketModeV16::Live && nonflat {
             if let PermissionlessProgressOutcomeV16::AccountBChunk(_) = self
                 .settle_account_side_effects_not_atomic(
                     account,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -462,6 +462,15 @@ impl MarketGroupV16HeaderAccount {
 }
 
 impl<'a, T> MarketGroupV16ViewMut<'a, T> {
+    pub fn kani_preflight_fee_sync_target_lag(
+        &self,
+        account: &PortfolioV16View<'_>,
+        market_mode: MarketModeV16,
+        nonflat: bool,
+    ) -> V16Result<()> {
+        self.preflight_fee_sync_target_lag(account, market_mode, nonflat)
+    }
+
     pub fn kani_clear_leg(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -195,6 +195,14 @@ pub fn kani_loss_stale_trade_scope_allowed(
     )
 }
 
+pub fn kani_fee_sync_target_lag_blocked(
+    live: bool,
+    nonflat: bool,
+    target_effective_lag: bool,
+) -> bool {
+    V16Core::fee_sync_target_lag_blocked(live, nonflat, target_effective_lag)
+}
+
 pub fn kani_prepare_asset_recovery_transition(
     asset: AssetStateV16,
     asset_set_epoch: u64,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -8,8 +8,8 @@ use percolator::v16::{
     kani_available_backing_num_for_source_credit_state,
     kani_backing_utilization_fee_quote_atoms_for_lien,
     kani_backing_utilization_rate_e9_for_source_state, kani_cert_is_current,
-    kani_expected_source_credit_rate_num_for_state, kani_health_cert_after_capital_debit,
-    kani_health_requirements_from_base_and_target_lag,
+    kani_expected_source_credit_rate_num_for_state, kani_fee_sync_target_lag_blocked,
+    kani_health_cert_after_capital_debit, kani_health_requirements_from_base_and_target_lag,
     kani_liquidation_close_would_leave_uncovered_loss_with_open_risk,
     kani_liquidation_engine_close_request_q, kani_liquidation_fee_from_raw_fee,
     kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
@@ -9570,6 +9570,23 @@ fn proof_v16_view_fee_sync_settles_negative_pnl_before_fee() {
     assert_eq!(market.header.c_tot.get(), capital - loss - expected_fee);
     assert_eq!(market.header.insurance.get(), expected_fee);
     assert_eq!(market.header.vault.get(), capital);
+}
+
+#[kani::proof]
+fn proof_v16_fee_sync_target_lag_guard_is_exact() {
+    let live: bool = kani::any();
+    let nonflat: bool = kani::any();
+    let target_effective_lag: bool = kani::any();
+    let blocked = kani_fee_sync_target_lag_blocked(live, nonflat, target_effective_lag);
+    kani::cover!(
+        blocked,
+        "fee-sync target-lag guard covers a blocked live nonflat account"
+    );
+    kani::cover!(
+        !blocked && live,
+        "fee-sync target-lag guard covers a live admissible account"
+    );
+    assert_eq!(blocked, live && nonflat && target_effective_lag);
 }
 
 #[kani::proof]

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -8,8 +8,8 @@ use percolator::v16::{
     kani_available_backing_num_for_source_credit_state,
     kani_backing_utilization_fee_quote_atoms_for_lien,
     kani_backing_utilization_rate_e9_for_source_state, kani_cert_is_current,
-    kani_expected_source_credit_rate_num_for_state, kani_fee_sync_target_lag_blocked,
-    kani_health_cert_after_capital_debit, kani_health_requirements_from_base_and_target_lag,
+    kani_expected_source_credit_rate_num_for_state, kani_health_cert_after_capital_debit,
+    kani_health_requirements_from_base_and_target_lag,
     kani_liquidation_close_would_leave_uncovered_loss_with_open_risk,
     kani_liquidation_engine_close_request_q, kani_liquidation_fee_from_raw_fee,
     kani_liquidation_partial_search_hi, kani_liquidation_projected_health_deficit_from_parts,
@@ -22,8 +22,8 @@ use percolator::v16::{
     BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
     CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
     HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
-    Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
-    PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
+    Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, MarketModeV16,
+    PermissionlessCrankActionV16, PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
     ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedCloseOutcomeV16,
@@ -160,6 +160,40 @@ fn one_market_direct_view_fixture() -> (
     )];
     markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
     (header, markets, PortfolioAccountV16Account::default())
+}
+
+fn two_market_direct_view_fixture() -> (
+    MarketGroupV16HeaderAccount,
+    [Market<u64>; 2],
+    PortfolioAccountV16Account,
+) {
+    let (market_group_id, _, _) = ids();
+    let cfg = V16Config::public_user_fund_with_market_slots(2, 2, 0, 10);
+    let mut header = MarketGroupV16HeaderAccount::default();
+    header.market_group_id = market_group_id;
+    header.config = V16ConfigAccount::from_runtime(&cfg);
+    header.asset_slot_capacity = V16PodU32::new(2);
+    header.asset_activation_count = V16PodU64::new(2);
+    header.next_market_id = V16PodU64::new(3);
+    header.slot_last = V16PodU64::new(1);
+    header.current_slot = V16PodU64::new(1);
+    let mut markets = [
+        Market::new(0u64, EngineAssetSlotV16Account::empty_for_market(1)),
+        Market::new(0u64, EngineAssetSlotV16Account::empty_for_market(2)),
+    ];
+    let mut asset_index = 0usize;
+    while asset_index < 2 {
+        let mut asset = AssetStateV16::default();
+        asset.market_id = asset_index as u64 + 1;
+        asset.lifecycle = AssetLifecycleV16::Active;
+        asset.raw_oracle_target_price = 100;
+        asset.effective_price = 100;
+        asset.fund_px_last = 100;
+        asset.slot_last = 1;
+        markets[asset_index].engine.asset = AssetStateV16Account::from_runtime(&asset);
+        asset_index += 1;
+    }
+    (header, markets, empty_account_fixture(market_group_id, 2))
 }
 
 fn empty_recovery_slot_for_market(
@@ -8681,7 +8715,7 @@ fn proof_v16_public_resolved_close_flat_account_pays_only_capital_and_vault() {
 #[kani::unwind(40)]
 #[kani::solver(cadical)]
 fn proof_v16_resolved_two_active_legs_are_unattributed_for_bankruptcy() {
-    let (mut header, mut markets, mut account_header) = two_market_view_fixture();
+    let (mut header, mut markets, mut account_header) = two_market_direct_view_fixture();
     header.mode = 1; // Resolved
     header.current_slot = V16PodU64::new(2);
     header.resolved_slot = V16PodU64::new(2);
@@ -9573,20 +9607,109 @@ fn proof_v16_view_fee_sync_settles_negative_pnl_before_fee() {
 }
 
 #[kani::proof]
-fn proof_v16_fee_sync_target_lag_guard_is_exact() {
-    let live: bool = kani::any();
-    let nonflat: bool = kani::any();
-    let target_effective_lag: bool = kani::any();
-    let blocked = kani_fee_sync_target_lag_blocked(live, nonflat, target_effective_lag);
+#[kani::unwind(24)]
+#[kani::solver(cadical)]
+fn proof_v16_fee_sync_preflight_cannot_preempt_any_active_leg_mark() {
+    let lag_asset_raw: u8 = kani::any();
+    let target_above_effective: bool = kani::any();
+    let first_leg_short: bool = kani::any();
+    let second_leg_short: bool = kani::any();
+    let target_delta_raw: u8 = kani::any();
+    kani::assume(lag_asset_raw < 2);
+    kani::assume((1..=50).contains(&target_delta_raw));
+
+    let lag_asset = lag_asset_raw as usize;
+    let target_delta = target_delta_raw as u64;
+    let (mut header, mut markets, mut account_header) = two_market_view_fixture();
+    header.current_slot = V16PodU64::new(10);
+    header.slot_last = V16PodU64::new(10);
+    header.vault = V16PodU128::new(1_000);
+    header.c_tot = V16PodU128::new(1_000);
+    account_header.capital = V16PodU128::new(1_000);
+
+    let mut bitmap = account_header.active_bitmap.map(V16PodU64::get);
+    let mut asset_index = 0usize;
+    while asset_index < 2 {
+        let mut asset = markets[asset_index].engine.asset.try_to_runtime().unwrap();
+        asset.effective_price = 100;
+        asset.raw_oracle_target_price = if asset_index == lag_asset {
+            if target_above_effective {
+                100 + target_delta
+            } else {
+                100 - target_delta
+            }
+        } else {
+            100
+        };
+        markets[asset_index].engine.asset = AssetStateV16Account::from_runtime(&asset);
+
+        let side =
+            if (asset_index == 0 && first_leg_short) || (asset_index == 1 && second_leg_short) {
+                SideV16::Short
+            } else {
+                SideV16::Long
+            };
+        account_header.legs[asset_index] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+            active: true,
+            asset_index: asset_index as u32,
+            market_id: asset.market_id,
+            side,
+            basis_pos_q: if side == SideV16::Short {
+                -(POS_SCALE as i128)
+            } else {
+                POS_SCALE as i128
+            },
+            a_basis: ADL_ONE,
+            k_snap: 0,
+            f_snap: 0,
+            epoch_snap: 0,
+            loss_weight: POS_SCALE,
+            b_snap: 0,
+            b_rem: 0,
+            b_epoch_snap: 0,
+            b_stale: false,
+            stale: false,
+        });
+        active_bitmap_set(&mut bitmap, asset_index).unwrap();
+        asset_index += 1;
+    }
+    account_header.active_bitmap = bitmap.map(V16PodU64::new);
+
+    let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let account = PortfolioV16ViewMut::new(&mut account_header);
+    let result =
+        market.kani_preflight_fee_sync_target_lag(&account.as_view(), MarketModeV16::Live, true);
+
     kani::cover!(
-        blocked,
-        "fee-sync target-lag guard covers a blocked live nonflat account"
+        lag_asset == 0 && target_above_effective && first_leg_short,
+        "fee sync blocks an upward target on the first short leg"
     );
     kani::cover!(
-        !blocked && live,
-        "fee-sync target-lag guard covers a live admissible account"
+        lag_asset == 0 && !target_above_effective && !first_leg_short,
+        "fee sync blocks a downward target on the first long leg"
     );
-    assert_eq!(blocked, live && nonflat && target_effective_lag);
+    kani::cover!(
+        lag_asset == 1 && target_above_effective && second_leg_short,
+        "fee sync scans through to an upward target on the second short leg"
+    );
+    kani::cover!(
+        lag_asset == 1 && !target_above_effective && !second_leg_short,
+        "fee sync scans through to a downward target on the second long leg"
+    );
+    assert_eq!(result, Err(V16Error::LockActive));
+
+    let mut caught_up = market.markets[lag_asset]
+        .engine
+        .asset
+        .try_to_runtime()
+        .unwrap();
+    caught_up.raw_oracle_target_price = caught_up.effective_price;
+    market.markets[lag_asset].engine.asset = AssetStateV16Account::from_runtime(&caught_up);
+    assert_eq!(
+        market.kani_preflight_fee_sync_target_lag(&account.as_view(), MarketModeV16::Live, true,),
+        Ok(()),
+        "the same portfolio becomes fee-sync eligible after the mark catches up"
+    );
 }
 
 #[kani::proof]

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -510,8 +510,7 @@ fn v16_fee_sync_on_nonflat_account_settles_hidden_k_loss_before_fee() {
     assert_eq!(header.insurance.get(), 0);
     let accrued_asset = markets[0].engine.asset.try_to_runtime().unwrap();
     assert_eq!(
-        accrued_asset.raw_oracle_target_price,
-        accrued_asset.effective_price,
+        accrued_asset.raw_oracle_target_price, accrued_asset.effective_price,
         "control must fully apply its authenticated target before fee sync"
     );
 

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -499,12 +499,21 @@ fn v16_fee_sync_on_nonflat_account_settles_hidden_k_loss_before_fee() {
             )
             .unwrap();
         market
+            .set_asset_raw_oracle_target_not_atomic(0, 50)
+            .unwrap();
+        market
             .accrue_asset_to_not_atomic(0, 2, 50, 0, true)
             .unwrap();
     }
     assert_eq!(long_header.pnl.get(), 0);
     assert_eq!(long_header.capital.get(), 100);
     assert_eq!(header.insurance.get(), 0);
+    let accrued_asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(
+        accrued_asset.raw_oracle_target_price,
+        accrued_asset.effective_price,
+        "control must fully apply its authenticated target before fee sync"
+    );
 
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
     let mut long = PortfolioV16ViewMut::new(&mut long_header);
@@ -521,6 +530,50 @@ fn v16_fee_sync_on_nonflat_account_settles_hidden_k_loss_before_fee() {
     assert_eq!(market.header.insurance.get(), 50);
     market.validate_shape().unwrap();
     long.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_fee_sync_rejects_target_effective_lag_before_charging() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut long_header = account_fixture(1, 16);
+    let mut short_header = account_fixture(1, 17);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market.deposit_not_atomic(&mut long, 100).unwrap();
+        market.deposit_not_atomic(&mut short, 1_000).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: signed_q(POS_SCALE),
+                    exec_price: 100,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(0, 9, 100, 0, true)
+            .unwrap();
+        market
+            .set_asset_raw_oracle_target_not_atomic(0, 50)
+            .unwrap();
+    }
+
+    let header_before = header;
+    let markets_before = markets.clone();
+    let account_before = long_header;
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let result = market.sync_account_fee_to_slot_not_atomic(&mut long, 10, 10);
+
+    assert_eq!(result, Err(V16Error::LockActive));
+    assert_eq!(market.header, &header_before);
+    assert_eq!(market.markets, markets_before.as_slice());
+    assert_eq!(long.header, &account_before);
 }
 
 #[test]


### PR DESCRIPTION
## Finding

A permissionless caller can front-run an already-authenticated adverse mark with `SyncMaintenanceFee`. Before the fix, fee sync settles only realized K/F/PnL and ignores target/effective mark lag.

The public wrapper LiteSVM exploit produced:

- mark first: cranker reward 50,000; victim payout 0; independent winner payout 50,000
- fee sync first: cranker reward 100,000; victim payout 0; independent winner payout 0

The attacker needs no authority. The authenticated mark update is already committed; the attacker invokes only the permissionless fee-sync route and withdraws its reward.

## Fix

For a live non-flat account, reject fee sync with `LockActive` while any exposed price-managed asset has target/effective lag. A public crank can apply the committed mark, after which fee sync succeeds. This does not block trading or exits.

The guard is a production kernel with an exact Kani contract over all Boolean combinations. The existing hidden-K loss test now stages the raw target before accrual, matching production ordering and retaining coverage for the fully-applied-mark path.

## Verification

- Exact pre-fix native RED: sync returned `Ok(20)` instead of `Err(LockActive)`
- Focused native GREEN
- Kani guard proof: 0 failures, 2/2 covers
- `cargo test --all-targets --features fuzz -- --test-threads=1`: 159 passed
- `cargo fmt --all -- --check`
- `git diff --check`

A paired wrapper PR will add the public LiteSVM regression and guard wrapper-profile lag until authenticated targets are staged into the engine at submission time.