### PR TITLE
[BLOCKER LoF] Net Recovery haircuts within position episodes

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -15740,10 +15740,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
         asset_index: usize,
-    ) -> V16Result<(u128, u128, u128, u128)> {
+    ) -> V16Result<(u128, u128, u128)> {
         let Some(leg_slot) = Self::active_leg_slot_for_asset(&account.as_view(), asset_index)?
         else {
-            return Ok((0, 0, 0, 0));
+            return Ok((0, 0, 0));
         };
         let mut leg = account.header.legs[leg_slot].try_to_runtime()?;
         let (k_now, f_now) = self.kf_target_for_leg(asset_index, leg)?;
@@ -15787,14 +15787,15 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let mut loss_settled = 0u128;
         let mut support_consumed = 0u128;
         let mut junior_face_burned = 0u128;
-        let mut positive_pnl_forfeited = 0u128;
         if net < 0 {
             loss_settled = net.unsigned_abs();
             let support = self.apply_haircut_bounded_close_loss_to_pnl(account, loss_settled)?;
             support_consumed = support.support_consumed;
             junior_face_burned = support.junior_face_burned;
-        } else {
-            positive_pnl_forfeited = net as u128;
+        } else if net > 0 {
+            let source_domain =
+                self.insurance_domain_index(asset_index, opposite_side(leg.side))?;
+            self.apply_signed_kf_delta_to_pnl(account, net, Some(source_domain))?;
         }
 
         Self::record_account_funding_flow(account, leg.side, f_delta)?;
@@ -15802,12 +15803,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         leg.f_snap = f_now;
         account.header.legs[leg_slot] = PortfolioLegV16Account::from_runtime(&leg);
         account.header.health_cert.valid = 0;
-        Ok((
-            loss_settled,
-            positive_pnl_forfeited,
-            support_consumed,
-            junior_face_burned,
-        ))
+        Ok((loss_settled, support_consumed, junior_face_burned))
     }
 
     fn forfeit_materialized_positive_pnl_for_leg(
@@ -15955,40 +15951,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Err(V16Error::LockActive);
         }
 
