### PR TITLE
[BLOCKER DoS] Keep winner-first Recovery forfeits live

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -15713,6 +15713,76 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         ))
     }
 
+    fn forfeit_materialized_positive_pnl_for_leg(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        asset_index: usize,
+        leg_side: SideV16,
+    ) -> V16Result<u128> {
+        let source_domain = self.insurance_domain_index(asset_index, opposite_side(leg_side))?;
+        let Some(mut source_slot) = account.source_domain_slot(source_domain)? else {
+            return Ok(0);
+        };
+        let source_claim_bound_num = account.header.source_domains[source_slot]
+            .source_claim_bound_num
+            .get();
+        if source_claim_bound_num == 0 {
+            return Ok(0);
+        }
+        V16Core::validate_bound_num_atom_aligned(source_claim_bound_num)?;
+
+        // A dead-leg forfeit values this leg's positive PnL at zero. Release any
+        // valid source-credit lien first so forfeiting the face returns backing
+        // instead of consuming it. Impaired claim fields are burned by the
+        // canonical source-claim burn below.
+        if account.header.source_domains[source_slot]
+            .source_claim_liened_num
+            .get()
+            != 0
+        {
+            self.release_account_source_credit_lien_for_domain_not_atomic(account, source_domain)?;
+            source_slot = account
+                .source_domain_slot(source_domain)?
+                .ok_or(V16Error::InvalidLeg)?;
+        }
+
+        // The canonical PnL setter burns source claims in sparse-slot order.
+        // Put this leg's source first so unrelated asset claims are untouched.
+        if source_slot != 0 {
+            account.header.source_domains.swap(0, source_slot);
+        }
+        let source_claim_face = V16Core::amount_from_bound_num(source_claim_bound_num)?;
+        let positive_pnl = account.header.pnl.get().max(0) as u128;
+        let positive_pnl_forfeited = source_claim_face.min(positive_pnl);
+        if positive_pnl_forfeited != 0 {
+            let decrease =
+                i128::try_from(positive_pnl_forfeited).map_err(|_| V16Error::ArithmeticOverflow)?;
+            let next_pnl = account
+                .header
+                .pnl
+                .get()
+                .checked_sub(decrease)
+                .ok_or(V16Error::ArithmeticOverflow)?;
+            self.set_account_pnl(account, next_pnl)?;
+        }
+
+        // Source bounds are normally exact atom multiples of positive PnL. Burn
+        // any conservative excess as attribution-only state after the PnL debit.
+        if let Some(remaining_slot) = account.source_domain_slot(source_domain)? {
+            let remaining = account.header.source_domains[remaining_slot]
+                .source_claim_bound_num
+                .get();
+            if remaining != 0 {
+                if remaining_slot != 0 {
+                    account.header.source_domains.swap(0, remaining_slot);
+                }
+                self.burn_account_source_claim_bound_num(account, remaining)?;
+            }
+        }
+        account.compact_source_domains();
+        Ok(positive_pnl_forfeited)
+    }
+
     pub fn forfeit_recovery_leg_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
@@ -15734,6 +15804,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Err(V16Error::LockActive);
         }
 
+        let materialized_positive_pnl_forfeited =
+            self.forfeit_materialized_positive_pnl_for_leg(account, asset_index, leg.side)?;
         let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;
         let b_target = self.b_target_for_leg(asset_index, leg)?;
         if account.header.pnl.get() == 0
@@ -15749,7 +15821,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             self.clear_leg(account, asset_index)?;
             return Ok(DeadLegForfeitOutcomeV16 {
                 detached: true,
-                positive_pnl_forfeited: 0,
+                positive_pnl_forfeited: materialized_positive_pnl_forfeited,
                 loss_settled: 0,
                 support_consumed: 0,
                 junior_face_burned: 0,
@@ -15760,8 +15832,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             });
         }
 
