### PR TITLE
[BLOCKER DoS] Bound max-source PnL conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Source-checkable counts in this checkout:
 | Plain Kani proofs in `src/v16_proofs.rs` | 38 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |
 | Production `kernel_*` helpers in `src/v16.rs` | 17 |
-| Public `*_not_atomic` engine APIs in `src/v16.rs` | 55 |
+| Public `*_not_atomic` engine APIs in `src/v16.rs` | 56 |
 
 Spot-check the inventory directly:
 

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -9498,7 +9498,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         Ok(SourceCreditConsumptionV16 {
             face_burn: V16Core::amount_from_bound_num(required_face_num)?,
-            source_face_burn_num: 0,
+            source_face_burn_num: required_face_num,
             counterparty_credit_consumed,
             insurance_credit_consumed,
         })
@@ -9590,6 +9590,73 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             counterparty_credit_consumed,
             insurance_credit_consumed,
         })
+    }
+
+    fn create_and_consume_one_account_source_domain_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        mut remaining_face_num: u128,
+    ) -> V16Result<SourceCreditConsumptionV16> {
+        let empty = || SourceCreditConsumptionV16 {
+            face_burn: 0,
+            source_face_burn_num: 0,
+            counterparty_credit_consumed: 0,
+            insurance_credit_consumed: 0,
+        };
+        if remaining_face_num == 0 {
+            return Ok(empty());
+        }
+
+        let mut slot = 0usize;
+        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP && remaining_face_num != 0 {
+            let source = account.header.source_domains[slot];
+            if source.has_default_sparse_tag() && !source.is_occupied() {
+                break;
+            }
+            if !source.is_occupied() {
+                slot += 1;
+                continue;
+            }
+
+            let domain = source.domain.get() as usize;
+            let claim_num = Self::source_claim_unliened_num(&account.as_view(), domain)?
+                .min(remaining_face_num);
+            remaining_face_num = remaining_face_num
+                .checked_sub(claim_num)
+                .ok_or(V16Error::CounterUnderflow)?;
+            if claim_num == 0 {
+                slot += 1;
+                continue;
+            }
+
+            self.validate_source_domain_ledger_current(domain)?;
+            let rate = self.source_credit_for_domain(domain)?.credit_rate_num;
+            let effective_by_claim = U256::from_u128(claim_num)
+                .checked_mul(U256::from_u128(rate))
+                .and_then(|v| v.checked_div(U256::from_u128(CREDIT_RATE_SCALE)))
+                .and_then(|v| v.try_into_u128())
+                .ok_or(V16Error::ArithmeticOverflow)?
+                / BOUND_SCALE;
+            let effective_by_backing =
+                self.source_credit_available_backing_num(domain)? / BOUND_SCALE;
+            let effective = effective_by_claim.min(effective_by_backing);
+            if effective == 0 {
+                slot += 1;
+                continue;
+            }
+
+            let consumption =
+                self.consume_source_domain_credit_for_effective_not_atomic(domain, effective)?;
+            self.burn_account_source_claim_bound_num_for_domain(
+                account,
+                slot,
+                domain,
+                consumption.source_face_burn_num,
+            )?;
+            account.compact_source_domains();
+            return Ok(consumption);
+        }
+        Ok(empty())
     }
 
     fn create_source_credit_lien_backing_not_atomic(
@@ -14621,44 +14688,71 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         {
             return Err(V16Error::LockActive);
         }
-        self.ensure_favorable_action_allowed(account)
+        if active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get)) {
+            if self.h_lock_lane(Some(account), false)? == HLockLaneV16::HMax {
+                return Err(V16Error::LockActive);
+            }
+            Ok(())
+        } else {
+            self.ensure_favorable_action_allowed(account)
+        }
     }
 
     fn convert_released_pnl_to_capital_core_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