-        let materialized_positive_pnl_forfeited =
-            self.forfeit_materialized_positive_pnl_for_leg(account, asset_index, leg.side)?;
-        let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;
-        let b_target = self.b_target_for_leg(asset_index, leg)?;
-        if account.header.pnl.get() == 0
-            && k_target == leg.k_snap
-            && f_target == leg.f_snap
-            && b_target <= leg.b_snap
-            && !account
-                .header
-                .close_progress
-                .try_to_runtime()?
-                .has_pending_residual()
-        {
-            self.clear_leg(account, asset_index)?;
-            return Ok(DeadLegForfeitOutcomeV16 {
-                detached: true,
-                positive_pnl_forfeited: materialized_positive_pnl_forfeited,
-                loss_settled: 0,
-                support_consumed: 0,
-                junior_face_burned: 0,
-                principal_used: 0,
-                insurance_used: 0,
-                residual_booked: 0,
-                explicit_loss: 0,
-            });
+        // Keep the selected episode's source suffix alive while K/F and B settle. Burning its
+        // gross claim first would make the episode's later B haircut consume the attach-time floor.
+        let source_domain = self.insurance_domain_index(asset_index, opposite_side(leg.side))?;
+        if let Some(source_slot) = account.source_domain_slot(source_domain)? {
+            if source_slot != 0 {
+                account.header.source_domains.swap(0, source_slot);
+            }
         }
 
-        let (loss_settled, positive_pnl_delta_forfeited, support_consumed, junior_face_burned) =
+        let (loss_settled, support_consumed, junior_face_burned) =
             self.settle_forfeited_leg_kf_effects(account, asset_index)?;
-        let positive_pnl_forfeited = materialized_positive_pnl_forfeited
-            .checked_add(positive_pnl_delta_forfeited)
-            .ok_or(V16Error::ArithmeticOverflow)?;
-
         let mut total_loss_settled = loss_settled;
         let refreshed = Self::active_leg_for_asset(&account.as_view(), asset_index)?;
         if self.b_target_for_leg(asset_index, refreshed)? > refreshed.b_snap {
@@ -16002,7 +15975,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 account.validate_with_market(&self.as_view())?;
                 return Ok(DeadLegForfeitOutcomeV16 {
                     detached: false,
-                    positive_pnl_forfeited,
+                    positive_pnl_forfeited: 0,
                     loss_settled: total_loss_settled,
                     support_consumed,
                     junior_face_burned,
@@ -16012,6 +15985,36 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     explicit_loss: 0,
                 });
             }
+        }
+
+        let materialized_positive_pnl_forfeited =
+            self.forfeit_materialized_positive_pnl_for_leg(account, asset_index, leg.side)?;
+        let positive_pnl_forfeited = materialized_positive_pnl_forfeited;
+        let refreshed = Self::active_leg_for_asset(&account.as_view(), asset_index)?;
+        let (k_target, f_target) = self.kf_target_for_leg(asset_index, refreshed)?;
+        let b_target = self.b_target_for_leg(asset_index, refreshed)?;
+        if account.header.pnl.get() == 0
+            && k_target == refreshed.k_snap
+            && f_target == refreshed.f_snap
+            && b_target <= refreshed.b_snap
+            && !account
+                .header
+                .close_progress
+                .try_to_runtime()?
+                .has_pending_residual()
+        {
+            self.clear_leg(account, asset_index)?;
+            return Ok(DeadLegForfeitOutcomeV16 {
+                detached: true,
+                positive_pnl_forfeited,
+                loss_settled: total_loss_settled,
+                support_consumed,
+                junior_face_burned,
+                principal_used: 0,
+                insurance_used: 0,
+                residual_booked: 0,
+                explicit_loss: 0,
+            });
         }
 
         let principal_used = self.settle_negative_pnl_from_principal_not_atomic(account)?;

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -711,6 +711,102 @@ fn v16_recovery_forfeit_preserves_prior_same_domain_position_episode() {
 }
 
 #[test]