-        let (loss_settled, positive_pnl_forfeited, support_consumed, junior_face_burned) =
+        let (loss_settled, positive_pnl_delta_forfeited, support_consumed, junior_face_burned) =
             self.settle_forfeited_leg_kf_effects(account, asset_index)?;
+        let positive_pnl_forfeited = materialized_positive_pnl_forfeited
+            .checked_add(positive_pnl_delta_forfeited)
+            .ok_or(V16Error::ArithmeticOverflow)?;
 
         let mut total_loss_settled = loss_settled;
         let refreshed = Self::active_leg_for_asset(&account.as_view(), asset_index)?;

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1808,8 +1808,9 @@ impl V16Core {
     /// (Some when a chunk was booked, None when it could not be — no loss-side
     /// weight, no B-headroom, or no positive delta), decide the step's terminal
     /// outcome. A booked chunk's outcome is carried through; an unbookable residual
-    /// is recorded ENTIRELY as explicit loss in a resolved market, else it signals
-    /// DeclareRecovery. PROVES residual conservation for EVERY Outcome path
+    /// is recorded ENTIRELY as explicit loss only when the caller has proved that
+    /// terminal assignment is safe, else it signals DeclareRecovery. PROVES residual
+    /// conservation for EVERY Outcome path
     /// (booked_loss+explicit_loss+remaining_after == residual_remaining), composing
     /// the leaf booking contract into the step decision — no value is created or
     /// lost regardless of which branch is taken. Pure.
@@ -1833,12 +1834,12 @@ impl V16Core {
     pub(crate) fn kernel_bresidual_step(
         residual_remaining: u128,
         booked: Option<BResidualBookingOutcomeV16>,
-        resolved: bool,
+        terminal_explicit_loss_allowed: bool,
     ) -> BResidualStepV16 {
         match booked {
             Some(o) => BResidualStepV16::Outcome(o),
             None => {
-                if resolved {
+                if terminal_explicit_loss_allowed {
                     BResidualStepV16::Outcome(BResidualBookingOutcomeV16 {
                         booked_loss: 0,
                         explicit_loss: residual_remaining,
@@ -1850,6 +1851,41 @@ impl V16Core {
                 }
             }
         }
+    }
+
+    /// An unbookable residual may be assigned as explicit loss in a resolved
+    /// market, or in an asset-local Recovery domain after every potential
+    /// claimant/provider obligation and social-loss recipient has disappeared.
+    /// Fresh unused backing and insurance reservations are not obligations and
+    /// intentionally do not block this terminal path.
+    #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|allowed: &bool| {
+        *allowed == (market_resolved
+            || (asset_lifecycle == AssetLifecycleV16::Recovery
+                && loss_weight_sum == 0
+                && source.positive_claim_bound_num == 0
+                && source.exact_positive_claim_num == 0
+                && source.provider_receivable_num == 0
+                && source.valid_liened_backing_num == 0
+                && source.impaired_liened_backing_num == 0
+                && source.valid_liened_insurance_num == 0
+                && source.impaired_liened_insurance_num == 0))
+    }))]
+    pub(crate) fn kernel_terminal_explicit_loss_allowed(
+        market_resolved: bool,
+        asset_lifecycle: AssetLifecycleV16,
+        loss_weight_sum: u128,
+        source: SourceCreditStateV16,
+    ) -> bool {
+        market_resolved
+            || (asset_lifecycle == AssetLifecycleV16::Recovery
+                && loss_weight_sum == 0
+                && source.positive_claim_bound_num == 0
+                && source.exact_positive_claim_num == 0
+                && source.provider_receivable_num == 0
+                && source.valid_liened_backing_num == 0
+                && source.impaired_liened_backing_num == 0
+                && source.valid_liened_insurance_num == 0
+                && source.impaired_liened_insurance_num == 0)
     }
 
     /// PRODUCTION KERNEL (roadmap workstream B.2, resolved-bankruptcy PnL
@@ -13258,6 +13294,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             SideV16::Short => asset.loss_weight_sum_short,
         };
         let resolved = decode_market_mode(self.header.mode)? == MarketModeV16::Resolved;
+        let loss_domain = self.insurance_domain_index(asset_index, bankrupt_side)?;
+        let loss_source = self.source_credit_for_domain(loss_domain)?;
+        let terminal_explicit_loss_allowed = V16Core::kernel_terminal_explicit_loss_allowed(
+            resolved,
+            asset.lifecycle,
+            weight_sum,
+            loss_source,
+        );
         // Determine whether a chunk can be booked (and the recovery reason if not).
         // weight_sum==0 -> no loss-side to absorb (ActiveBankruptClose); engine
         // chunk 0 / apply None -> no B-headroom (BIndexHeadroomExhausted). The
@@ -13302,7 +13346,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
         };
         // PRODUCTION KERNEL: the conservation-proven step decision.
