### PR TITLE
[BLOCKER DoS] Bound resolved close work per call

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -8429,6 +8429,22 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(Self::account_source_claim_bound_sum_num(account)? != 0)
     }
 
+    fn account_source_claim_domain_count(account: &PortfolioV16View<'_>) -> usize {
+        let mut count = 0usize;
+        let mut slot = 0usize;
+        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let source = account.source_domains()[slot];
+            if source.has_default_sparse_tag() && !source.is_occupied() {
+                break;
+            }
+            if source.is_occupied() && source.source_claim_bound_num.get() != 0 {
+                count += 1;
+            }
+            slot += 1;
+        }
+        count
+    }
+
     fn source_claim_unliened_num(account: &PortfolioV16View<'_>, domain: usize) -> V16Result<u128> {
         let source = account.source_domain(domain)?;
         let locked = source
@@ -15267,6 +15283,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     fn realize_source_backed_claims_for_resolved_close_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
+        one_source_domain: bool,
     ) -> V16Result<u128> {
         if decode_bool(account.header.resolved_payout_receipt.present)? {
             // The face is already frozen into the receipt pool.
@@ -15316,7 +15333,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         // Terminal: PnL reservations no longer gate realization.
         account.header.reserved_pnl = V16PodU128::new(0);
-        let converted = self.convert_released_pnl_to_capital_core_not_atomic(account, false)?;
+        let converted =
+            self.convert_released_pnl_to_capital_core_not_atomic(account, one_source_domain)?;
         // If the payout snapshot was captured before this account realized (another
         // winner closed first), the realized face is still counted in the ledger's
         // unreceipted bound. Refine it out, or the stale bound dilutes the payout
@@ -15442,12 +15460,25 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             || decode_bool(account.header.b_stale_state)?
             || decode_bool(account.header.stale_state)?
         {
+            self.validate_shape()?;
+            account.validate_with_market(&self.as_view())?;
             return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
         }
         if account.header.pnl.get() > 0 && !self.resolved_positive_payout_ready()? {
             return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
         }
-        self.realize_source_backed_claims_for_resolved_close_not_atomic(account)?;
+        let multiple_source_domains =
+            Self::account_source_claim_domain_count(&account.as_view()) > 1;
+        if self.realize_source_backed_claims_for_resolved_close_not_atomic(
+            account,
+            multiple_source_domains,
+        )? != 0
+            && multiple_source_domains
+        {
+            self.validate_shape()?;
+            account.validate_with_market(&self.as_view())?;
+            return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
+        }
         let mut payout_receipt = None;
         let pnl_payout = if account.header.pnl.get() > 0
             || decode_bool(account.header.resolved_payout_receipt.present)?
@@ -15556,7 +15587,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
             let leg = account.header.legs[slot].try_to_runtime()?;
             if leg.active {
+                // Clearing every admitted leg in one call can exceed the SVM CU
+                // limit. The remaining bitmap makes this a ProgressOnly result.
                 self.clear_resolved_close_leg(account, leg.asset_index as usize)?;
+                break;
             }
             slot += 1;
         }

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -11359,8 +11359,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
             slot += 1;
         }
-        self.settle_negative_pnl_from_principal_not_atomic(account)?;
+        self.settle_negative_pnl_from_principal_core_not_atomic(account)?;
         account.header.health_cert.valid = 0;
+        self.validate_account_audit_scan(&account.as_view())?;
+        self.validate_shape_audit_scan()?;
         Ok(PermissionlessProgressOutcomeV16::AccountCurrent)
     }
 
@@ -15143,6 +15145,32 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(charged)
     }
 
+    fn sync_resolved_account_fee_from_validated_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        fee_rate_per_slot: u128,
+    ) -> V16Result<u128> {
+        if decode_market_mode(self.header.mode)? != MarketModeV16::Resolved {
+            return Err(V16Error::LockActive);
+        }
+        let fee_anchor = self.header.resolved_slot.get();
+        if fee_anchor < account.header.last_fee_slot.get() {
+            return Err(V16Error::Stale);
+        }
+        if fee_anchor == account.header.last_fee_slot.get() {
+            return Ok(0);
+        }
+        let dt = fee_anchor - account.header.last_fee_slot.get();
+        let raw_fee = U256::from_u128(fee_rate_per_slot)
+            .checked_mul(U256::from_u64(dt))
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        let requested_fee = raw_fee.try_into_u128().unwrap_or(u128::MAX);
+        self.settle_negative_pnl_from_principal_core_not_atomic(account)?;
+        let charged = self.charge_account_fee_current_not_atomic(account, requested_fee)?;
+        account.header.last_fee_slot = V16PodU64::new(fee_anchor);
+        Ok(charged)
+    }
+
     pub fn withdraw_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
@@ -15445,12 +15473,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             self.validate_shape()?;
             return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
         }
