### PR TITLE
[BLOCKER LoF] Reconcile backing expiry during Recovery forfeit

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -717,6 +717,94 @@ impl V16Core {
         Ok((required_face_num, required_backing_num))
     }
 
+    fn crystallize_source_lien_fee_for_effective(
+        source: &mut PortfolioSourceDomainV16Account,
+        impaired_effective: u128,
+    ) -> V16Result<u128> {
+        let live_effective = source.source_lien_effective_reserved.get();
+        if impaired_effective > live_effective {
+            return Err(V16Error::CounterUnderflow);
+        }
+        let live_fee = source.source_lien_capital_at_risk_fee_revenue.get();
+        let impaired_fee = if impaired_effective == live_effective {
+            live_fee
+        } else if impaired_effective == 0 || live_fee == 0 {
+            0
+        } else {
+            U256::from_u128(live_fee)
+                .checked_mul(U256::from_u128(impaired_effective))
+                .ok_or(V16Error::ArithmeticOverflow)?
+                .checked_div(U256::from_u128(live_effective))
+                .ok_or(V16Error::ArithmeticOverflow)?
+                .try_into_u128()
+                .ok_or(V16Error::ArithmeticOverflow)?
+        };
+        source.source_lien_capital_at_risk_fee_revenue = V16PodU128::new(
+            live_fee
+                .checked_sub(impaired_fee)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        source.source_lien_impaired_capital_at_risk_fee_revenue = V16PodU128::new(
+            source
+                .source_lien_impaired_capital_at_risk_fee_revenue
+                .get()
+                .checked_add(impaired_fee)
+                .ok_or(V16Error::CounterOverflow)?,
+        );
+        Ok(impaired_fee)
+    }
+
+    fn prepare_account_counterparty_lien_impairment(
+        mut source: PortfolioSourceDomainV16Account,
+    ) -> V16Result<(PortfolioSourceDomainV16Account, u128)> {
+        let face = source.source_claim_counterparty_liened_num.get();
+        let backing_num = source.source_lien_counterparty_backing_num.get();
+        if face == 0 && backing_num == 0 {
+            return Ok((source, 0));
+        }
+        if face == 0 || backing_num == 0 || backing_num % BOUND_SCALE != 0 {
+            return Err(V16Error::InvalidLeg);
+        }
+        let effective = backing_num / BOUND_SCALE;
+        if effective == 0 {
+            return Err(V16Error::InvalidLeg);
+        }
+
+        Self::crystallize_source_lien_fee_for_effective(&mut source, effective)?;
+        source.source_claim_counterparty_liened_num = V16PodU128::new(0);
+        source.source_claim_liened_num = V16PodU128::new(
+            source
+                .source_claim_liened_num
+                .get()
+                .checked_sub(face)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        source.source_claim_impaired_num = V16PodU128::new(
+            source
+                .source_claim_impaired_num
+                .get()
+                .checked_add(face)
+                .ok_or(V16Error::CounterOverflow)?,
+        );
+        source.source_lien_counterparty_backing_num = V16PodU128::new(0);
+        source.source_lien_effective_reserved = V16PodU128::new(
+            source
+                .source_lien_effective_reserved
+                .get()
+                .checked_sub(effective)
+                .ok_or(V16Error::CounterUnderflow)?,
+        );
+        source.source_lien_impaired_effective_reserved = V16PodU128::new(
+            source
+                .source_lien_impaired_effective_reserved
+                .get()
+                .checked_add(effective)
+                .ok_or(V16Error::CounterOverflow)?,
+        );
+        source.source_lien_fee_last_slot = V16PodU64::new(0);
+        Ok((source, effective))
+    }
+
     #[inline]
     fn validate_bound_num_atom_aligned(bound_num: u128) -> V16Result<()> {
         if bound_num == 0 {
@@ -11050,6 +11138,19 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
         domain: usize,
     ) -> V16Result<u128> {
+        self.collect_account_backing_utilization_fee_for_domain_through_slot_not_atomic(
+            account,
+            domain,
+            self.header.current_slot.get(),
+        )
+    }
+
+    fn collect_account_backing_utilization_fee_for_domain_through_slot_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        domain: usize,
+        through_slot: u64,
+    ) -> V16Result<u128> {
         self.domain_asset_side(domain)?;
         let slot = match account.source_domain_slot(domain)? {
             Some(slot) => slot,
@@ -11066,17 +11167,26 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let last_slot = account.header.source_domains[slot]
             .source_lien_fee_last_slot
             .get();
+        let mut bucket = self.backing_bucket_for_domain(domain)?;
+        let fee_through_slot = if bucket.expiry_slot == 0 {
+            through_slot
+        } else {
+            through_slot.min(bucket.expiry_slot)
+        };
         if last_slot == 0 {
             account.header.source_domains[slot].source_lien_fee_last_slot =
-                V16PodU64::new(self.header.current_slot.get());
+                V16PodU64::new(fee_through_slot);
             return Ok(0);
+        }
+        if fee_through_slot < last_slot {
+            return Err(V16Error::Stale);
         }
         let fee = V16Core::backing_utilization_fee_quote_atoms_for_lien(
             self.header.config.try_to_runtime_shape()?,
             self.source_credit_for_domain(domain)?,
             lien_backing_num,
             last_slot,
-            self.header.current_slot.get(),
+            fee_through_slot,
         )?;
         // Carry the floored-away fractional accrual forward: when the rent quote
         // floors to zero this interval, do NOT advance the fee cursor, so a later
@@ -11087,8 +11197,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Ok(0);
         }
         account.header.source_domains[slot].source_lien_fee_last_slot =
-            V16PodU64::new(self.header.current_slot.get());
-        let mut bucket = self.backing_bucket_for_domain(domain)?;
+            V16PodU64::new(fee_through_slot);
         let (charged, next_capital, next_c_tot, next_earnings) =
             apply_backing_utilization_fee_charge(
                 account.header.capital.get(),
@@ -15806,6 +15915,58 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok((loss_settled, support_consumed, junior_face_burned))
     }
 
+    fn reconcile_recovery_forfeit_source_backing_expiry_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        asset_index: usize,
+        authenticated_slot: u64,
+    ) -> V16Result<()> {
+        if authenticated_slot < self.header.current_slot.get() {
+            return Err(V16Error::Stale);
+        }
+        let leg = Self::active_leg_for_asset(&account.as_view(), asset_index)?;
+        let source_domain = self.insurance_domain_index(asset_index, opposite_side(leg.side))?;
+        let Some(source_slot) = account.source_domain_slot(source_domain)? else {
+            return Ok(());
+        };
+        let source = account.header.source_domains[source_slot];
+        let bucket = self.backing_bucket_for_domain(source_domain)?;
+        let newly_lapsed = bucket.status == BackingBucketStatusV16::Fresh
+            && bucket.expiry_slot <= authenticated_slot;
+        let account_counterparty_backing = source.source_lien_counterparty_backing_num.get();
+        let impair_account = account_counterparty_backing != 0
+            && (newly_lapsed || bucket.status == BackingBucketStatusV16::Impaired);
+        if !newly_lapsed && !impair_account {
+            return Ok(());
+        }
+
+        if impair_account {
+            self.collect_account_backing_utilization_fee_for_domain_through_slot_not_atomic(
+                account,
+                source_domain,
+                authenticated_slot,
+            )?;
+        }
+        if newly_lapsed {
+            self.expire_source_backing_bucket_not_atomic(source_domain, authenticated_slot)?;
+        }
+        if impair_account {
+            let impaired_backing = self
+                .backing_bucket_for_domain(source_domain)?
+                .impaired_liened_backing_num;
+            if impaired_backing < account_counterparty_backing {
+                return Err(V16Error::CounterUnderflow);
+            }
+            let (impaired_source, _) = V16Core::prepare_account_counterparty_lien_impairment(
+                account.header.source_domains[source_slot],
+            )?;
+            account.header.source_domains[source_slot] = impaired_source;
+            account.header.health_cert.valid = 0;
+        }
+        account.validate_with_market(&self.as_view())?;
+        self.validate_shape()
+    }
+
     fn forfeit_materialized_positive_pnl_for_leg(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
@@ -15839,14 +16000,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // in the same transition as the lien release, so a backing provider
         // cannot withdraw between release and realization.
         if source_plan.release_valid_lien {
-            if source_plan.preserved_claim_bound_num != 0 && impaired_claim_bound_num != 0 {
-                return Err(V16Error::LockActive);
-            }
             self.release_account_source_credit_lien_for_domain_not_atomic(account, source_domain)?;
             source_slot = account
                 .source_domain_slot(source_domain)?
                 .ok_or(V16Error::InvalidLeg)?;
-            if source_plan.preserved_claim_bound_num != 0 {
+            if source_plan.preserved_claim_bound_num != 0 && impaired_claim_bound_num == 0 {
                 if source_slot != 0 {
                     account.header.source_domains.swap(0, source_slot);
                 }
@@ -15928,6 +16086,38 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         account.compact_source_domains();
         Ok(positive_pnl_forfeited)
+    }
+
+    pub fn forfeit_recovery_leg_at_slot_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        asset_index: usize,
+        b_delta_budget: u128,
+        authenticated_slot: u64,
+    ) -> V16Result<DeadLegForfeitOutcomeV16> {
+        account.validate_with_market(&self.as_view())?;
+        if asset_index >= self.header.config.max_market_slots.get() as usize
+            || asset_index >= self.markets.len()
+            || b_delta_budget == 0
+        {
+            return Err(V16Error::InvalidLeg);
+        }
+        if authenticated_slot < self.header.current_slot.get() {
+            return Err(V16Error::Stale);
+        }
+        let leg = Self::active_leg_for_asset(&account.as_view(), asset_index)?;
+        if !leg.active {
+            return Err(V16Error::InvalidLeg);
+        }
+        if !self.leg_is_dead_for_forfeit(asset_index, leg.side)? {
+            return Err(V16Error::LockActive);
+        }
+        self.reconcile_recovery_forfeit_source_backing_expiry_not_atomic(
+            account,
+            asset_index,
+            authenticated_slot,
+        )?;
+        self.forfeit_recovery_leg_not_atomic(account, asset_index, b_delta_budget)
     }
 
     pub fn forfeit_recovery_leg_not_atomic(

--- a/src/v16_proofs.rs
+++ b/src/v16_proofs.rs
@@ -55,6 +55,39 @@ fn closure_recovery_forfeit_source_plan_partitions_claim_without_overlap() {
     }
 }
 
+#[cfg(all(kani, feature = "closure"))]
+#[kani::proof]
+#[kani::unwind(4)]
+#[kani::solver(cadical)]
+fn closure_recovery_expiry_impairment_preserves_claim_and_effective_totals() {
+    let face = u128::from(kani::any::<u16>());
+    let effective = u128::from(kani::any::<u8>());
+    kani::assume(face != 0 && effective != 0);
+
+    let mut source = PortfolioSourceDomainV16Account::default();
+    source.source_claim_bound_num = V16PodU128::new(face);
+    source.source_claim_liened_num = V16PodU128::new(face);
+    source.source_claim_counterparty_liened_num = V16PodU128::new(face);
+    source.source_lien_effective_reserved = V16PodU128::new(effective);
+    source.source_lien_counterparty_backing_num = V16PodU128::new(effective * BOUND_SCALE);
+    source.source_lien_fee_last_slot = V16PodU64::new(1);
+
+    let (impaired, impaired_effective) =
+        V16Core::prepare_account_counterparty_lien_impairment(source).unwrap();
+    assert_eq!(impaired_effective, effective);
+    assert_eq!(impaired.source_claim_bound_num.get(), face);
+    assert_eq!(impaired.source_claim_liened_num.get(), 0);
+    assert_eq!(impaired.source_claim_counterparty_liened_num.get(), 0);
+    assert_eq!(impaired.source_claim_impaired_num.get(), face);
+    assert_eq!(impaired.source_lien_effective_reserved.get(), 0);
+    assert_eq!(
+        impaired.source_lien_impaired_effective_reserved.get(),
+        effective
+    );
+    assert_eq!(impaired.source_lien_counterparty_backing_num.get(), 0);
+    assert_eq!(impaired.source_lien_fee_last_slot.get(), 0);
+}
+
 // ===================== KANI FUNCTION-CONTRACT LAYER =====================
 // Built ONLY by scripts/contracts_runner.sh (cargo feature `contracts` +
 // CLI -Z function-contracts + a separate CARGO_TARGET_DIR). The main proof

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -769,6 +769,98 @@ fn v16_recovery_forfeit_nets_current_episode_b_before_prior_claim() {
 }
 
 #[test]
+fn v16_recovery_forfeit_at_slot_impairs_expired_backing_and_preserves_floor() {
+    const HISTORICAL_FACE: u128 = 48_000;
+    const LIEN_FACE: u128 = 50_000;
+    const BACKING: u128 = 200_000;
+    const EXPIRY_SLOT: u64 = 26;
+    let (mut header, mut markets, mut long_header, mut short_header) =
+        bankrupt_recovery_pair_fixture();
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+
+        market.full_account_refresh_not_atomic(&mut short).unwrap();
+        assert!(short.header.pnl.get() > HISTORICAL_FACE as i128);
+        market
+            .deposit_fresh_counterparty_backing_not_atomic(0, BACKING, EXPIRY_SLOT)
+            .unwrap();
+
+        let mut bucket = market.markets[0]
+            .engine
+            .backing_long
+            .try_to_runtime()
+            .unwrap();
+        bucket.fresh_unliened_backing_num -= LIEN_FACE * BOUND_SCALE;
+        bucket.valid_liened_backing_num += LIEN_FACE * BOUND_SCALE;
+        market.markets[0].engine.backing_long = BackingBucketV16Account::from_runtime(&bucket);
+
+        let mut source_credit = market.markets[0]
+            .engine
+            .source_credit_long
+            .try_to_runtime()
+            .unwrap();
+        source_credit.valid_liened_backing_num += LIEN_FACE * BOUND_SCALE;
+        market.markets[0].engine.source_credit_long =
+            SourceCreditStateV16Account::from_runtime(&source_credit);
+
+        let source = &mut short.header.source_domains[0];
+        source.active_leg_claim_floor_num = V16PodU128::new(HISTORICAL_FACE * BOUND_SCALE);
+        source.source_claim_liened_num = V16PodU128::new(LIEN_FACE * BOUND_SCALE);
+        source.source_claim_counterparty_liened_num = V16PodU128::new(LIEN_FACE * BOUND_SCALE);
+        source.source_lien_effective_reserved = V16PodU128::new(LIEN_FACE);
+        source.source_lien_counterparty_backing_num = V16PodU128::new(LIEN_FACE * BOUND_SCALE);
+        source.source_lien_fee_last_slot = V16PodU64::new(25);
+
+        market.validate_shape().unwrap();
+        short.validate_with_market(&market.as_view()).unwrap();
+        let capital_before = short.header.capital.get();
+        let bankrupt = market
+            .forfeit_recovery_leg_not_atomic(&mut long, 0, u128::MAX)
+            .unwrap();
+        assert!(bankrupt.detached);
+
+        let short_leg = short.header.legs[0].try_to_runtime().unwrap();
+        let asset = market.markets[0].engine.asset.try_to_runtime().unwrap();
+        let first_budget = (asset.b_short_num - short_leg.b_snap) / 2;
+        assert!(first_budget > 0);
+        let partial = market
+            .forfeit_recovery_leg_at_slot_not_atomic(&mut short, 0, first_budget, EXPIRY_SLOT + 1)
+            .expect("expiry reconciliation must compose with bounded B progress");
+        assert!(!partial.detached);
+
+        let winner = market
+            .forfeit_recovery_leg_at_slot_not_atomic(&mut short, 0, u128::MAX, EXPIRY_SLOT + 1)
+            .expect("authenticated expiry must not strand the remaining Recovery leg");
+        assert!(winner.detached);
+        assert_eq!(short.header.capital.get(), capital_before);
+        assert_eq!(short.header.pnl.get(), HISTORICAL_FACE as i128);
+        assert_eq!(
+            short.header.source_domains[0]
+                .source_claim_impaired_num
+                .get(),
+            HISTORICAL_FACE * BOUND_SCALE
+        );
+        assert_eq!(
+            short.header.source_domains[0].source_claim_liened_num.get(),
+            0
+        );
+        let expired_bucket = market.markets[0]
+            .engine
+            .backing_long
+            .try_to_runtime()
+            .unwrap();
+        assert_eq!(expired_bucket.status, BackingBucketStatusV16::Impaired);
+        assert_eq!(expired_bucket.valid_liened_backing_num, 0);
+        assert_eq!(expired_bucket.consumed_liened_backing_num, 0);
+        market.validate_shape().unwrap();
+        long.validate_with_market(&market.as_view()).unwrap();
+        short.validate_with_market(&market.as_view()).unwrap();
+    }
+}
+
+#[test]
 fn v16_recovery_forfeit_nets_pending_positive_kf_before_prior_claim() {
     const HISTORICAL_FACE: u128 = 48_000;
     let (mut header, mut markets, mut long_header, mut short_header) =


### PR DESCRIPTION
## Impact

A signed `ForfeitRecoveryLeg` transaction retained before a backing bucket expired could be landed after expiry. The Recovery capitalization path still treated the lapsed source lien as valid, allowing a claimant to consume an external provider's expired backing principal and withdraw it.

Public program reachability and the corresponding SBF regression are covered by aeyakovenko/percolator-prog#374.

## Root cause

The Recovery forfeit transition had no authenticated execution-slot input and did not reconcile source-bucket expiry before capitalizing a detached leg's claim. A cached pre-expiry market slot therefore remained sufficient after the transaction's actual execution slot crossed expiry.

## Change

- Add a slot-authenticated Recovery forfeit entry point.
- Reconcile expiry only for the selected source domain.
- Relabel the selected account's lapsed counterparty lien as impaired before capitalization.
- Cap utilization fees at the bucket's expiry slot.
- Preserve historical impaired claim floors while burning the current episode suffix when expired backing cannot lawfully fund it.
- Keep the existing API for callers that do not yet supply an authenticated slot.

This adds no custody path, admin authority, or DAO authority over user/provider funds.

## Validation

- Exact-base RED regression: `v16_recovery_forfeit_at_slot_impairs_expired_backing_and_preserves_floor`.
- Fixed engine suite: 50 unit + 9 backing fuzz + 2 resolved fuzz + 75 spec tests (136 total).
- Kani closure proof: `closure_recovery_expiry_impairment_preserves_claim_and_effective_totals`, 326 checks, 0 failures.
- `cargo fmt --all -- --check` and `git diff --check`.

Stacked on #168 because the test exercises the retained Recovery claim-floor semantics introduced there.