### PR TITLE
[BLOCKER DoS] Resolve terminal recovery through auto-crank

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -11582,7 +11582,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     ///   pending_close    — Live, a close-progress ledger is active
     ///   expired_close    — Live, that ledger is past its max-close slot
     ///   liquidatable     — Live, current cert with nonzero certified liq deficit
-    ///   recovery_eligible— Resolved, unattributed-insolvent negative-PnL recovery
+    ///   recovery_eligible— Recovery, terminal resolution continuation
     ///   resolved_winner  — Resolved, positive PnL, resolved payout ready
     /// Assembled via the proven actionable_summary_from_signals kernel. Live-only
     /// flags need cert currentness only where their entrypoint does (liquidate),
@@ -11595,6 +11595,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let mode = decode_market_mode(self.header.mode)?;
         let live = mode == MarketModeV16::Live;
         let resolved = mode == MarketModeV16::Resolved;
+        let recovery = mode == MarketModeV16::Recovery;
 
         let cert = account.header.health_cert.try_to_runtime()?;
         let cert_current = V16Core::kernel_cert_is_current(
@@ -11633,17 +11634,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // closed, but with no active leg there is nothing to liquidate (the real
         // liquidate entrypoint requires an active leg), so the flag must be false.
         let liquidatable = live && cert_current && cert.certified_liq_deficit != 0 && has_open_risk;
-        // Permissionless recovery (declare_permissionless_recovery) is a LIVE-mode
-        // action — it rejects Resolved mode with LockActive. The proactive Live
-        // recovery condition the auto-crank declares is an EXPIRED outstanding
-        // close (expired_close -> DeclareRecovery, reason
-        // ActiveBankruptCloseCannotProgress); every other recovery reason is
-        // declared REACTIVELY inside the dispatched crank op when it detects
-        // non-progress (BIndexHeadroomExhausted, etc.). Resolved bad-debt
-        // wind-down is handled by CloseResolved itself, not by the recovery
-        // selector flag, so recovery_eligible stays in the summary type for the
-        // proven selector but is driven by expired_close.
-        let recovery_eligible = false;
+        // A committed Recovery state can exist across an engine/program upgrade.
+        // Classify it as terminally actionable so the same sole public auto-crank
+        // that declares a new recovery also completes its transition to Resolved.
+        let recovery_eligible = recovery;
         // resolved_winner routes to close_resolved, which LAZILY captures the
         // payout snapshot itself (initialize_resolved_payout_ledger_if_needed is
         // reached only via close_resolved -> create_resolved_payout_receipt) — so
@@ -11741,7 +11735,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let recovery_reason = if summary.expired_close {
             PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
         } else {
-            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow
+            self.header
+                .recovery_reason
+                .try_to_runtime()?
+                .unwrap_or(PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow)
         };
         // PRODUCTION KERNEL: the proven plan selector (priority + totality +
         // engine-selected asset). refresh accrues the first active leg's asset.

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -11835,8 +11835,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 )?)
             }
             AutoCrankPlanV16::DeclareRecovery { reason } => {
-                // recovery declaration needs no observation.
-                AutoCrankOutcomeV16::Progressed(self.permissionless_crank_not_atomic(
+                // Recovery declaration needs no observation. Complete the terminal
+                // transition in the same public auto-crank so Recovery cannot become
+                // a committed mode with no user withdrawal or resolution path.
+                let progress = self.permissionless_crank_not_atomic(
                     account,
                     PermissionlessCrankRequestV16 {
                         now_slot: work.now_slot,
@@ -11845,7 +11847,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                         funding_rate_e9: 0,
                         action: PermissionlessCrankActionV16::Recover(reason),
                     },
-                )?)
+                )?;
+                self.resolve_market_not_atomic(work.now_slot)?;
+                AutoCrankOutcomeV16::Progressed(progress)
             }
             AutoCrankPlanV16::CloseResolved => {
                 AutoCrankOutcomeV16::ResolvedClose(self.close_resolved_account_not_atomic(
@@ -14981,9 +14985,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     }
 
     pub fn resolve_market_not_atomic(&mut self, resolved_slot: u64) -> V16Result<()> {
-        if decode_market_mode(self.header.mode)? == MarketModeV16::Recovery {
-            return Err(V16Error::LockActive);
-        }
+        // Recovery is a terminal safety mode, not a permanent sink. Resolution
+        // preserves its recorded reason while exposing the bounded resolved-close
+        // path for every account.
+        decode_market_mode(self.header.mode)?;
         if resolved_slot < self.header.current_slot.get() {
             return Err(V16Error::Stale);
         }

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -18,12 +18,11 @@ use percolator::v16::{
     kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
     kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
     kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
-    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, AutoCrankOutcomeV16, AutoCrankPlanV16,
-    AutoCrankWorkV16, BackingBucketStatusV16, BackingBucketV16, BackingBucketV16Account,
-    BatchTradeOutcomeV16, CloseProgressLedgerV16, CloseProgressLedgerV16Account,
-    EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16, HealthCertV16Account,
-    InsuranceCreditReservationV16, InsuranceCreditReservationV16Account, Market,
-    MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
+    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
+    BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
+    CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
+    HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
+    Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
     PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
@@ -4790,60 +4789,90 @@ fn proof_v16_trade_fee_helper_moves_capital_to_insurance_only() {
 #[kani::proof]
 #[kani::unwind(32)]
 #[kani::solver(cadical)]
-fn proof_v16_committed_recovery_auto_crank_resolves_value_neutrally() {
-    let c_tot: u16 = kani::any();
-    let insurance: u16 = kani::any();
-    let surplus: u16 = kani::any();
+fn proof_v16_committed_recovery_is_always_actionable() {
+    let reason_code: u8 = kani::any();
+    let loss_stale: bool = kani::any();
+    let c_tot: u8 = kani::any();
+    let insurance: u8 = kani::any();
+    let surplus: u8 = kani::any();
+    kani::assume(reason_code < 8);
+    let reason = match reason_code {
+        0 => PermissionlessRecoveryReasonV16::BelowProgressFloor,
+        1 => PermissionlessRecoveryReasonV16::BlockedSegmentHeadroomOrRepresentability,
+        2 => PermissionlessRecoveryReasonV16::AccountBSettlementCannotProgress,
+        3 => PermissionlessRecoveryReasonV16::BIndexHeadroomExhausted,
+        4 => PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+        5 => PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+        6 => PermissionlessRecoveryReasonV16::OracleOrTargetUnavailableByAuthenticatedPolicy,
+        _ => PermissionlessRecoveryReasonV16::CounterOrEpochOverflowDeclaredRecovery,
+    };
     let (mut header, mut markets, mut account_header) = one_market_view_fixture();
     header.mode = 2;
     header.current_slot = V16PodU64::new(7);
-    header.recovery_reason = V16OptionalRecoveryReasonAccount::from_runtime(Some(
-        PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
-    ));
+    header.loss_stale_active = u8::from(loss_stale);
+    header.recovery_reason = V16OptionalRecoveryReasonAccount::from_runtime(Some(reason));
     header.c_tot = V16PodU128::new(c_tot as u128);
     header.insurance = V16PodU128::new(insurance as u128);
     header.vault = V16PodU128::new(c_tot as u128 + insurance as u128 + surplus as u128);
-    let vault_before = header.vault;
-    let c_tot_before = header.c_tot;
-    let insurance_before = header.insurance;
-    let reason_before = header.recovery_reason;
-    let asset_before = markets[0].engine;
+    account_header.capital = V16PodU128::new(c_tot as u128);
 
-    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
-    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let account = PortfolioV16ViewMut::new(&mut account_header);
     let summary = market.build_actionable_summary(&account.as_view()).unwrap();
+    assert!(summary.is_actionable());
     assert!(summary.recovery_eligible);
-    let result = market
-        .permissionless_auto_crank_not_atomic(
-            &mut account,
-            AutoCrankWorkV16 {
-                now_slot: 8,
-                observations: &[],
-                resolved_close_fee_rate_per_slot: 0,
-            },
-        )
-        .unwrap();
+    assert!(!summary.stale);
+    assert!(!summary.b_stale);
+    assert!(!summary.pending_close);
+    assert!(!summary.expired_close);
+    assert!(!summary.liquidatable);
+    assert!(!summary.resolved_winner);
+    kani::cover!(
+        reason_code == 0 && !loss_stale && c_tot > 0 && insurance > 0 && surplus > 0,
+        "the first recovery reason remains actionable with nonzero value state"
+    );
+    kani::cover!(
+        reason_code == 7 && loss_stale && c_tot > 0 && insurance > 0 && surplus > 0,
+        "the last recovery reason remains actionable with stale loss and nonzero value state"
+    );
+}
 
-    assert_eq!(
-        result.selected,
-        AutoCrankPlanV16::DeclareRecovery {
-            reason: PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow
-        }
+#[kani::proof]
+#[kani::unwind(32)]
+#[kani::solver(cadical)]
+fn proof_v16_expired_close_is_always_recovery_actionable() {
+    let loss_stale: bool = kani::any();
+    let c_tot: u8 = kani::any();
+    let insurance: u8 = kani::any();
+    let surplus: u8 = kani::any();
+    let (mut header, mut markets, mut account_header) = one_market_view_fixture();
+    header.current_slot = V16PodU64::new(7);
+    header.loss_stale_active = u8::from(loss_stale);
+    header.c_tot = V16PodU128::new(c_tot as u128);
+    header.insurance = V16PodU128::new(insurance as u128);
+    header.vault = V16PodU128::new(c_tot as u128 + insurance as u128 + surplus as u128);
+    account_header.capital = V16PodU128::new(c_tot as u128);
+    account_header.close_progress =
+        CloseProgressLedgerV16Account::from_runtime(&CloseProgressLedgerV16 {
+            active: true,
+            close_id: 1,
+            market_id: markets[0].engine.asset.market_id.get(),
+            gross_loss_at_close_start: 1,
+            max_close_slot: 6,
+            residual_remaining: 1,
+            ..CloseProgressLedgerV16::EMPTY
+        });
+
+    let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let account = PortfolioV16ViewMut::new(&mut account_header);
+    let summary = market.build_actionable_summary(&account.as_view()).unwrap();
+    assert!(summary.is_actionable());
+    assert!(summary.expired_close);
+    assert!(!summary.recovery_eligible);
+    kani::cover!(
+        loss_stale && c_tot > 0 && insurance > 0 && surplus > 0,
+        "an expired close is recovery-actionable with stale loss and nonzero value state"
     );
-    assert_eq!(
-        result.outcome,
-        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::RecoveryDeclared(
-            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow
-        ))
-    );
-    assert_eq!(market.header.mode, 1);
-    assert_eq!(market.header.current_slot.get(), 8);
-    assert_eq!(market.header.resolved_slot.get(), 8);
-    assert_eq!(market.header.recovery_reason, reason_before);
-    assert_eq!(market.header.vault, vault_before);
-    assert_eq!(market.header.c_tot, c_tot_before);
-    assert_eq!(market.header.insurance, insurance_before);
-    assert_eq!(market.markets[0].engine, asset_before);
 }
 
 #[kani::proof]

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -3175,6 +3175,7 @@ fn proof_v16_recovery_mode_blocks_fee_sync_and_pnl_conversion_before_mutation() 
 #[kani::unwind(32)]
 #[kani::solver(cadical)]
 fn proof_v16_public_resolve_market_is_value_neutral_and_clears_loss_stale() {
+    let recovery: bool = kani::any();
     let current_slot_raw: u8 = kani::any();
     let stale_lag_raw: u8 = kani::any();
     let resolved_delta_raw: u8 = kani::any();
@@ -3191,6 +3192,12 @@ fn proof_v16_public_resolve_market_is_value_neutral_and_clears_loss_stale() {
     let slot_last = current_slot - stale_lag_raw as u64;
     let resolved_slot = current_slot + resolved_delta_raw as u64;
     let (mut header, mut markets, _) = one_market_view_fixture();
+    if recovery {
+        header.mode = 2;
+        header.recovery_reason = V16OptionalRecoveryReasonAccount::from_runtime(Some(
+            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+        ));
+    }
     header.vault = V16PodU128::new(c_tot + insurance + surplus);
     header.c_tot = V16PodU128::new(c_tot);
     header.insurance = V16PodU128::new(insurance);
@@ -3201,6 +3208,7 @@ fn proof_v16_public_resolve_market_is_value_neutral_and_clears_loss_stale() {
     let c_tot_before = header.c_tot;
     let insurance_before = header.insurance;
     let slot_last_before = header.slot_last;
+    let recovery_reason_before = header.recovery_reason;
     let asset_before = markets[0].engine.asset;
     let long_budget_before = markets[0].engine.insurance_domain_budget_long;
     let short_budget_before = markets[0].engine.insurance_domain_budget_short;
@@ -3221,11 +3229,16 @@ fn proof_v16_public_resolve_market_is_value_neutral_and_clears_loss_stale() {
             && surplus > 255,
         "resolved market transition covers future authenticated slot over wide symbolic value state"
     );
+    kani::cover!(
+        recovery && resolved_delta_raw > 0,
+        "terminal Recovery mode has a successful authenticated resolution escape"
+    );
     assert_eq!(market.header.mode, 1);
     assert_eq!(market.header.resolved_slot.get(), resolved_slot);
     assert_eq!(market.header.current_slot.get(), resolved_slot);
     assert_eq!(market.header.slot_last, slot_last_before);
     assert_eq!(market.header.loss_stale_active, 0);
+    assert_eq!(market.header.recovery_reason, recovery_reason_before);
     assert_eq!(market.header.vault, vault_before);
     assert_eq!(market.header.c_tot, c_tot_before);
     assert_eq!(market.header.insurance, insurance_before);

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -18,11 +18,12 @@ use percolator::v16::{
     kani_prepare_asset_recovery_transition, kani_source_credit_state_realizable_support_for_face,
     kani_target_effective_lag_adverse_delta, kani_trade_preexisting_oi_reduction_gate,
     kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution,
-    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, BackingBucketStatusV16,
-    BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16, CloseProgressLedgerV16,
-    CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16,
-    HealthCertV16Account, InsuranceCreditReservationV16, InsuranceCreditReservationV16Account,
-    Market, MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
+    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, AutoCrankOutcomeV16, AutoCrankPlanV16,
+    AutoCrankWorkV16, BackingBucketStatusV16, BackingBucketV16, BackingBucketV16Account,
+    BatchTradeOutcomeV16, CloseProgressLedgerV16, CloseProgressLedgerV16Account,
+    EngineAssetSlotV16Account, HLockLaneV16, HealthCertV16, HealthCertV16Account,
+    InsuranceCreditReservationV16, InsuranceCreditReservationV16Account, Market,
+    MarketGroupV16HeaderAccount, MarketGroupV16ViewMut, PermissionlessCrankActionV16,
     PermissionlessCrankRequestV16, PermissionlessProgressOutcomeV16,
     PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
     PortfolioLegV16Account, PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut,
@@ -4784,6 +4785,65 @@ fn proof_v16_trade_fee_helper_moves_capital_to_insurance_only() {
     // Junior-pool isolation: this transition must not move the junior
     // residual pool (haircut/payout funding).
     assert_eq!(market.kani_residual(), residual_before);
+}
+
+#[kani::proof]
+#[kani::unwind(32)]
+#[kani::solver(cadical)]
+fn proof_v16_committed_recovery_auto_crank_resolves_value_neutrally() {
+    let c_tot: u16 = kani::any();
+    let insurance: u16 = kani::any();
+    let surplus: u16 = kani::any();
+    let (mut header, mut markets, mut account_header) = one_market_view_fixture();
+    header.mode = 2;
+    header.current_slot = V16PodU64::new(7);
+    header.recovery_reason = V16OptionalRecoveryReasonAccount::from_runtime(Some(
+        PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+    ));
+    header.c_tot = V16PodU128::new(c_tot as u128);
+    header.insurance = V16PodU128::new(insurance as u128);
+    header.vault = V16PodU128::new(c_tot as u128 + insurance as u128 + surplus as u128);
+    let vault_before = header.vault;
+    let c_tot_before = header.c_tot;
+    let insurance_before = header.insurance;
+    let reason_before = header.recovery_reason;
+    let asset_before = markets[0].engine;
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let summary = market.build_actionable_summary(&account.as_view()).unwrap();
+    assert!(summary.recovery_eligible);
+    let result = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 8,
+                observations: &[],
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .unwrap();
+
+    assert_eq!(
+        result.selected,
+        AutoCrankPlanV16::DeclareRecovery {
+            reason: PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow
+        }
+    );
+    assert_eq!(
+        result.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::RecoveryDeclared(
+            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow
+        ))
+    );
+    assert_eq!(market.header.mode, 1);
+    assert_eq!(market.header.current_slot.get(), 8);
+    assert_eq!(market.header.resolved_slot.get(), 8);
+    assert_eq!(market.header.recovery_reason, reason_before);
+    assert_eq!(market.header.vault, vault_before);
+    assert_eq!(market.header.c_tot, c_tot_before);
+    assert_eq!(market.header.insurance, insurance_before);
+    assert_eq!(market.markets[0].engine, asset_before);
 }
 
 #[kani::proof]

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -13,7 +13,8 @@ use percolator::{
     ProvenanceHeaderV16, ProvenanceHeaderV16Account, ResolvedPayoutLedgerV16,
     ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16, ResolvedPayoutReceiptV16Account,
     SideModeV16, SideV16, SourceCreditStateV16, SourceCreditStateV16Account, TradeRequestV16,
-    V16Config, V16Error, V16PodI128, V16PodU128, V16PodU32, V16PodU64, V16_EMPTY_ACTIVE_BITMAP,
+    V16Config, V16Error, V16OptionalRecoveryReasonAccount, V16PodI128, V16PodU128, V16PodU32,
+    V16PodU64, V16_EMPTY_ACTIVE_BITMAP,
 };
 use percolator::{ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, POS_SCALE};
 
@@ -3234,9 +3235,10 @@ fn v16_auto_crank_liquidates_current_account_without_observation() {
 // Live account whose outstanding bankruptcy close ledger has EXPIRED (current
 // slot past max_close_slot) is classified expired_close, and the auto-crank
 // dispatches the terminal recovery declaration (ActiveBankruptCloseCannotProgress)
-// — the close-cannot-progress recovery, no caller-chosen action, no value move.
+// and resolves in the same public call. Recovery is an audit reason, not a
+// committed sink with no account exit.
 #[test]
-fn v16_auto_crank_declares_recovery_for_expired_live_close() {
+fn v16_auto_crank_terminally_resolves_expired_live_close() {
     use percolator::{CloseProgressLedgerV16, CloseProgressLedgerV16Account};
 
     let (mut header, mut markets) = market_fixture(1, 100);
@@ -3299,8 +3301,49 @@ fn v16_auto_crank_declares_recovery_for_expired_live_close() {
             PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
         ))
     );
-    // recovery declaration moves no value.
+    assert_eq!(market.header.mode, 1, "terminal recovery must be Resolved");
+    assert_eq!(market.header.resolved_slot.get(), 10);
+    assert_eq!(market.header.current_slot.get(), 10);
+    assert_eq!(
+        market.header.recovery_reason.try_to_runtime().unwrap(),
+        Some(PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress),
+        "the resolved market retains the terminal recovery reason for audit"
+    );
+    // Terminal recovery and resolution move no value.
     assert_eq!(market.header.vault, vault_before);
+    market.validate_shape().unwrap();
+}
+
+#[test]
+fn v16_committed_recovery_has_value_neutral_resolution_escape() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    header.mode = 2;
+    header.current_slot = V16PodU64::new(7);
+    header.recovery_reason = V16OptionalRecoveryReasonAccount::from_runtime(Some(
+        PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+    ));
+    header.vault = V16PodU128::new(17);
+    header.c_tot = V16PodU128::new(11);
+    header.insurance = V16PodU128::new(3);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let vault_before = market.header.vault;
+    let c_tot_before = market.header.c_tot;
+    let insurance_before = market.header.insurance;
+    market
+        .resolve_market_not_atomic(8)
+        .expect("Recovery must retain a terminal resolution escape");
+
+    assert_eq!(market.header.mode, 1);
+    assert_eq!(market.header.resolved_slot.get(), 8);
+    assert_eq!(market.header.current_slot.get(), 8);
+    assert_eq!(
+        market.header.recovery_reason.try_to_runtime().unwrap(),
+        Some(PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow)
+    );
+    assert_eq!(market.header.vault, vault_before);
+    assert_eq!(market.header.c_tot, c_tot_before);
+    assert_eq!(market.header.insurance, insurance_before);
     market.validate_shape().unwrap();
 }
 

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3315,8 +3315,9 @@ fn v16_auto_crank_terminally_resolves_expired_live_close() {
 }
 
 #[test]
-fn v16_committed_recovery_has_value_neutral_resolution_escape() {
+fn v16_auto_crank_resolves_committed_recovery_value_neutrally() {
     let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 43);
     header.mode = 2;
     header.current_slot = V16PodU64::new(7);
     header.recovery_reason = V16OptionalRecoveryReasonAccount::from_runtime(Some(
@@ -3327,13 +3328,38 @@ fn v16_committed_recovery_has_value_neutral_resolution_escape() {
     header.insurance = V16PodU128::new(3);
 
     let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let summary = market.build_actionable_summary(&account.as_view()).unwrap();
+    assert!(
+        summary.recovery_eligible,
+        "a committed Recovery mode must remain actionable through the sole public auto-crank"
+    );
     let vault_before = market.header.vault;
     let c_tot_before = market.header.c_tot;
     let insurance_before = market.header.insurance;
-    market
-        .resolve_market_not_atomic(8)
-        .expect("Recovery must retain a terminal resolution escape");
+    let result = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 8,
+                observations: &[],
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the sole public auto-crank must resolve committed Recovery");
 
+    assert_eq!(
+        result.selected,
+        AutoCrankPlanV16::DeclareRecovery {
+            reason: PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow
+        }
+    );
+    assert_eq!(
+        result.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::RecoveryDeclared(
+            PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow
+        ))
+    );
     assert_eq!(market.header.mode, 1);
     assert_eq!(market.header.resolved_slot.get(), 8);
     assert_eq!(market.header.current_slot.get(), 8);


### PR DESCRIPTION
## Impact

A normally initialized market can enter a permanent global `Recovery` sink after a legitimate asset shutdown. A portfolio owner can publicly start a chunked `ForfeitRecoveryLeg`, leave a nonzero residual until its close deadline expires, and let an unsigned `PermissionlessCrank` commit `Recovery`. Unrelated flat users then lose every bounded principal-exit path.

The primary LiteSVM reproduction uses only public wrapper instructions and normal accounts. It does not mutate protocol state. It is RED against wrapper `36fa587e` with engine `143e68c4917ed0400a27b952f036a5677047cd84`: the expiry crank leaves mode `Recovery`, and the unrelated user's funds are globally locked.

## Root cause

`AutoCrankPlanV16::DeclareRecovery` committed `MarketModeV16::Recovery`, while `resolve_market_not_atomic` rejected that same mode. The actionable-summary builder also classified a persisted `Recovery` state as having no continuation, so upgrading the program could not rescue an already committed state through the sole public auto-crank.

## Fix

- Complete `DeclareRecovery -> Resolved` in the same auto-crank call.
- Permit the value-neutral engine resolution transition from `Recovery` while retaining its audit reason.
- Classify a persisted `Recovery` state as `recovery_eligible`, preserving the recorded reason and routing it through the same auto-crank.
- Add runtime and Kani coverage for fresh expiry and pre-upgrade persisted states.

## Verification

- `cargo test --all-targets -- --test-threads=1`: 130/130 passed.
- `proof_v16_public_resolve_market_is_value_neutral_and_clears_loss_stale`: 4,543 checks passed, 3/3 covers.
- `proof_v16_committed_recovery_auto_crank_resolves_value_neutrally`: 14,839 checks passed over symbolic capital, insurance, and surplus.
- Associated wrapper branch: SBF build passed; 567/567 LiteSVM/CU tests plus wrapper unit tests passed.
- Exact parent/head public TDD: parent commits global `Recovery`; fixed head reaches `Resolved` and pays an unrelated flat owner's 100 real SPL tokens through `CloseResolved`.

## Known dependency

This PR restores the global transition and the unrelated flat-user exit. Full wind-down of the loss-side cohort under a small valid B budget additionally depends on #155: without that independent unit fix, `public_b_chunk_atoms` is incorrectly reused as a B-index delta cap and terminal settlement can require billions of calls. This PR intentionally does not duplicate #155.