+fn v16_recovery_forfeit_nets_current_episode_b_before_prior_claim() {
+    const HISTORICAL_FACE: u128 = 48_000;
+    let (mut header, mut markets, mut long_header, mut short_header) =
+        bankrupt_recovery_pair_fixture();
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+
+        market.full_account_refresh_not_atomic(&mut short).unwrap();
+        assert_eq!(short.header.pnl.get(), 59_424);
+        short.header.source_domains[0].active_leg_claim_floor_num =
+            V16PodU128::new(HISTORICAL_FACE * BOUND_SCALE);
+        short.validate_with_market(&market.as_view()).unwrap();
+
+        let bankrupt = market
+            .forfeit_recovery_leg_not_atomic(&mut long, 0, u128::MAX)
+            .unwrap();
+        assert!(bankrupt.detached);
+        let short_leg = short.header.legs[0].try_to_runtime().unwrap();
+        let asset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+        assert!(
+            short_leg.b_snap < asset.b_short_num,
+            "bankrupt counterparty must book a real B haircut"
+        );
+
+        let first_budget = (asset.b_short_num - short_leg.b_snap) / 2;
+        assert!(first_budget > 0);
+        let partial = market
+            .forfeit_recovery_leg_not_atomic(&mut short, 0, first_budget)
+            .unwrap();
+        assert!(!partial.detached);
+        assert_eq!(partial.positive_pnl_forfeited, 0);
+        assert_eq!(
+            short.header.source_domains[0]
+                .active_leg_claim_floor_num
+                .get(),
+            HISTORICAL_FACE * BOUND_SCALE,
+            "partial B progress must retain the episode boundary"
+        );
+
+        let winner = market
+            .forfeit_recovery_leg_not_atomic(&mut short, 0, u128::MAX)
+            .unwrap();
+        assert!(winner.detached);
+        assert_eq!(short.header.pnl.get(), HISTORICAL_FACE as i128);
+        assert_eq!(
+            short.header.source_domains[0].source_claim_bound_num.get(),
+            HISTORICAL_FACE * BOUND_SCALE,
+            "the current episode's B haircut must net against its own gross claim"
+        );
+        market.validate_shape().unwrap();
+        long.validate_with_market(&market.as_view()).unwrap();
+        short.validate_with_market(&market.as_view()).unwrap();
+    }
+}
+
+#[test]
+fn v16_recovery_forfeit_nets_pending_positive_kf_before_prior_claim() {
+    const HISTORICAL_FACE: u128 = 48_000;
+    let (mut header, mut markets, mut long_header, mut short_header) =
+        bankrupt_recovery_pair_fixture();
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+
+        market
+            .add_account_source_positive_pnl_not_atomic(&mut short, 0, HISTORICAL_FACE)
+            .unwrap();
+        short.header.source_domains[0].active_leg_claim_floor_num =
+            V16PodU128::new(HISTORICAL_FACE * BOUND_SCALE);
+        assert_eq!(short.header.pnl.get(), HISTORICAL_FACE as i128);
+
+        let bankrupt = market
+            .forfeit_recovery_leg_not_atomic(&mut long, 0, u128::MAX)
+            .unwrap();
+        assert!(bankrupt.detached);
+        let winner = market
+            .forfeit_recovery_leg_not_atomic(&mut short, 0, u128::MAX)
+            .unwrap();
+        assert!(winner.detached);
+        assert_eq!(winner.positive_pnl_forfeited, 51_000);
+        assert_eq!(short.header.pnl.get(), HISTORICAL_FACE as i128);
+        assert_eq!(
+            short.header.source_domains[0].source_claim_bound_num.get(),
+            HISTORICAL_FACE * BOUND_SCALE,
+            "pending positive K/F must absorb its episode's B haircut before forfeit"
+        );
+        market.validate_shape().unwrap();
+        long.validate_with_market(&market.as_view()).unwrap();
+        short.validate_with_market(&market.as_view()).unwrap();
+    }
+}
+
+#[test]
 fn v16_funding_counters_ignore_inactive_accounts_when_market_funding_moves() {
     let (mut header, mut markets) = funding_market_fixture(FUNDING_COUNTER_PRICE);
     let mut long_header = account_fixture(1, 130);


### PR DESCRIPTION
## Impact

An unprivileged relayer can land a retained, honestly signed `ForfeitRecoveryLeg` transaction after the counterparty changes public market state. On the exact stacked parent, a newly booked `B` haircut from the reopened position consumes an older, fully closed, provider-backed same-domain claim.

The public LiteSVM reproduction creates a 48,000-atom historical claim, reopens the same side, and earns 59,424 atoms in the new episode. The victim signs while its `B` snapshot is current. The underfunded counterparty forfeits first and books an 8,424-atom haircut; replaying the unchanged victim transaction then reduces the old claim from 48,000 to 39,576.

This is classified as `[BLOCKER LoF]`: the victim transaction was safe when signed, and an unprivileged relayer can reorder it within the valid blockhash window after another public transaction changes the haircut target.

## Root cause

Recovery forfeiture discarded the current episode's positive claim suffix before settling that episode's pending `K`, `F`, and `B` deltas. Once the suffix was gone, the later `B` settlement reached below the attach-time claim floor and charged the prior episode.

## Fix

Materialize pending positive `K`/`F` into the selected source domain, promote the selected episode source first, settle bounded `B` while the current-episode suffix still exists, and only then forfeit positive value above the attach-time floor. Partial `B` progress preserves the suffix until settlement is complete.

No authority, custody, withdrawal, or admin surface is added.

## Validation

- Exact-parent public LiteSVM RED against engine `d3133a93cf2cf219b69e0072cb4079d24a07f4f6`: `48,000 -> 39,576`
- Fixed public LiteSVM GREEN: prior claim remains `48,000`; terminal SPL payout is exactly `1,048,000`
- Engine all-target test suite passes
- `cargo fmt --all -- --check`
- `cargo kani --tests --only-codegen --features fuzz` passes

The end-to-end public-program regression is in the paired stacked `percolator-prog` PR.