-        self.sync_account_fee_to_slot_not_atomic(
-            account,
-            self.header.resolved_slot.get(),
-            fee_rate_per_slot,
-        )?;
-        self.settle_negative_pnl_from_principal_not_atomic(account)?;
+        self.sync_resolved_account_fee_from_validated_not_atomic(account, fee_rate_per_slot)?;
         if account.header.pnl.get() < 0 {
             self.settle_resolved_bankruptcy_negative_pnl(account)?;
         }

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -10,10 +10,11 @@ use percolator::{
     PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
-    ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedPayoutLedgerV16,
-    ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16, ResolvedPayoutReceiptV16Account,
-    SideModeV16, SideV16, SourceCreditStateV16, SourceCreditStateV16Account, TradeRequestV16,
-    V16Config, V16Error, V16PodI128, V16PodU128, V16PodU32, V16PodU64, V16_EMPTY_ACTIVE_BITMAP,
+    ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedCloseOutcomeV16,
+    ResolvedPayoutLedgerV16, ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16,
+    ResolvedPayoutReceiptV16Account, SideModeV16, SideV16, SourceCreditStateV16,
+    SourceCreditStateV16Account, TradeRequestV16, V16Config, V16Error, V16PodI128, V16PodU128,
+    V16PodU32, V16PodU64, V16_EMPTY_ACTIVE_BITMAP,
 };
 use percolator::{ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, POS_SCALE};
 
@@ -2449,6 +2450,92 @@ fn v16_permissionless_recovery_crank_is_value_neutral_and_idempotent() {
     assert_eq!(account.header.pnl, pnl_before);
     market.validate_shape().unwrap();
     account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_resolved_close_removes_one_active_leg_per_progress_call() {
+    let (mut header, mut markets) = market_fixture(2, 100);
+    let mut long_header = account_fixture(2, 13);
+    let mut short_header = account_fixture(2, 14);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market.deposit_not_atomic(&mut long, 1_000_000).unwrap();
+        market.deposit_not_atomic(&mut short, 1_000_000).unwrap();
+        for asset_index in 0..2 {
+            market
+                .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                    &mut long,
+                    &mut short,
+                    TradeRequestV16 {
+                        asset_index,
+                        size_q: POS_SCALE as i128,
+                        exec_price: 100,
+                        fee_bps: 0,
+                    },
+                )
+                .unwrap();
+        }
+        let resolved_slot = market.header.current_slot.get();
+        market.resolve_market_not_atomic(resolved_slot).unwrap();
+    }
+
+    let active_leg_count = |account: &PortfolioAccountV16Account| {
+        account
+            .active_bitmap
+            .iter()
+            .map(|word| word.get().count_ones())
+            .sum::<u32>()
+    };
+    assert_eq!(active_leg_count(&long_header), 2);
+    let vault_before = header.vault;
+    let c_tot_before = header.c_tot;
+    let capital_before = long_header.capital;
+    let pnl_before = long_header.pnl;
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let first = market
+        .close_resolved_account_not_atomic(&mut long, 0)
+        .unwrap();
+    assert_eq!(first, ResolvedCloseOutcomeV16::ProgressOnly);
+    assert_eq!(
+        long.header
+            .active_bitmap
+            .iter()
+            .map(|word| word.get().count_ones())
+            .sum::<u32>(),
+        1
+    );
+    assert_eq!(market.header.vault, vault_before);
+    assert_eq!(market.header.c_tot, c_tot_before);
+    assert_eq!(long.header.capital, capital_before);
+    assert_eq!(long.header.pnl, pnl_before);
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+
+    let second = market
+        .close_resolved_account_not_atomic(&mut long, 0)
+        .unwrap();
+    assert_eq!(
+        second,
+        ResolvedCloseOutcomeV16::Closed {
+            payout: capital_before.get()
+        }
+    );
+    assert_eq!(
+        long.header
+            .active_bitmap
+            .iter()
+            .map(|word| word.get().count_ones())
+            .sum::<u32>(),
+        0
+    );
+    assert_eq!(long.header.capital.get(), 0);
+    assert_eq!(long.header.pnl.get(), 0);
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- clear at most one active leg per `close_resolved_account_not_atomic` call
- realize at most one source-claim domain when multiple domains remain
- return `ProgressOnly` after each bounded step and validate the committed state
- preserve the existing one-domain realization semantics
- add a production-API engine regression that opens two legs, resolves, and proves each close call makes value-neutral progress before payout

## Root cause

Resolved close detached every active leg and realized every source domain in one invocation. A publicly constructed maximum-shape portfolio can therefore exceed the SVM compute limit after permissionless resolution. SVM rollback restores the same state, so retrying the only terminal close route cannot make progress and funds remain locked.

## Impact

This turns terminal close into a bounded rank-decreasing operation. Repeated permissionless calls remove one leg or one source domain at a time and eventually complete without requiring a privileged recovery path.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-targets` (132 passed)
- `cargo test --test backing_double_claim_fuzz` (9 passed)

Stacked on the one-source-domain conversion primitive in PR #160; the public LiteSVM red/green regression is being added in the corresponding wrapper PR.