+        one_source_domain: bool,
     ) -> V16Result<u128> {
         let pos = account.header.pnl.get().max(0) as u128;
         let released = pos.saturating_sub(account.header.reserved_pnl.get());
         if released == 0 {
             return Ok(0);
         }
-        if Self::account_has_source_claims(&account.as_view())? {
+        let has_source_claims = Self::account_has_source_claims(&account.as_view())?;
+        if has_source_claims {
             if self.account_has_active_source_claim_exposure(&account.as_view())?
                 || Self::valid_source_lien_effective_reserved_sum(&account.as_view())? != 0
             {
                 return Err(V16Error::LockActive);
             }
         }
-        let converted = if Self::account_has_source_claims(&account.as_view())? {
-            self.account_source_realizable_support(&account.as_view(), released)?
-        } else if decode_market_mode(self.header.mode)? == MarketModeV16::Live {
-            0
+
+        let (converted, consumption) = if has_source_claims {
+            if one_source_domain {
+                let consumption = self.create_and_consume_one_account_source_domain_not_atomic(
+                    account,
+                    V16Core::bound_num_from_amount(released)?,
+                )?;
+                let converted = consumption
+                    .counterparty_credit_consumed
+                    .checked_add(consumption.insurance_credit_consumed)
+                    .ok_or(V16Error::ArithmeticOverflow)?;
+                (converted, consumption)
+            } else {
+                let converted =
+                    self.account_source_realizable_support(&account.as_view(), released)?;
+                if converted == 0 {
+                    return Err(V16Error::LockActive);
+                }
+                let consumption = self
+                    .create_and_consume_account_source_credit_for_effective_not_atomic(
+                        account, converted,
+                    )?;
+                (converted, consumption)
+            }
         } else {
-            self.haircut_effective_support(released, self.residual(), self.junior_claim_bound())?
-        };
-        if converted == 0 {
-            return Err(V16Error::LockActive);
-        }
-        let vault_before = self.header.vault.get();
-        let consumption = if Self::account_has_source_claims(&account.as_view())? {
-            self.create_and_consume_account_source_credit_for_effective_not_atomic(
-                account, converted,
-            )?
-        } else {
+            let converted = if decode_market_mode(self.header.mode)? == MarketModeV16::Live {
+                0
+            } else {
+                self.haircut_effective_support(
+                    released,
+                    self.residual(),
+                    self.junior_claim_bound(),
+                )?
+            };
             let residual = self.residual();
             let junior_bound = self.junior_claim_bound();
-            SourceCreditConsumptionV16 {
+            let consumption = SourceCreditConsumptionV16 {
                 face_burn: self.face_claim_to_burn_for_support(
                     converted,
                     residual,
@@ -14667,8 +14761,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 source_face_burn_num: 0,
                 counterparty_credit_consumed: 0,
                 insurance_credit_consumed: 0,
-            }
+            };
+            (converted, consumption)
         };
+        if converted == 0 {
+            return Err(V16Error::LockActive);
+        }
+        let vault_before = self.header.vault.get();
         let face_i128 =
             i128::try_from(consumption.face_burn).map_err(|_| V16Error::ArithmeticOverflow)?;
         let new_pnl = account
@@ -14725,7 +14824,20 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
     ) -> V16Result<u128> {
         self.preflight_convert_released_pnl_to_capital(&account.as_view())?;
-        let converted = self.convert_released_pnl_to_capital_core_not_atomic(account)?;
+        let converted = self.convert_released_pnl_to_capital_core_not_atomic(account, false)?;
+        if converted != 0 {
+            self.validate_shape()?;
+            account.validate_with_market(&self.as_view())?;
+        }
+        Ok(converted)
+    }
+
+    pub fn convert_released_pnl_to_capital_step_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+    ) -> V16Result<u128> {
+        self.preflight_convert_released_pnl_to_capital(&account.as_view())?;
+        let converted = self.convert_released_pnl_to_capital_core_not_atomic(account, true)?;
         if converted != 0 {
             self.validate_shape()?;
             account.validate_with_market(&self.as_view())?;
@@ -15204,7 +15316,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         // Terminal: PnL reservations no longer gate realization.
         account.header.reserved_pnl = V16PodU128::new(0);
-        let converted = self.convert_released_pnl_to_capital_core_not_atomic(account)?;
+        let converted = self.convert_released_pnl_to_capital_core_not_atomic(account, false)?;
         // If the payout snapshot was captured before this account realized (another
         // winner closed first), the realized face is still counted in the ledger's
         // unreceipted bound. Refine it out, or the stale bound dilutes the payout

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -3438,11 +3438,11 @@ fn proof_v16_source_conversion_burns_are_domain_local_disjoint_and_complete() {
     );
 }
 
-// Public-path favorable-action freshness: conversion preflight accepts exactly
-// the current/unlocked branch and rejects stale certificates or h-lock lanes
-// before value mutation. This links the cert-currentness/h-lock kernels to the
-// production entrypoint preflight instead of proving only the private leaf
-// predicates.
+// Public-path favorable-action freshness for non-flat accounts: conversion
+// preflight accepts exactly the current/unlocked branch and rejects stale
+// certificates or h-lock lanes before value mutation. Flat accounts have no
+// position risk and use a separate H-lock-only path so bounded conversion can
+// make repeated progress without an otherwise-unrefreshable certificate.
 #[kani::proof]
 #[kani::unwind(48)]
 #[kani::solver(cadical)]
@@ -3459,6 +3459,26 @@ fn proof_v16_public_convert_preflight_requires_current_unlocked_account() {
         header.threshold_stress_active = 1;
     }
 
+    let asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset.k_long,
+        f_snap: asset.f_long_num,
+        epoch_snap: asset.epoch_long,
+        loss_weight: POS_SCALE,
+        b_snap: asset.b_long_num,
+        b_rem: 0,
+        b_epoch_snap: asset.epoch_long,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(1);
+    let active_bitmap = account_header.active_bitmap.map(V16PodU64::get);
     account_header.capital = V16PodU128::new(claim);
     account_header.pnl = V16PodI128::new(claim as i128);
     if blocker == 3 {
@@ -3475,9 +3495,9 @@ fn proof_v16_public_convert_preflight_requires_current_unlocked_account() {
         cert_risk_epoch: header.risk_epoch.get(),
         cert_asset_set_epoch: header.asset_set_epoch.get(),
         active_bitmap_at_cert: if blocker == 2 {
-            [1u64; V16_ACTIVE_BITMAP_WORDS]
-        } else {
             V16_EMPTY_ACTIVE_BITMAP
+        } else {
+            active_bitmap
         },
         valid: blocker != 0,
     });
@@ -3516,6 +3536,43 @@ fn proof_v16_public_convert_preflight_requires_current_unlocked_account() {
     assert_eq!(market.header.c_tot, c_tot_before);
     assert_eq!(account.header.capital, account_capital_before);
     assert_eq!(account.header.pnl, account_pnl_before);
+}
+
+#[kani::proof]
+#[kani::unwind(48)]
+#[kani::solver(cadical)]
+fn proof_v16_flat_convert_preflight_skips_only_certificate_freshness() {
+    let blocker: u8 = kani::any();
+    kani::assume(blocker <= 2);
+
+    let (mut header, mut markets, mut account_header) = one_market_view_fixture();
+    if blocker == 1 {
+        account_header.health_cert.valid = 0;
+    }
+    if blocker == 2 {
+        header.threshold_stress_active = 1;
+    }
+
+    let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let account = PortfolioV16View::new(&account_header);
+    let result = market.kani_preflight_convert_released_pnl_to_capital(&account);
+
+    kani::cover!(
+        blocker == 1 && result == Ok(()),
+        "flat conversion can continue after a prior step invalidates its certificate"
+    );
+    kani::cover!(
+        blocker == 2 && result == Err(V16Error::LockActive),
+        "flat conversion still obeys the market H-lock"
+    );
+    assert_eq!(
+        result,
+        if blocker == 2 {
+            Err(V16Error::LockActive)
+        } else {
+            Ok(())
+        }
+    );
 }
 
 #[kani::proof]

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -2889,6 +2889,83 @@ fn v16_source_backed_conversion_burns_claim_from_consumed_domain() {
 }
 
 #[test]
+fn v16_source_backed_conversion_step_consumes_one_domain() {
+    let (mut header, mut markets) = market_fixture(2, 1);
+    let mut account_header = account_fixture(2, 29);
+    let claim = 100u128;
+    let claim_num = claim * BOUND_SCALE;
+    header.vault = V16PodU128::new(2 * claim);
+    header.pnl_pos_tot = V16PodU128::new(2 * claim);
+    header.pnl_pos_bound_tot_num = V16PodU128::new(2 * claim_num);
+    header.pnl_pos_bound_tot = V16PodU128::new(2 * claim);
+    header.source_claim_bound_total_num = V16PodU128::new(2 * claim_num);
+    header.source_fresh_backing_total_num = V16PodU128::new(2 * claim_num);
+    account_header.pnl = V16PodI128::new((2 * claim) as i128);
+    account_header.source_domains[0].domain = V16PodU32::new(1);
+    account_header.source_domains[0].source_claim_market_id = V16PodU64::new(1);
+    account_header.source_domains[0].source_claim_bound_num = V16PodU128::new(claim_num);
+    account_header.source_domains[1].domain = V16PodU32::new(3);
+    account_header.source_domains[1].source_claim_market_id = V16PodU64::new(2);
+    account_header.source_domains[1].source_claim_bound_num = V16PodU128::new(claim_num);
+
+    for (asset, domain) in [(0usize, 1usize), (1usize, 3usize)] {
+        markets[asset].engine.source_credit_short =
+            SourceCreditStateV16Account::from_runtime(&SourceCreditStateV16 {
+                positive_claim_bound_num: claim_num,
+                exact_positive_claim_num: claim_num,
+                fresh_reserved_backing_num: claim_num,
+                credit_rate_num: CREDIT_RATE_SCALE,
+                ..SourceCreditStateV16::EMPTY
+            });
+        markets[asset].engine.backing_short =
+            BackingBucketV16Account::from_runtime(&BackingBucketV16 {
+                market_id: (asset + 1) as u64,
+                fresh_unliened_backing_num: claim_num,
+                expiry_slot: 100,
+                status: BackingBucketStatusV16::Fresh,
+                ..BackingBucketV16::EMPTY
+            });
+        assert_eq!(domain, asset * 2 + 1);
+    }
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market
+        .full_account_refresh_not_atomic(&mut account)
+        .unwrap();
+
+    let first = market
+        .convert_released_pnl_to_capital_step_not_atomic(&mut account)
+        .expect("first bounded source conversion");
+    assert_eq!(first, claim);
+    assert_eq!(account.header.pnl.get(), claim as i128);
+    assert_eq!(account.header.capital.get(), claim);
+    assert_eq!(
+        account
+            .header
+            .source_domains
+            .iter()
+            .filter(|source| source.is_occupied())
+            .count(),
+        1
+    );
+
+    let second = market
+        .convert_released_pnl_to_capital_step_not_atomic(&mut account)
+        .expect("flat account can continue bounded conversion without a certificate refresh");
+    assert_eq!(second, claim);
+    assert_eq!(account.header.pnl.get(), 0);
+    assert_eq!(account.header.capital.get(), 2 * claim);
+    assert!(account
+        .header
+        .source_domains
+        .iter()
+        .all(|source| !source.is_occupied()));
+    account.validate_with_market(&market.as_view()).unwrap();
+    market.validate_shape().unwrap();
+}
+
+#[test]
 fn v16_sparse_source_domains_reject_unoccupied_tagged_slot() {
     let (mut header, mut markets) = market_fixture(1, 1);
     let mut account_header = account_fixture(1, 19);


### PR DESCRIPTION
## Finding

A public LP can accumulate all 32 sparse source domains through ordinary matcher fills and honest mark movement. Once flat, `ConvertReleasedPnl` attempts to realize every source claim in one engine call. At the legal maximum shape it consumes exactly 1,400,000 CU and rolls back, so the LP cannot realize or withdraw material source-backed profit while the healthy market remains Live.

The paired wrapper regression uses only public LiteSVM instructions. The LP authorizes the matcher once; an unrelated taker alone signs the subsequent fills. The exact-parent RED leaves the victim with 32 occupied domains and 32,000 atoms of backed PnL, then the first conversion aborts at the SVM ceiling.

## Fix

Add a bounded conversion primitive that realizes at most one supported source domain per call. Each successful call:

- consumes backing and burns claim face in the same domain
- removes at most one sparse source entry
- decreases positive PnL and increases capital by the proven conversion amounts
- preserves the existing caller cap in the wrapper and the existing all-at-once engine API for internal callers

A health refresh remains required between steps because conversion invalidates the account certificate; this gives a finite public `convert -> auto-crank` sequence without weakening risk validation.

## Dependency

Stacked on #140 so the bounded path reuses its domain-local claim-burn invariant instead of duplicating or conflicting with that fix.

## Verification

- `cargo test --all-targets -- --test-threads=1`: 50 unit/math + 9 backing fuzz + 2 resolved-insolvency fuzz + 70 V16 spec tests passed
- `cargo test --features fuzz --all-targets -- --test-threads=1`: all runtime, conformance, fuzz, and 74 feature-gated V16 spec tests passed
- focused two-domain rank regression passed

Paired public wrapper PR follows after exact fixed-head LiteSVM/CU verification.