### PR TITLE
[BLOCKER DoS] Release flat source liens before PnL conversion

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -2407,7 +2407,6 @@ impl V16Core {
         Ok((bucket, source))
     }
 
-    #[cfg(any(kani, feature = "fuzz"))]
     // Contract layer: lien release is the un-pledge relabel — valid liened
     // returns to fresh unliened atom-for-atom, fresh_reserved and all stock
     // quantities untouched; zero-amount is the identity.
@@ -2672,7 +2671,6 @@ impl V16Core {
         Ok((reservation, source))
     }
 
-    #[cfg(any(kani, feature = "fuzz"))]
     // Contract layer: insurance lien release un-encumbers reserved credit —
     // exact mirror of creation; reservation total and backing-side untouched.
     #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &V16Result<(InsuranceCreditReservationV16, SourceCreditStateV16)>| match result {
@@ -7819,7 +7817,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
-    #[cfg(any(kani, feature = "fuzz"))]
     pub fn release_source_credit_lien_from_counterparty_not_atomic(
         &mut self,
         domain: usize,
@@ -8074,7 +8071,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
-    #[cfg(any(kani, feature = "fuzz"))]
     pub fn release_source_credit_lien_from_insurance_not_atomic(
         &mut self,
         domain: usize,
@@ -14711,7 +14707,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let has_source_claims = Self::account_has_source_claims(&account.as_view())?;
         if has_source_claims {
             if self.account_has_active_source_claim_exposure(&account.as_view())?
-                || Self::valid_source_lien_effective_reserved_sum(&account.as_view())? != 0
+                || (!one_source_domain
+                    && Self::valid_source_lien_effective_reserved_sum(&account.as_view())? != 0)
             {
                 return Err(V16Error::LockActive);
             }
@@ -14824,6 +14821,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
     ) -> V16Result<u128> {
         self.preflight_convert_released_pnl_to_capital(&account.as_view())?;
+        if Self::valid_source_lien_effective_reserved_sum(&account.as_view())? != 0 {
+            self.release_account_source_credit_liens_if_unneeded_not_atomic(account)?;
+        }
         let converted = self.convert_released_pnl_to_capital_core_not_atomic(account, false)?;
         if converted != 0 {
             self.validate_shape()?;
@@ -14837,6 +14837,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
     ) -> V16Result<u128> {
         self.preflight_convert_released_pnl_to_capital(&account.as_view())?;
+        if Self::valid_source_lien_effective_reserved_sum(&account.as_view())? != 0 {
+            self.release_account_source_credit_liens_if_unneeded_core_not_atomic(account, true)?;
+        }
         let converted = self.convert_released_pnl_to_capital_core_not_atomic(account, true)?;
         if converted != 0 {
             self.validate_shape()?;
@@ -14845,10 +14848,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(converted)
     }
 
-    #[cfg(any(kani, feature = "fuzz"))]
     pub fn release_account_source_credit_liens_if_unneeded_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
+    ) -> V16Result<u128> {
+        self.release_account_source_credit_liens_if_unneeded_core_not_atomic(account, false)
+    }
+
+    fn release_account_source_credit_liens_if_unneeded_core_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        one_source_domain: bool,
     ) -> V16Result<u128> {
         if decode_market_mode(self.header.mode)? != MarketModeV16::Live {
             return Err(V16Error::LockActive);
@@ -14901,7 +14911,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 source.source_lien_counterparty_backing_num = V16PodU128::new(0);
                 source.source_lien_insurance_backing_num = V16PodU128::new(0);
                 source.source_lien_fee_last_slot = V16PodU64::new(0);
+                source.source_lien_capital_at_risk_fee_revenue = V16PodU128::new(0);
                 account.reset_source_domain_slot_if_empty(slot);
+                if one_source_domain {
+                    break;
+                }
             }
             slot += 1;
         }

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -2620,6 +2620,42 @@ fn v16_risk_increasing_trade_creates_source_credit_lien_for_im() {
         Err(V16Error::LockActive),
         "source-backed positive PnL must not be realized while the source-claim exposure remains open"
     );
+    long.header.source_domains[0].source_lien_capital_at_risk_fee_revenue = V16PodU128::new(3);
+
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: -signed_q(10 * POS_SCALE),
+                exec_price: 1,
+                fee_bps: 0,
+            },
+        )
+        .expect("risk-reducing trade must flatten the source-claim exposure");
+    assert_eq!(
+        long.header.active_bitmap.map(V16PodU64::get),
+        V16_EMPTY_ACTIVE_BITMAP
+    );
+    assert_eq!(
+        long.header.source_domains[0]
+            .source_lien_effective_reserved
+            .get(),
+        10,
+        "flattening preserves the lien until a favorable conversion proves it is unneeded"
+    );
+
+    let converted = market
+        .convert_released_pnl_to_capital_step_not_atomic(&mut long)
+        .expect("flat account must release its unneeded lien and realize source-backed PnL");
+    assert_eq!(converted, claim);
+    assert_eq!(long.header.pnl.get(), 0);
+    assert_eq!(long.header.capital.get(), claim);
+    assert_eq!(
+        long.header.source_domains[0],
+        PortfolioSourceDomainV16Account::default()
+    );
     market.validate_shape().unwrap();
     long.validate_with_market(&market.as_view()).unwrap();
     short.validate_with_market(&market.as_view()).unwrap();


### PR DESCRIPTION
## What changed

- Compile the existing source-lien release kernels into production.
- Keep full conversion behavior for direct engine callers, while `convert_released_pnl_to_capital_step_not_atomic` releases at most one source domain and converts at most one source domain per call.
- Release only after the favorable-action preflight and only when capital without positive source credit satisfies current initial margin.
- Clear the completed lien's live fee cursor/counter so its sparse source slot can dematerialize.
- Extend the production lifecycle test through risk increase, flattening, lien release, and PnL realization.

## Root cause

The no-DoS proof surface included `release_account_source_credit_liens_if_unneeded_not_atomic`, but that transition and its lower release kernels were behind `cfg(kani|fuzz)`. A normal account could use source-backed positive PnL as initial margin, close every leg, and retain a now-unneeded lien. Production conversion could consume only unliened claims, so it returned `LockActive` forever even though the account was flat and healthy.

## Stack / merge prerequisites

This PR is stacked on #160 because the wrapper uses its bounded one-source conversion API. Releasing every lien before that step would reintroduce max-shape CU work; this version preserves the one-domain rank decrease.

The final rebased engine lineage must also carry `14c2919d` (companion wrapper #306), which aligns aggregate source support with whole atoms consumable by individual domains. Without that independent fix, any bounded per-domain converter can inherit the already-known cross-domain rounding stall.

## Validation

- `cargo fmt --check`
- `cargo test --all-targets`: 131/131 passed
- Companion public LiteSVM regression passes with production SBF
- Combined 32-source public regression completes every conversion; worst call is 1,321,211 CU, 78,789 below the transaction limit
- Exact parent RED: `ConvertReleasedPnl` returned `LockActive` after both user legs closed successfully

Companion wrapper PR: https://github.com/aeyakovenko/percolator-prog/pull/364