-        match V16Core::kernel_bresidual_step(residual_remaining, booked, resolved) {
+        match V16Core::kernel_bresidual_step(
+            residual_remaining,
+            booked,
+            terminal_explicit_loss_allowed,
+        ) {
             BResidualStepV16::Outcome(outcome) => {
                 if let Some(asset_mut) = new_asset {
                     self.set_asset_state(asset_index, asset_mut)?;

--- a/src/v16_proofs.rs
+++ b/src/v16_proofs.rs
@@ -2566,8 +2566,8 @@ fn contract_check_bresidual_chunk_conservation() {
 // ROADMAP workstream B.2 (bankruptcy-residual conservation composition): the step
 // decision kernel preserves residual conservation on every Outcome path — a
 // booked chunk (conservation assumed from the proven leaf contract) is carried
-// through, an unbookable residual in a resolved market becomes pure explicit
-// loss, and the non-resolved case signals recovery. No value created or lost.
+// through, an unbookable residual on a caller-proved terminal path becomes pure
+// explicit loss, and every other case signals recovery. No value created or lost.
 #[cfg(all(kani, feature = "contracts"))]
 #[kani::proof_for_contract(V16Core::kernel_bresidual_step)]
 #[kani::solver(cadical)]
@@ -2583,8 +2583,25 @@ fn contract_check_kernel_bresidual_step() {
     } else {
         None
     };
-    let resolved: bool = kani::any();
-    let _ = V16Core::kernel_bresidual_step(residual_remaining, booked, resolved);
+    let terminal_explicit_loss_allowed: bool = kani::any();
+    let _ =
+        V16Core::kernel_bresidual_step(residual_remaining, booked, terminal_explicit_loss_allowed);
+}
+
+#[cfg(all(kani, feature = "contracts"))]
+#[kani::proof_for_contract(V16Core::kernel_terminal_explicit_loss_allowed)]
+#[kani::solver(cadical)]
+fn contract_check_kernel_terminal_explicit_loss_allowed() {
+    let market_resolved: bool = kani::any();
+    let asset_lifecycle: AssetLifecycleV16 = kani::any();
+    let loss_weight_sum: u128 = kani::any();
+    let source: SourceCreditStateV16 = kani::any();
+    let _ = V16Core::kernel_terminal_explicit_loss_allowed(
+        market_resolved,
+        asset_lifecycle,
+        loss_weight_sum,
+        source,
+    );
 }
 
 // ROADMAP workstream B.2 (cross-layer conservation): book_bankruptcy_residual_

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -422,14 +422,22 @@ fn v16_funding_counters_record_forfeited_dead_leg_settlement() {
     );
 }
 
-fn bankrupt_recovery_pair_fixture() -> (
+fn bankrupt_recovery_pair_fixture_at(
+    market_slots: u32,
+    asset_index: usize,
+) -> (
     MarketGroupV16HeaderAccount,
     Vec<Market<u64>>,
     PortfolioAccountV16Account,
     PortfolioAccountV16Account,
 ) {
     let (market_id, _, _) = ids();
-    let mut cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 6_480_000);
+    let mut cfg = V16Config::public_user_fund_with_market_slots(
+        market_slots as u16,
+        market_slots,
+        0,
+        6_480_000,
+    );
     cfg.min_nonzero_mm_req = 599;
     cfg.min_nonzero_im_req = 600;
     cfg.maintenance_margin_bps = 500;
@@ -440,13 +448,36 @@ fn bankrupt_recovery_pair_fixture() -> (
     cfg.max_accrual_dt_slots = 20;
     cfg.max_abs_funding_e9_per_slot = 1_000;
     cfg.min_funding_lifetime_slots = 10_000_000;
-    let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_id, cfg, 1, 0).unwrap();
-    let mut markets = vec![Market::new(0, EngineAssetSlotV16Account::default())];
+    let mut header =
+        MarketGroupV16HeaderAccount::new_dynamic(market_id, cfg, market_slots, 0).unwrap();
+    let mut markets = (0..market_slots)
+        .map(|i| Market::new(i as u64, EngineAssetSlotV16Account::default()))
+        .collect::<Vec<_>>();
     header
-        .activate_empty_asset_slot_not_atomic(0, &mut markets[0].engine, FUNDING_COUNTER_PRICE, 0)
+        .activate_empty_asset_slot_not_atomic(
+            asset_index as u32,
+            &mut markets[asset_index].engine,
+            FUNDING_COUNTER_PRICE,
+            0,
+        )
         .unwrap();
-    let mut long_header = account_fixture(1, 132);
-    let mut short_header = account_fixture(1, 133);
+    let mut activation_slot = 1u64;
+    for (i, market) in markets.iter_mut().enumerate() {
+        if i == asset_index {
+            continue;
+        }
+        header
+            .activate_empty_asset_slot_not_atomic(
+                i as u32,
+                &mut market.engine,
+                FUNDING_COUNTER_PRICE,
+                activation_slot,
+            )
+            .unwrap();
+        activation_slot += 1;
+    }
+    let mut long_header = account_fixture(market_slots, 132);
+    let mut short_header = account_fixture(market_slots, 133);
     {
         let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
         let mut long = PortfolioV16ViewMut::new(&mut long_header);
@@ -458,7 +489,7 @@ fn bankrupt_recovery_pair_fixture() -> (
                 &mut long,
                 &mut short,
                 TradeRequestV16 {
-                    asset_index: 0,
+                    asset_index,
                     size_q: signed_q(POS_SCALE),
                     exec_price: FUNDING_COUNTER_PRICE,
                     fee_bps: 0,
@@ -466,14 +497,25 @@ fn bankrupt_recovery_pair_fixture() -> (
             )
             .unwrap();
         market
-            .accrue_asset_to_not_atomic(0, 20, 952_000, 0, true)
+            .accrue_asset_to_not_atomic(asset_index, 20, 952_000, 0, true)
             .unwrap();
         market
-            .accrue_asset_to_not_atomic(0, 25, 940_576, 0, true)
+            .accrue_asset_to_not_atomic(asset_index, 25, 940_576, 0, true)
             .unwrap();
-        market.force_asset_recovery_not_atomic(0, 25).unwrap();
+        market
+            .force_asset_recovery_not_atomic(asset_index, 25)
+            .unwrap();
     }
     (header, markets, long_header, short_header)
+}
+
+fn bankrupt_recovery_pair_fixture() -> (
+    MarketGroupV16HeaderAccount,
+    Vec<Market<u64>>,
+    PortfolioAccountV16Account,
+    PortfolioAccountV16Account,
+) {
+    bankrupt_recovery_pair_fixture_at(1, 0)
 }
 
 #[test]
@@ -520,7 +562,7 @@ fn v16_claim_free_recovery_domain_survives_winner_first_forfeit() {
 }
 
 #[test]
-fn v16_recovery_residual_preserves_materialized_winner_claim() {
+fn v16_recovery_forfeit_waives_materialized_winner_claim_before_detach() {
     let (mut header, mut markets, mut long_header, mut short_header) =
         bankrupt_recovery_pair_fixture();
     {
@@ -534,22 +576,98 @@ fn v16_recovery_residual_preserves_materialized_winner_claim() {
             .forfeit_recovery_leg_not_atomic(&mut short, 0, u128::MAX)
             .unwrap();
         assert!(winner.detached);
-        assert_eq!(winner.positive_pnl_forfeited, 0);
-        assert!(
+        assert!(winner.positive_pnl_forfeited > 0);
+        assert_eq!(short.header.pnl.get(), 0);
+        assert_eq!(
             market.markets[0]
                 .engine
                 .source_credit_long
                 .try_to_runtime()
                 .unwrap()
-                .positive_claim_bound_num
-                > 0
+                .positive_claim_bound_num,
+            0,
+            "owner-signed dead-leg forfeit must waive the selected leg's materialized claim"
         );
 
+        let loser = market
+            .forfeit_recovery_leg_not_atomic(&mut long, 0, u128::MAX)
+            .expect("winner-first materialization must not strand the bankrupt counterparty");
+        assert!(loser.detached);
+        assert!(loser.explicit_loss > 0);
+        assert_eq!(long.header.pnl.get(), 0);
+        assert_eq!(long.header.capital.get(), 0);
+        market.validate_shape().unwrap();
+        long.validate_with_market(&market.as_view()).unwrap();
+        short.validate_with_market(&market.as_view()).unwrap();
+    }
+}
+
+#[test]
+fn v16_recovery_forfeit_preserves_unrelated_source_domain_claim() {
+    const RECOVERY_ASSET: usize = 1;
+    const UNRELATED_FACE: u128 = 777;
+    let (mut header, mut markets, mut long_header, mut short_header) =
+        bankrupt_recovery_pair_fixture_at(2, RECOVERY_ASSET);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+
+        market
+            .add_account_source_positive_pnl_not_atomic(&mut short, 0, UNRELATED_FACE)
+            .unwrap();
+        market.full_account_refresh_not_atomic(&mut short).unwrap();
+        let selected_claim_before = market.markets[RECOVERY_ASSET]
+            .engine
+            .source_credit_long
+            .try_to_runtime()
+            .unwrap()
+            .positive_claim_bound_num;
+        assert!(selected_claim_before > 0);
         assert_eq!(
-            market.forfeit_recovery_leg_not_atomic(&mut long, 0, u128::MAX),
-            Err(V16Error::RecoveryRequired),
-            "a real winner claim still requires global loss resolution"
+            short.header.pnl.get(),
+            i128::try_from(UNRELATED_FACE + selected_claim_before / BOUND_SCALE).unwrap()
         );
+
+        let winner = market
+            .forfeit_recovery_leg_not_atomic(&mut short, RECOVERY_ASSET, u128::MAX)
+            .unwrap();
+        assert!(winner.detached);
+        assert_eq!(
+            winner.positive_pnl_forfeited,
+            selected_claim_before / BOUND_SCALE
+        );
+        assert_eq!(
+            short.header.pnl.get(),
+            i128::try_from(UNRELATED_FACE).unwrap()
+        );
+        assert_eq!(
+            market.markets[RECOVERY_ASSET]
+                .engine
+                .source_credit_long
+                .try_to_runtime()
+                .unwrap()
+                .positive_claim_bound_num,
+            0
+        );
+        assert_eq!(
+            market.markets[0]
+                .engine
+                .source_credit_long
+                .try_to_runtime()
+                .unwrap()
+                .positive_claim_bound_num,
+            UNRELATED_FACE * BOUND_SCALE,
+            "selected-leg forfeit must not burn another asset's source claim"
+        );
+
+        let loser = market
+            .forfeit_recovery_leg_not_atomic(&mut long, RECOVERY_ASSET, u128::MAX)
+            .unwrap();
+        assert!(loser.detached);
+        market.validate_shape().unwrap();
+        long.validate_with_market(&market.as_view()).unwrap();
+        short.validate_with_market(&market.as_view()).unwrap();
     }
 }
 

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -422,6 +422,137 @@ fn v16_funding_counters_record_forfeited_dead_leg_settlement() {
     );
 }
 
+fn bankrupt_recovery_pair_fixture() -> (
+    MarketGroupV16HeaderAccount,
+    Vec<Market<u64>>,
+    PortfolioAccountV16Account,
+    PortfolioAccountV16Account,
+) {
+    let (market_id, _, _) = ids();
+    let mut cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 6_480_000);
+    cfg.min_nonzero_mm_req = 599;
+    cfg.min_nonzero_im_req = 600;
+    cfg.maintenance_margin_bps = 500;
+    cfg.initial_margin_bps = 500;
+    cfg.liquidation_fee_bps = 5;
+    cfg.liquidation_fee_cap = percolator::MAX_PROTOCOL_FEE_ABS;
+    cfg.max_price_move_bps_per_slot = 24;
+    cfg.max_accrual_dt_slots = 20;
+    cfg.max_abs_funding_e9_per_slot = 1_000;
+    cfg.min_funding_lifetime_slots = 10_000_000;
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic(market_id, cfg, 1, 0).unwrap();
+    let mut markets = vec![Market::new(0, EngineAssetSlotV16Account::default())];
+    header
+        .activate_empty_asset_slot_not_atomic(0, &mut markets[0].engine, FUNDING_COUNTER_PRICE, 0)
+        .unwrap();
+    let mut long_header = account_fixture(1, 132);
+    let mut short_header = account_fixture(1, 133);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market.deposit_not_atomic(&mut long, 51_000).unwrap();
+        market.deposit_not_atomic(&mut short, 100_000).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: signed_q(POS_SCALE),
+                    exec_price: FUNDING_COUNTER_PRICE,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(0, 20, 952_000, 0, true)
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(0, 25, 940_576, 0, true)
+            .unwrap();
+        market.force_asset_recovery_not_atomic(0, 25).unwrap();
+    }
+    (header, markets, long_header, short_header)
+}
+
+#[test]
+fn v16_claim_free_recovery_domain_survives_winner_first_forfeit() {
+    let (mut header, mut markets, mut long_header, mut short_header) =
+        bankrupt_recovery_pair_fixture();
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        let winner = market
+            .forfeit_recovery_leg_not_atomic(&mut short, 0, u128::MAX)
+            .unwrap();
+        assert!(winner.detached);
+        assert!(winner.positive_pnl_forfeited > 0);
+        assert_eq!(short.header.pnl.get(), 0);
+
+        let asset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+        assert_eq!(asset.loss_weight_sum_short, 0);
+        assert_eq!(asset.oi_eff_short_q, 0);
+        assert_eq!(
+            market.markets[0]
+                .engine
+                .source_credit_long
+                .try_to_runtime()
+                .unwrap()
+                .positive_claim_bound_num,
+            0
+        );
+
+        let loser = market
+            .forfeit_recovery_leg_not_atomic(&mut long, 0, u128::MAX)
+            .expect("claim-free shutdown loss must not require global Recovery");
+        assert!(loser.detached);
+        assert!(loser.explicit_loss > 0);
+        assert_eq!(long.header.pnl.get(), 0);
+        assert_eq!(long.header.capital.get(), 0);
+        assert!(!long.header.legs[0].try_to_runtime().unwrap().active);
+        assert!(!short.header.legs[0].try_to_runtime().unwrap().active);
+        market.validate_shape().unwrap();
+        long.validate_with_market(&market.as_view()).unwrap();
+        short.validate_with_market(&market.as_view()).unwrap();
+    }
+}
+
+#[test]
+fn v16_recovery_residual_preserves_materialized_winner_claim() {
+    let (mut header, mut markets, mut long_header, mut short_header) =
+        bankrupt_recovery_pair_fixture();
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+
+        market.full_account_refresh_not_atomic(&mut short).unwrap();
+        assert!(short.header.pnl.get() > 0);
+        let winner = market
+            .forfeit_recovery_leg_not_atomic(&mut short, 0, u128::MAX)
+            .unwrap();
+        assert!(winner.detached);
+        assert_eq!(winner.positive_pnl_forfeited, 0);
+        assert!(
+            market.markets[0]
+                .engine
+                .source_credit_long
+                .try_to_runtime()
+                .unwrap()
+                .positive_claim_bound_num
+                > 0
+        );
+
+        assert_eq!(
+            market.forfeit_recovery_leg_not_atomic(&mut long, 0, u128::MAX),
+            Err(V16Error::RecoveryRequired),
+            "a real winner claim still requires global loss resolution"
+        );
+    }
+}
+
 #[test]
 fn v16_funding_counters_ignore_inactive_accounts_when_market_funding_moves() {
     let (mut header, mut markets) = funding_market_fixture(FUNDING_COUNTER_PRICE);


### PR DESCRIPTION
## Impact

After a normal secondary-asset shutdown, the winning owner can publicly forfeit first. The bankrupt owner's subsequent `ForfeitRecoveryLeg` used to return `RecoveryRequired`; wrapper/SVM rollback erased both its declaration and close-ledger progress. Retry, unilateral reduction, pair force-close, and auto crank had no successful continuation, while an honestly refreshed base oracle kept whole-market stale resolution unavailable. A real provider-backing lien created through public cross-margin risk also remained stranded.

The paired wrapper LiteSVM reproduction uses only ordinary deposits, provider backing, trades, bounded authenticated marks, shutdown, owner forfeits, and permissionless crank instructions. It does not inject protocol state.

## Root cause

The winner could detach after positive PnL and its source claim had already been materialized. The old forfeit path removed the selected leg and its social-loss weight but preserved that materialized claim and valid source lien. This contradicted the dead-leg rule in `spec.md`: an owner-forfeited leg's positive PnL must be valued at zero unless source backing is consumed. With no remaining recipient weight and a stale source claim, the bankrupt counterparty could not settle its residual.

## Fix

The selected-leg forfeit now:

- waives that leg's already materialized positive PnL and matching source claim;
- releases valid source liens back to backing instead of consuming provider principal;
- isolates the selected source slot before canonical claim/PnL burn, preserving unrelated source domains;
- permits explicit terminal loss only for a claim-free local Recovery domain with no provider receivable or backing/insurance lien.

The accounting remains conservative: any selected-domain attribution residue is also forfeited, and unrelated PnL, claims, backing, insurance, and liens remain unchanged.

## TDD

- `v16_claim_free_recovery_domain_survives_winner_first_forfeit`: the winner detaches and the loser then clears a claim-free terminal residual.
- `v16_recovery_forfeit_waives_materialized_winner_claim_before_detach`: refreshes/materializes the winner first, proves its selected claim is waived, and proves the loser remains live.
- `v16_recovery_forfeit_preserves_unrelated_source_domain_claim`: proves the selected-leg waiver cannot burn another asset's claim or PnL.
- Wrapper PR aeyakovenko/percolator-prog#371 supplies the end-to-end public LiteSVM red/green reproduction, including a provider-backing lien created by public cross-margin trading.

Against exact parent `143e68c4917ed0400a27b952f036a5677047cd84`, the wrapper loser forfeit fails with `Custom(23)` at 77,366 CU and 22.6k atoms of provider backing remain liened. With this commit, all three portfolios close and the provider withdraws the full 100k backing while the unrelated base market remains live.

## Verification

- `cargo test --all-targets -- --test-threads=1`: 132 passed
- `contract_check_kernel_terminal_explicit_loss_allowed`: 211 checks, 0 failures
- `contract_check_kernel_bresidual_step`: 147 checks, 0 failures
- Wrapper full suite: 566/566 LiteSVM tests pass
- `cargo fmt --all -- --check`
- `git diff --check`