### PR TITLE
[BLOCKER LoF] Preserve prior claims across Recovery forfeits

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -28,7 +28,8 @@ pub const V16_EMPTY_ACTIVE_BITMAP: V16ActiveBitmap = [0; V16_ACTIVE_BITMAP_WORDS
 pub const V16_BACKING_BUCKETS_PER_DOMAIN: usize = 1;
 // Bump whenever the on-chain account/header Pod layout changes (see the
 // PortfolioAccountV16Account size assertion). 17: added funding flow counters.
-pub const V16_LAYOUT_DISCRIMINATOR: u16 = 17;
+// 18: preserve pre-existing same-domain claims across a later leg episode.
+pub const V16_LAYOUT_DISCRIMINATOR: u16 = 18;
 pub const V16_ACCOUNT_VERSION: u16 = 1;
 pub const BACKING_FEE_RATE_DEN_E9: u128 = 1_000_000_000;
 pub const MAX_BACKING_FEE_RATE_E9_PER_SLOT: u64 = 1_000_000_000;
@@ -4223,8 +4224,24 @@ impl<'a> PortfolioV16View<'a> {
             } else {
                 slot.source_credit_short.try_to_runtime()?
             };
-            if source.source_claim_bound_num.get() > domain_credit.positive_claim_bound_num {
+            if source.source_claim_bound_num.get() > domain_credit.positive_claim_bound_num
+                || source.active_leg_claim_floor_num.get() > source.source_claim_bound_num.get()
+            {
                 return Err(V16Error::InvalidLeg);
+            }
+            if source.active_leg_claim_floor_num.get() != 0 {
+                let expected_leg_side = if d % 2 == 0 {
+                    SideV16::Short
+                } else {
+                    SideV16::Long
+                };
+                let leg_slot = self
+                    .active_leg_slot_for_asset(asset_index)?
+                    .ok_or(V16Error::InvalidLeg)?;
+                let leg = self.header.legs[leg_slot].try_to_runtime()?;
+                if leg.side != expected_leg_side {
+                    return Err(V16Error::InvalidLeg);
+                }
             }
             let proof = SourceCreditLienAggregateProofV16 {
                 domain: u16::try_from(d).map_err(|_| V16Error::ArithmeticOverflow)?,
@@ -8453,12 +8470,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             .checked_sub(impaired_burn)
             .ok_or(V16Error::CounterUnderflow)?;
         let source = &mut account.header.source_domains[slot];
-        source.source_claim_bound_num = V16PodU128::new(
+        let next_claim_bound = source
+            .source_claim_bound_num
+            .get()
+            .checked_sub(impaired_burn)
+            .ok_or(V16Error::CounterUnderflow)?;
+        source.source_claim_bound_num = V16PodU128::new(next_claim_bound);
+        source.active_leg_claim_floor_num = V16PodU128::new(
             source
-                .source_claim_bound_num
+                .active_leg_claim_floor_num
                 .get()
-                .checked_sub(impaired_burn)
-                .ok_or(V16Error::CounterUnderflow)?,
+                .min(next_claim_bound),
         );
         source.source_claim_impaired_num = V16PodU128::new(next_impaired);
         let impaired_effective_burn = if next_impaired == 0 {
@@ -8640,12 +8662,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             let burn = burnable.min(burn_num);
             if burn != 0 {
                 let source = &mut account.header.source_domains[slot];
-                source.source_claim_bound_num = V16PodU128::new(
+                let next_claim_bound = source
+                    .source_claim_bound_num
+                    .get()
+                    .checked_sub(burn)
+                    .ok_or(V16Error::CounterUnderflow)?;
+                source.source_claim_bound_num = V16PodU128::new(next_claim_bound);
+                source.active_leg_claim_floor_num = V16PodU128::new(
                     source
-                        .source_claim_bound_num
+                        .active_leg_claim_floor_num
                         .get()
-                        .checked_sub(burn)
-                        .ok_or(V16Error::CounterUnderflow)?,
+                        .min(next_claim_bound),
                 );
                 let mut source_credit = self.source_credit_for_domain(d)?;
                 source_credit.positive_claim_bound_num = source_credit
@@ -12785,9 +12812,19 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             SideV16::Short => asset.a_short,
         };
         let loss_weight = loss_weight_for_basis(basis_pos_q.unsigned_abs(), a_basis)?;
+        let source_domain = self.insurance_domain_index(asset_index, opposite_side(side))?;
+        let active_leg_claim_floor_num = account
+            .as_view()
+            .source_domain(source_domain)?
+            .source_claim_bound_num
+            .get();
         let (asset, new_leg) =
             V16Core::kernel_attach_leg(asset, side, basis_pos_q, loss_weight, asset_index as u32)?;
         account.header.legs[leg_slot] = PortfolioLegV16Account::from_runtime(&new_leg);
+        if active_leg_claim_floor_num != 0 {
+            let source = account.source_domain_mut_or_insert(source_domain)?;
+            source.active_leg_claim_floor_num = V16PodU128::new(active_leg_claim_floor_num);
+        }
         let mut bitmap = account.header.active_bitmap.map(V16PodU64::get);
         active_bitmap_set(&mut bitmap, leg_slot)?;
         account.header.active_bitmap = bitmap.map(V16PodU64::new);
@@ -12826,6 +12863,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         let asset = self.asset_state(asset_index)?;
         let asset = V16Core::kernel_clear_leg(leg, asset)?;
+        let source_domain = self.insurance_domain_index(asset_index, opposite_side(leg.side))?;
+        if let Some(source_slot) = account.source_domain_slot(source_domain)? {
+            account.header.source_domains[source_slot].active_leg_claim_floor_num =
+                V16PodU128::new(0);
+            account.reset_source_domain_slot_if_empty(source_slot);
+        }
         account.header.legs[leg_slot] =
             PortfolioLegV16Account::from_runtime(&PortfolioLegV16::EMPTY);
         let mut bitmap = account.header.active_bitmap.map(V16PodU64::get);
@@ -12870,6 +12913,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         leg.b_rem = 0;
         let asset = self.asset_state(asset_index)?;
         let asset = V16Core::kernel_clear_leg(leg, asset)?;
+        let source_domain = self.insurance_domain_index(asset_index, opposite_side(leg.side))?;
+        if let Some(source_slot) = account.source_domain_slot(source_domain)? {
+            account.header.source_domains[source_slot].active_leg_claim_floor_num =
+                V16PodU128::new(0);
+            account.reset_source_domain_slot_if_empty(source_slot);
+        }
         account.header.legs[leg_slot] =
             PortfolioLegV16Account::from_runtime(&PortfolioLegV16::EMPTY);
         let mut bitmap = account.header.active_bitmap.map(V16PodU64::get);
@@ -15726,20 +15775,37 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let source_claim_bound_num = account.header.source_domains[source_slot]
             .source_claim_bound_num
             .get();
-        if source_claim_bound_num == 0 {
+        let preserved_claim_floor_num = account.header.source_domains[source_slot]
+            .active_leg_claim_floor_num
+            .get()
+            .min(source_claim_bound_num);
+        let forfeited_claim_bound_num = source_claim_bound_num
+            .checked_sub(preserved_claim_floor_num)
+            .ok_or(V16Error::CounterUnderflow)?;
+        if forfeited_claim_bound_num == 0 {
             return Ok(0);
         }
-        V16Core::validate_bound_num_atom_aligned(source_claim_bound_num)?;
+        V16Core::validate_bound_num_atom_aligned(forfeited_claim_bound_num)?;
 
         // A dead-leg forfeit values this leg's positive PnL at zero. Release any
-        // valid source-credit lien first so forfeiting the face returns backing
-        // instead of consuming it. Impaired claim fields are burned by the
-        // canonical source-claim burn below.
-        if account.header.source_domains[source_slot]
+        // valid source-credit lien first when every claim in the domain belongs
+        // to this episode, so forfeiting the face returns backing instead of
+        // consuming it. If a prior episode's claim floor remains, only an
+        // unencumbered current-episode suffix is identifiable without weakening
+        // that historical claim's backing.
+        let source = account.header.source_domains[source_slot];
+        let locked_claim_bound_num = source
             .source_claim_liened_num
             .get()
-            != 0
-        {
+            .checked_add(source.source_claim_impaired_num.get())
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        let unliened_claim_bound_num = source_claim_bound_num
+            .checked_sub(locked_claim_bound_num)
+            .ok_or(V16Error::CounterUnderflow)?;
+        if forfeited_claim_bound_num > unliened_claim_bound_num {
+            if preserved_claim_floor_num != 0 {
+                return Err(V16Error::LockActive);
+            }
             self.release_account_source_credit_lien_for_domain_not_atomic(account, source_domain)?;
             source_slot = account
                 .source_domain_slot(source_domain)?
@@ -15751,7 +15817,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if source_slot != 0 {
             account.header.source_domains.swap(0, source_slot);
         }
-        let source_claim_face = V16Core::amount_from_bound_num(source_claim_bound_num)?;
+        let source_claim_face = V16Core::amount_from_bound_num(forfeited_claim_bound_num)?;
         let positive_pnl = account.header.pnl.get().max(0) as u128;
         let positive_pnl_forfeited = source_claim_face.min(positive_pnl);
         if positive_pnl_forfeited != 0 {
@@ -15767,11 +15833,20 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
 
         // Source bounds are normally exact atom multiples of positive PnL. Burn
-        // any conservative excess as attribution-only state after the PnL debit.
+        // only this episode's conservative excess as attribution-only state
+        // after the PnL debit; the attach-time floor belongs to an earlier leg.
         if let Some(remaining_slot) = account.source_domain_slot(source_domain)? {
-            let remaining = account.header.source_domains[remaining_slot]
+            let remaining_source = account.header.source_domains[remaining_slot];
+            let remaining = remaining_source
                 .source_claim_bound_num
-                .get();
+                .get()
+                .checked_sub(
+                    remaining_source
+                        .active_leg_claim_floor_num
+                        .get()
+                        .min(remaining_source.source_claim_bound_num.get()),
+                )
+                .ok_or(V16Error::CounterUnderflow)?;
             if remaining != 0 {
                 if remaining_slot != 0 {
                     account.header.source_domains.swap(0, remaining_slot);
@@ -16230,6 +16305,9 @@ pub struct PortfolioSourceDomainV16Account {
     pub domain: V16PodU32,
     pub source_claim_market_id: V16PodU64,
     pub source_claim_bound_num: V16PodU128,
+    // Claim bound already present when the current leg episode attached. A
+    // Recovery forfeit may burn only the selected episode's suffix above it.
+    pub active_leg_claim_floor_num: V16PodU128,
     pub source_claim_liened_num: V16PodU128,
     pub source_claim_counterparty_liened_num: V16PodU128,
     pub source_claim_insurance_liened_num: V16PodU128,
@@ -16251,6 +16329,7 @@ impl PortfolioSourceDomainV16Account {
     #[inline]
     pub fn is_occupied(self) -> bool {
         self.source_claim_bound_num.get() != 0
+            || self.active_leg_claim_floor_num.get() != 0
             || self.source_claim_liened_num.get() != 0
             || self.source_claim_counterparty_liened_num.get() != 0
             || self.source_claim_insurance_liened_num.get() != 0
@@ -16315,7 +16394,7 @@ pub struct PortfolioAccountV16Account {
 // Gated to non-kani: under `cfg(kani)` PORTFOLIO_SOURCE_DOMAIN_CAP is reduced for
 // proof tractability, so the production on-chain layout is the non-kani one.
 #[cfg(not(kani))]
-const _: () = assert!(core::mem::size_of::<PortfolioAccountV16Account>() == 9291);
+const _: () = assert!(core::mem::size_of::<PortfolioAccountV16Account>() == 9803);
 
 impl Default for PortfolioAccountV16Account {
     fn default() -> Self {

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -5483,6 +5483,32 @@ pub struct DeadLegForfeitOutcomeV16 {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct RecoveryForfeitSourcePlanV16 {
+    preserved_claim_bound_num: u128,
+    forfeited_claim_bound_num: u128,
+    release_valid_lien: bool,
+}
+
+fn recovery_forfeit_source_plan(
+    source_claim_bound_num: u128,
+    active_leg_claim_floor_num: u128,
+    locked_claim_bound_num: u128,
+) -> V16Result<RecoveryForfeitSourcePlanV16> {
+    if active_leg_claim_floor_num > source_claim_bound_num
+        || locked_claim_bound_num > source_claim_bound_num
+    {
+        return Err(V16Error::InvalidLeg);
+    }
+    let forfeited_claim_bound_num = source_claim_bound_num - active_leg_claim_floor_num;
+    let unliened_claim_bound_num = source_claim_bound_num - locked_claim_bound_num;
+    Ok(RecoveryForfeitSourcePlanV16 {
+        preserved_claim_bound_num: active_leg_claim_floor_num,
+        forfeited_claim_bound_num,
+        release_valid_lien: forfeited_claim_bound_num > unliened_claim_bound_num,
+    })
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct SupportLossApplicationV16 {
     support_consumed: u128,
     junior_face_burned: u128,
@@ -14626,18 +14652,36 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     fn convert_released_pnl_to_capital_core_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
+        face_limit: Option<u128>,
+        source_domain_scope: Option<usize>,
     ) -> V16Result<u128> {
         let pos = account.header.pnl.get().max(0) as u128;
-        let released = pos.saturating_sub(account.header.reserved_pnl.get());
+        let mut released = pos.saturating_sub(account.header.reserved_pnl.get());
+        if let Some(limit) = face_limit {
+            released = released.min(limit);
+        }
         if released == 0 {
             return Ok(0);
         }
         if Self::account_has_source_claims(&account.as_view())?
             && self.account_has_active_source_claim_exposure(&account.as_view())?
+            && source_domain_scope.is_none()
         {
             return Err(V16Error::LockActive);
         }
-        let converted = if Self::account_has_source_claims(&account.as_view())? {
+        let converted = if let Some(domain) = source_domain_scope {
+            let source_slot = account
+                .source_domain_slot(domain)?
+                .ok_or(V16Error::InvalidLeg)?;
+            let released_num = V16Core::bound_num_from_amount(released)?;
+            if Self::source_claim_unliened_num(&account.as_view(), domain)? < released_num {
+                return Err(V16Error::LockActive);
+            }
+            if source_slot != 0 {
+                account.header.source_domains.swap(0, source_slot);
+            }
+            self.source_domain_realizable_support_for_face(domain, released)?
+        } else if Self::account_has_source_claims(&account.as_view())? {
             self.account_source_realizable_support(&account.as_view(), released)?
         } else if decode_market_mode(self.header.mode)? == MarketModeV16::Live {
             0
@@ -14648,7 +14692,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Err(V16Error::LockActive);
         }
         let vault_before = self.header.vault.get();
-        let consumption = if Self::account_has_source_claims(&account.as_view())? {
+        let consumption = if let Some(domain) = source_domain_scope {
+            self.consume_source_domain_credit_for_effective_not_atomic(domain, converted)?
+        } else if Self::account_has_source_claims(&account.as_view())? {
             self.create_and_consume_account_source_credit_for_effective_not_atomic(
                 account, converted,
             )?
@@ -14717,7 +14763,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
     ) -> V16Result<u128> {
         self.preflight_convert_released_pnl_to_capital(&account.as_view())?;
-        let converted = self.convert_released_pnl_to_capital_core_not_atomic(account)?;
+        let converted =
+            self.convert_released_pnl_to_capital_core_not_atomic(account, None, None)?;
         if converted != 0 {
             self.validate_shape()?;
             account.validate_with_market(&self.as_view())?;
@@ -15196,7 +15243,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         // Terminal: PnL reservations no longer gate realization.
         account.header.reserved_pnl = V16PodU128::new(0);
-        let converted = self.convert_released_pnl_to_capital_core_not_atomic(account)?;
+        let converted =
+            self.convert_released_pnl_to_capital_core_not_atomic(account, None, None)?;
         // If the payout snapshot was captured before this account realized (another
         // winner closed first), the realized face is still counted in the ledger's
         // unreceipted bound. Refine it out, or the stale bound dilutes the payout
@@ -15775,41 +15823,68 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let source_claim_bound_num = account.header.source_domains[source_slot]
             .source_claim_bound_num
             .get();
-        let preserved_claim_floor_num = account.header.source_domains[source_slot]
-            .active_leg_claim_floor_num
-            .get()
-            .min(source_claim_bound_num);
-        let forfeited_claim_bound_num = source_claim_bound_num
-            .checked_sub(preserved_claim_floor_num)
-            .ok_or(V16Error::CounterUnderflow)?;
-        if forfeited_claim_bound_num == 0 {
-            return Ok(0);
-        }
-        V16Core::validate_bound_num_atom_aligned(forfeited_claim_bound_num)?;
-
-        // A dead-leg forfeit values this leg's positive PnL at zero. Release any
-        // valid source-credit lien first when every claim in the domain belongs
-        // to this episode, so forfeiting the face returns backing instead of
-        // consuming it. If a prior episode's claim floor remains, only an
-        // unencumbered current-episode suffix is identifiable without weakening
-        // that historical claim's backing.
         let source = account.header.source_domains[source_slot];
+        let impaired_claim_bound_num = source.source_claim_impaired_num.get();
         let locked_claim_bound_num = source
             .source_claim_liened_num
             .get()
-            .checked_add(source.source_claim_impaired_num.get())
+            .checked_add(impaired_claim_bound_num)
             .ok_or(V16Error::ArithmeticOverflow)?;
-        let unliened_claim_bound_num = source_claim_bound_num
-            .checked_sub(locked_claim_bound_num)
-            .ok_or(V16Error::CounterUnderflow)?;
-        if forfeited_claim_bound_num > unliened_claim_bound_num {
-            if preserved_claim_floor_num != 0 {
+        let source_plan = recovery_forfeit_source_plan(
+            source_claim_bound_num,
+            source.active_leg_claim_floor_num.get(),
+            locked_claim_bound_num,
+        )?;
+        V16Core::validate_bound_num_atom_aligned(source_plan.forfeited_claim_bound_num)?;
+
+        // A dead-leg forfeit values this episode's positive PnL at zero. When
+        // the suffix overlaps a fungible domain lien, first realize the saved
+        // pre-attach floor from this domain into senior capital. This happens
+        // in the same transition as the lien release, so a backing provider
+        // cannot withdraw between release and realization.
+        if source_plan.release_valid_lien {
+            if source_plan.preserved_claim_bound_num != 0 && impaired_claim_bound_num != 0 {
                 return Err(V16Error::LockActive);
             }
             self.release_account_source_credit_lien_for_domain_not_atomic(account, source_domain)?;
             source_slot = account
                 .source_domain_slot(source_domain)?
                 .ok_or(V16Error::InvalidLeg)?;
+            if source_plan.preserved_claim_bound_num != 0 {
+                if source_slot != 0 {
+                    account.header.source_domains.swap(0, source_slot);
+                }
+
+                let pnl_before = account.header.pnl.get().max(0) as u128;
+                let preserved_claim_face =
+                    V16Core::amount_from_bound_num(source_plan.preserved_claim_bound_num)?;
+                self.convert_released_pnl_to_capital_core_not_atomic(
+                    account,
+                    Some(preserved_claim_face),
+                    Some(source_domain),
+                )?;
+                let pnl_after = account.header.pnl.get().max(0) as u128;
+                let preserved_face_burned = pnl_before
+                    .checked_sub(pnl_after)
+                    .ok_or(V16Error::CounterUnderflow)?;
+                let preserved_bound_burned = V16Core::bound_num_from_amount(preserved_face_burned)?;
+                if preserved_bound_burned > source_plan.preserved_claim_bound_num {
+                    return Err(V16Error::CounterUnderflow);
+                }
+                source_slot = account
+                    .source_domain_slot(source_domain)?
+                    .ok_or(V16Error::InvalidLeg)?;
+                account.header.source_domains[source_slot].active_leg_claim_floor_num =
+                    V16PodU128::new(
+                        source_plan
+                            .preserved_claim_bound_num
+                            .checked_sub(preserved_bound_burned)
+                            .ok_or(V16Error::CounterUnderflow)?,
+                    );
+            }
+        }
+        if source_plan.forfeited_claim_bound_num == 0 {
+            return Ok(0);
         }
 
         // The canonical PnL setter burns source claims in sparse-slot order.
@@ -15817,7 +15892,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         if source_slot != 0 {
             account.header.source_domains.swap(0, source_slot);
         }
-        let source_claim_face = V16Core::amount_from_bound_num(forfeited_claim_bound_num)?;
+        let source_claim_face =
+            V16Core::amount_from_bound_num(source_plan.forfeited_claim_bound_num)?;
         let positive_pnl = account.header.pnl.get().max(0) as u128;
         let positive_pnl_forfeited = source_claim_face.min(positive_pnl);
         if positive_pnl_forfeited != 0 {

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -1366,6 +1366,7 @@ pub fn kani_eq_portfolio_source_domain_v16_account(
     a.domain.get() == b.domain.get()
         && a.source_claim_market_id.get() == b.source_claim_market_id.get()
         && a.source_claim_bound_num.get() == b.source_claim_bound_num.get()
+        && a.active_leg_claim_floor_num.get() == b.active_leg_claim_floor_num.get()
         && a.source_claim_liened_num.get() == b.source_claim_liened_num.get()
         && a.source_claim_counterparty_liened_num.get()
             == b.source_claim_counterparty_liened_num.get()

--- a/src/v16_proofs.rs
+++ b/src/v16_proofs.rs
@@ -12,6 +12,49 @@ use super::*;
 use crate::wide_math::{checked_mul_div_ceil_u256, U256};
 use crate::{BOUND_SCALE, MAX_VAULT_TVL, V16_TOKEN_VALUE_CLASS_COUNT};
 
+#[cfg(all(kani, feature = "closure"))]
+#[kani::proof]
+#[kani::unwind(4)]
+#[kani::solver(cadical)]
+fn closure_recovery_forfeit_source_plan_partitions_claim_without_overlap() {
+    let source_claim_bound_num: u128 = kani::any();
+    let active_leg_claim_floor_num: u128 = kani::any();
+    let locked_claim_bound_num: u128 = kani::any();
+
+    match recovery_forfeit_source_plan(
+        source_claim_bound_num,
+        active_leg_claim_floor_num,
+        locked_claim_bound_num,
+    ) {
+        Ok(plan) => {
+            assert!(active_leg_claim_floor_num <= source_claim_bound_num);
+            assert!(locked_claim_bound_num <= source_claim_bound_num);
+            assert_eq!(
+                plan.preserved_claim_bound_num
+                    .checked_add(plan.forfeited_claim_bound_num),
+                Some(source_claim_bound_num)
+            );
+            assert_eq!(
+                plan.release_valid_lien,
+                locked_claim_bound_num > active_leg_claim_floor_num
+            );
+            if !plan.release_valid_lien {
+                assert!(
+                    plan.forfeited_claim_bound_num
+                        <= source_claim_bound_num - locked_claim_bound_num
+                );
+            }
+        }
+        Err(V16Error::InvalidLeg) => {
+            assert!(
+                active_leg_claim_floor_num > source_claim_bound_num
+                    || locked_claim_bound_num > source_claim_bound_num
+            );
+        }
+        Err(other) => panic!("unexpected source-plan error: {other:?}"),
+    }
+}
+
 // ===================== KANI FUNCTION-CONTRACT LAYER =====================
 // Built ONLY by scripts/contracts_runner.sh (cargo feature `contracts` +
 // CLI -Z function-contracts + a separate CARGO_TARGET_DIR). The main proof

--- a/src/v16_proofs.rs
+++ b/src/v16_proofs.rs
@@ -1909,8 +1909,8 @@ fn composition_attach_body_frame_division_stubbed() {
         }
     }
     kani::cover!(true, "division-stubbed attach body frame reached");
-    // WHOLE-BODY FRAME: the body touches ONLY leg[0], the active bitmap, and
-    // the health cert in the account; every other account field is frozen.
+    // EMPTY-SOURCE WHOLE-BODY FRAME: without a pre-existing source claim, the
+    // body touches only leg[0], the active bitmap, and the health certificate.
     let mut expected = a0;
     expected.legs[0] = account_header.legs[0];
     expected.active_bitmap = account_header.active_bitmap;
@@ -1988,6 +1988,103 @@ fn composition_clear_leg_body_frame() {
     ));
     // leg[0] is now empty/inactive
     assert!(!account_header.legs[0].try_to_runtime().unwrap().active);
+}
+
+// Episode-attribution composition for the nonempty-source branch introduced by
+// layout 18. The real attach body must snapshot the existing same-domain claim
+// exactly; the real clear body must remove only that marker and leave the prior
+// claim untouched. Division and the two already-contracted asset kernels are
+// irrelevant to this account-local attribution property.
+#[cfg(all(kani, feature = "contracts"))]
+#[kani::proof]
+#[kani::unwind(40)]
+#[kani::solver(cadical)]
+#[kani::stub(crate::v16::loss_weight_for_basis, kani_any_loss_weight)]
+#[kani::stub_verified(V16Core::kernel_clear_leg)]
+#[kani::stub_verified(V16Core::kernel_attach_leg)]
+fn composition_same_domain_claim_floor_attach_clear() {
+    let cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic([1u8; 32], cfg, 1, 0).unwrap();
+    let mut markets = [Market::new(0u64, EngineAssetSlotV16Account::default())];
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        market.activate_empty_market_not_atomic(0, 100, 1).unwrap();
+    }
+    let market_id = markets[0].engine.asset.market_id.get();
+    let prov = ProvenanceHeaderV16Account::from_runtime(&ProvenanceHeaderV16::new(
+        [1u8; 32], [2u8; 32], [2u8; 32],
+    ));
+    let mut account_header = PortfolioAccountV16Account::default();
+    account_header.init_empty_in_place(prov).unwrap();
+    account_header.last_fee_slot = V16PodU64::new(1);
+
+    let claim_atoms: u8 = kani::any();
+    kani::assume((1..=16).contains(&claim_atoms));
+    let claim_num = (claim_atoms as u128) * BOUND_SCALE;
+    account_header.pnl = V16PodI128::new(claim_atoms as i128);
+    account_header.source_domains[0].domain = V16PodU32::new(1);
+    account_header.source_domains[0].source_claim_market_id = V16PodU64::new(market_id);
+    account_header.source_domains[0].source_claim_bound_num = V16PodU128::new(claim_num);
+    markets[0].engine.source_credit_short =
+        SourceCreditStateV16Account::from_runtime(&SourceCreditStateV16 {
+            positive_claim_bound_num: claim_num,
+            exact_positive_claim_num: claim_num,
+            credit_rate_num: CREDIT_RATE_SCALE,
+            ..SourceCreditStateV16::EMPTY
+        });
+
+    let basis: i128 = kani::any();
+    kani::assume(basis > 0 && basis <= MAX_POSITION_ABS_Q as i128);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut account_header);
+        if market
+            .kani_attach_leg_at_slot(&mut account, 0, SideV16::Long, basis, 0)
+            .is_err()
+        {
+            return;
+        }
+    }
+    kani::cover!(
+        claim_atoms > 1,
+        "same-domain attach snapshots a nontrivial prior claim"
+    );
+    assert_eq!(
+        account_header.source_domains[0]
+            .active_leg_claim_floor_num
+            .get(),
+        claim_num
+    );
+    assert_eq!(
+        account_header.source_domains[0]
+            .source_claim_bound_num
+            .get(),
+        claim_num
+    );
+
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut account_header);
+        if market.kani_clear_leg(&mut account, 0).is_err() {
+            return;
+        }
+    }
+    kani::cover!(
+        claim_atoms > 1,
+        "same-domain clear removes the episode marker"
+    );
+    assert_eq!(
+        account_header.source_domains[0]
+            .active_leg_claim_floor_num
+            .get(),
+        0
+    );
+    assert_eq!(
+        account_header.source_domains[0]
+            .source_claim_bound_num
+            .get(),
+        claim_num
+    );
 }
 
 // ============ NO-DoS GATE-REACHABILITY (existential liveness) ============

--- a/src/v16_proofs.rs
+++ b/src/v16_proofs.rs
@@ -55,6 +55,64 @@ fn closure_recovery_forfeit_source_plan_partitions_claim_without_overlap() {
     }
 }
 
+#[cfg(all(kani, feature = "closure"))]
+#[kani::proof]
+#[kani::unwind(4)]
+#[kani::solver(cadical)]
+fn closure_recovery_forfeit_preserves_prior_episode_value() {
+    let prior_claim_atoms: u8 = kani::any();
+    let current_episode_atoms: u8 = kani::any();
+    let locked_claim_atoms: u16 = kani::any();
+    let realized_prior_atoms: u8 = kani::any();
+    kani::assume(prior_claim_atoms > 0);
+    kani::assume(realized_prior_atoms <= prior_claim_atoms);
+
+    let prior_claim_atoms = prior_claim_atoms as u128;
+    let current_episode_atoms = current_episode_atoms as u128;
+    let total_claim_atoms = prior_claim_atoms + current_episode_atoms;
+    kani::assume((locked_claim_atoms as u128) <= total_claim_atoms);
+
+    let total_claim_num = total_claim_atoms * BOUND_SCALE;
+    let prior_claim_num = prior_claim_atoms * BOUND_SCALE;
+    let locked_claim_num = (locked_claim_atoms as u128) * BOUND_SCALE;
+    let plan =
+        recovery_forfeit_source_plan(total_claim_num, prior_claim_num, locked_claim_num).unwrap();
+
+    assert_eq!(plan.preserved_claim_bound_num, prior_claim_num);
+    assert_eq!(
+        plan.forfeited_claim_bound_num,
+        current_episode_atoms * BOUND_SCALE
+    );
+
+    let realized_prior_atoms = if plan.release_valid_lien {
+        assert!((locked_claim_atoms as u128) > prior_claim_atoms);
+        realized_prior_atoms as u128
+    } else {
+        assert!((locked_claim_atoms as u128) <= prior_claim_atoms);
+        0
+    };
+    let post_claim_atoms = total_claim_atoms
+        .checked_sub(current_episode_atoms)
+        .and_then(|v| v.checked_sub(realized_prior_atoms))
+        .unwrap();
+
+    assert_eq!(post_claim_atoms + realized_prior_atoms, prior_claim_atoms);
+    if plan.release_valid_lien {
+        kani::cover!(
+            current_episode_atoms > 0
+                && realized_prior_atoms > 0
+                && realized_prior_atoms < prior_claim_atoms,
+            "overlapping lien preserves value across partial prior-claim realization"
+        );
+    } else {
+        assert!(post_claim_atoms >= locked_claim_atoms as u128);
+        kani::cover!(
+            current_episode_atoms > 0 && locked_claim_atoms as u128 == prior_claim_atoms,
+            "nonoverlapping lien remains fully covered after current-episode forfeit"
+        );
+    }
+}
+
 // ===================== KANI FUNCTION-CONTRACT LAYER =====================
 // Built ONLY by scripts/contracts_runner.sh (cargo feature `contracts` +
 // CLI -Z function-contracts + a separate CARGO_TARGET_DIR). The main proof
@@ -1905,7 +1963,7 @@ fn closure_restarted_slot_preserves_budget_witness() {
 // the value's exactness is the separately-proven kernel_attach_leg contract.
 // With the division gone, the body is gates + the cheap real kernel + slot
 // placement — the composition the direct/stub_verified routes could not reach.
-#[cfg(all(kani, feature = "contracts"))]
+#[cfg(all(kani, any(feature = "contracts", feature = "closure")))]
 fn kani_any_loss_weight(_abs_basis_q: u128, _a_basis: u128) -> V16Result<u128> {
     let w: u128 = kani::any();
     kani::assume(w != 0);
@@ -2036,15 +2094,14 @@ fn composition_clear_leg_body_frame() {
 // Episode-attribution composition for the nonempty-source branch introduced by
 // layout 18. The real attach body must snapshot the existing same-domain claim
 // exactly; the real clear body must remove only that marker and leave the prior
-// claim untouched. Division and the two already-contracted asset kernels are
-// irrelevant to this account-local attribution property.
-#[cfg(all(kani, feature = "contracts"))]
+// claim untouched. Only the intractable division is stubbed; the attach and
+// clear kernels remain real so an unconstrained contract result cannot satisfy
+// this composition vacuously.
+#[cfg(all(kani, feature = "closure"))]
 #[kani::proof]
 #[kani::unwind(40)]
 #[kani::solver(cadical)]
 #[kani::stub(crate::v16::loss_weight_for_basis, kani_any_loss_weight)]
-#[kani::stub_verified(V16Core::kernel_clear_leg)]
-#[kani::stub_verified(V16Core::kernel_attach_leg)]
 fn composition_same_domain_claim_floor_attach_clear() {
     let cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
     let mut header = MarketGroupV16HeaderAccount::new_dynamic([1u8; 32], cfg, 1, 0).unwrap();

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -672,6 +672,45 @@ fn v16_recovery_forfeit_preserves_unrelated_source_domain_claim() {
 }
 
 #[test]
+fn v16_recovery_forfeit_preserves_prior_same_domain_position_episode() {
+    let (mut header, mut markets, mut long_header, mut short_header) =
+        bankrupt_recovery_pair_fixture();
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market.full_account_refresh_not_atomic(&mut short).unwrap();
+        let historical_pnl = short.header.pnl.get();
+        let historical_claim = short.header.source_domains[0].source_claim_bound_num.get();
+        assert!(historical_pnl > 0 && historical_claim > 0);
+        short.header.source_domains[0].active_leg_claim_floor_num =
+            V16PodU128::new(historical_claim);
+        short.validate_with_market(&market.as_view()).unwrap();
+
+        let short_forfeit = market
+            .forfeit_recovery_leg_not_atomic(&mut short, 0, u128::MAX)
+            .unwrap();
+        assert!(short_forfeit.detached);
+        assert_eq!(short_forfeit.positive_pnl_forfeited, 0);
+        assert_eq!(short.header.pnl.get(), historical_pnl);
+        assert_eq!(
+            short.header.source_domains[0].source_claim_bound_num.get(),
+            historical_claim
+        );
+        assert_eq!(
+            short.header.source_domains[0]
+                .active_leg_claim_floor_num
+                .get(),
+            0,
+            "clearing episode two removes only its attribution floor"
+        );
+        market.validate_shape().unwrap();
+        long.validate_with_market(&market.as_view()).unwrap();
+        short.validate_with_market(&market.as_view()).unwrap();
+    }
+}
+
+#[test]
 fn v16_funding_counters_ignore_inactive_accounts_when_market_funding_moves() {
     let (mut header, mut markets) = funding_market_fixture(FUNDING_COUNTER_PRICE);
     let mut long_header = account_fixture(1, 130);


### PR DESCRIPTION
## Impact

A public, normally initialized market can erase a user's settled source-backed PnL from an earlier position episode.

Public LiteSVM sequence:

1. A victim earns and fully closes a profitable short, leaving a 48,000-atom same-domain claim.
2. The victim later reopens the same asset and side at the current mark.
3. The asset enters normal Recovery and the new counterparty forfeits first.
4. Conversion, unilateral reduction, and pair close are unavailable while an unrelated base asset stays honestly current.
5. On exact parent `a9a8588483ac6ecccd5d94bcbc80e116cf5487a8`, the victim's unilateral forfeit burns the prior claim.

The strengthened public case also earns new PnL in episode two and increases risk until its source lien crosses the historical claim floor. The first version of this fix returned `LockActive` there, persistently blocking the victim's only remaining exit.

No account bytes or private engine state are injected by wrapper PR aeyakovenko/percolator-prog#372.

## Fix

Snapshot the source-domain claim bound when a new leg episode attaches. Recovery forfeit burns only the selected episode's suffix above that floor.

When a later valid lien overlaps the historical floor, the same forfeit transition now:

1. releases the domain lien,
2. realizes at most the saved historical floor from that same domain into senior capital,
3. reduces the floor by the exact face burned, and
4. waives only the current episode's remaining suffix.

The release and realization are atomic, so the backing provider cannot withdraw between them. Normal leg clear removes the episode marker, persisted claim burns clamp it, validation binds it to the matching active asset/side, and the layout discriminator is 18.

This PR is intentionally stacked on #166 because it corrects an episode-attribution edge exposed by that Recovery liveness fix.

## Verification

- `cargo test --all-targets -- --test-threads=1`: 133 passed
- `cargo check --all-targets`
- `cargo fmt --all -- --check`
- Kani `closure_recovery_forfeit_source_plan_partitions_claim_without_overlap`: 64 checks, 0 failures
- wrapper PR #372 exact-parent RED / fixed-head GREEN
- public overlap case exits in one forfeit, atomically capitalizes exactly 48,000 historical atoms, permits immediate withdrawal of all unconsumed provider backing, and still pays the victim all 53,000 remaining atoms
