### PR TITLE
[REAL DoS] Preserve flat trade residual progress

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -171,8 +171,9 @@ pub fn v16_domain_pair_for_asset_index(asset_index: usize) -> V16Result<(usize, 
 /// account leg from which to choose a committed asset, so it must accrue a NEW
 /// price. `RefreshAccount { asset_index: Some(_) }` and EVERY other plan are
 /// dispatchable from committed on-chain state alone — `SettleBChunk` ignores
-/// price, `Liquidate` reads the current health cert, `DeclareRecovery` /
-/// `FinalizeRecovery` / `CloseResolved` / `NoAction` take no price — so a keeper
+/// price, `Liquidate` reads the current health cert, and `AdvanceClose` /
+/// `DeclareRecovery` / `FinalizeRecovery` / `CloseResolved` / `NoAction` take no
+/// price — so a keeper
 /// holding no fresh observation can still drive the account forward (no liveness
 /// stall). A wrapper may call this to decide whether it must source an oracle
 /// observation before cranking.
@@ -187,7 +188,8 @@ pub fn v16_domain_pair_for_asset_index(asset_index: usize) -> V16Result<(usize, 
 pub fn auto_crank_plan_requires_caller_observation(plan: &AutoCrankPlanV16) -> bool {
     match plan {
         AutoCrankPlanV16::RefreshAccount { asset_index } => asset_index.is_none(),
-        AutoCrankPlanV16::SettleBChunk { .. }
+        AutoCrankPlanV16::AdvanceClose
+        | AutoCrankPlanV16::SettleBChunk { .. }
         | AutoCrankPlanV16::Liquidate { .. }
         | AutoCrankPlanV16::DeclareRecovery { .. }
         | AutoCrankPlanV16::FinalizeRecovery
@@ -1744,12 +1746,9 @@ impl V16Core {
     /// bounded plan, carrying the engine-chosen asset (the caller chooses neither
     /// the action nor the asset). PROVES: TOTALITY (an actionable account yields a
     /// non-NoAction plan), PRIORITY DETERMINISM (the documented order: recovery >
-    /// resolved-close > b-stale settle > liquidate > refresh), and SELECTED-ASSET
-    /// fidelity (SettleBChunk/Liquidate carry exactly the provided engine-selected
-    /// slot). `pending_close` is classifier-unreachable (build_actionable_summary
-    /// never sets it — a leg-bearing pending close is liquidatable; see the
-    /// AdvanceClose note), so it is required absent here. Pure.
-    #[cfg_attr(all(kani, feature = "contracts"), kani::requires(!summary.pending_close))]
+    /// resolved-close > pending-close > b-stale settle > liquidate > refresh), and
+    /// SELECTED-ASSET fidelity (SettleBChunk/Liquidate carry exactly the provided
+    /// engine-selected slot). Pure.
     #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|r: &AutoCrankPlanV16| {
         let recovery = summary.expired_close || summary.recovery_eligible;
         match r {
@@ -1757,14 +1756,19 @@ impl V16Core {
             AutoCrankPlanV16::DeclareRecovery { reason } => recovery && *reason == recovery_reason,
             AutoCrankPlanV16::FinalizeRecovery => false,
             AutoCrankPlanV16::CloseResolved => !recovery && summary.resolved_winner,
+            AutoCrankPlanV16::AdvanceClose =>
+                !recovery && !summary.resolved_winner && summary.pending_close,
             AutoCrankPlanV16::SettleBChunk { asset_index } =>
-                !recovery && !summary.resolved_winner && summary.b_stale && *asset_index == b_stale_slot,
+                !recovery && !summary.resolved_winner && !summary.pending_close
+                    && summary.b_stale && *asset_index == b_stale_slot,
             AutoCrankPlanV16::Liquidate { asset_index } =>
-                !recovery && !summary.resolved_winner && !summary.b_stale && summary.liquidatable
+                !recovery && !summary.resolved_winner && !summary.pending_close
+                    && !summary.b_stale && summary.liquidatable
                     && *asset_index == liq_slot,
             AutoCrankPlanV16::RefreshAccount { asset_index } =>
-                !recovery && !summary.resolved_winner && !summary.b_stale && !summary.liquidatable
-                    && summary.stale && *asset_index == refresh_asset,
+                !recovery && !summary.resolved_winner && !summary.pending_close
+                    && !summary.b_stale && !summary.liquidatable && summary.stale
+                    && *asset_index == refresh_asset,
         }
     }))]
     pub(crate) fn select_auto_crank_plan(
@@ -1780,6 +1784,8 @@ impl V16Core {
             }
         } else if summary.resolved_winner {
             AutoCrankPlanV16::CloseResolved
+        } else if summary.pending_close {
+            AutoCrankPlanV16::AdvanceClose
         } else if summary.b_stale {
             AutoCrankPlanV16::SettleBChunk {
                 asset_index: b_stale_slot,
@@ -5175,6 +5181,7 @@ pub enum AutoCrankPlanV16 {
     Liquidate {
         asset_index: usize,
     },
+    AdvanceClose,
     DeclareRecovery {
         reason: PermissionlessRecoveryReasonV16,
     },
@@ -12368,7 +12375,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     ///   pending_close    — Live, a close-progress ledger is active
     ///   expired_close    — Live, that ledger is past its max-close slot
     ///   liquidatable     — Live, current cert with nonzero certified liq deficit
-    ///   recovery_eligible— reserved for selector-level proactive Recovery
+    ///   recovery_eligible— Live sticky-h-lock completion or an unattributed
+    ///                      flat deficit that requires terminal Recovery
     ///   resolved_winner  — Resolved, positive PnL, resolved payout ready
     /// Assembled via the proven actionable_summary_from_signals kernel. Live-only
     /// flags need cert currentness only where their entrypoint does (liquidate),
@@ -12412,19 +12420,14 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // A close ledger with residual_remaining==0 is already fully booked/covered
         // (e.g. insurance absorbed the loss); only OUTSTANDING residual is real,
         // actionable close work. The `active` flag can linger past that.
-        let close_outstanding = ledger.active && ledger.residual_remaining > 0;
+        let close_outstanding = ledger.has_pending_residual();
         let stale = live && (!cert_current || reset_obligation_asset.is_some());
         let b_stale = live && Self::has_b_stale_leg(account)?;
-        // pending_close is NOT proactively classified: the close-ledger residual is
-        // booked ONLY inside the liquidation/resolved path that owns it
-        // (book_bankruptcy_residual_chunk_for_account_core) — settle_account_b_chunk
-        // does not touch it, so an AdvanceClose->SettleB dispatch would not advance
-        // the ledger. An outstanding Live close with a leg is liquidatable (the
-        // residual is an open deficit), so the Liquidate continuation books the
-        // residual chunk; the leg-less / expired cases are handled by expired_close
-        // -> recovery or are the documented backstopped A3 route. AdvanceClose is
-        // therefore classifier-unreachable (the proven selector still admits it).
-        let pending_close = false;
+        // A durable close ledger is independently actionable even after the trade
+        // that created it cleared the bankrupt leg. AdvanceClose infers the asset
+        // and bankrupt side from this immutable ledger, so no caller hint can
+        // redirect the residual.
+        let pending_close = live && close_outstanding;
         // Expired outstanding close -> terminal recovery (Recover needs no leg).
         let expired_close =
             live && close_outstanding && self.header.current_slot.get() > ledger.max_close_slot;
@@ -12439,17 +12442,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             && cert.certified_liq_deficit != 0
             && has_open_risk
             && reset_obligation_asset.is_none();
-        // Permissionless recovery (declare_permissionless_recovery) is a LIVE-mode
-        // action — it rejects Resolved mode with LockActive. The proactive Live
-        // recovery condition the auto-crank declares is an EXPIRED outstanding
-        // close (expired_close -> DeclareRecovery, reason
-        // ActiveBankruptCloseCannotProgress); every other recovery reason is
-        // declared REACTIVELY inside the dispatched crank op when it detects
-        // non-progress (BIndexHeadroomExhausted, etc.). Resolved bad-debt
-        // wind-down is handled by CloseResolved itself, not by the recovery
-        // selector flag, so recovery_eligible stays in the summary type for the
-        // proven selector but is driven by expired_close.
-        let recovery_eligible = false;
+        // Bankruptcy h-lock is intentionally sticky in Live mode. Once every
+        // negative-PnL account has been durably settled, there is no further Live
+        // work that can clear it. A flat negative account without a durable close
+        // ledger has also lost asset-local attribution, so it must not charge an
+        // arbitrary domain. Both states route to terminal Recovery instead of
+        // leaving favorable actions locked or inventing attribution.
+        let flat_unattributed_deficit = account.header.pnl.get() < 0
+            && active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get));
+        let recovery_eligible = live
+            && decode_bool(self.header.bankruptcy_hlock_active)?
+            && !close_outstanding
+            && (self.header.negative_pnl_account_count.get() == 0 || flat_unattributed_deficit);
         // resolved_winner routes to close_resolved, which LAZILY captures the
         // payout snapshot itself (initialize_resolved_payout_ledger_if_needed is
         // reached only via close_resolved -> create_resolved_payout_receipt) — so
@@ -12605,7 +12609,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         let (summary, (b_stale_asset, refresh_asset, liquidatable_asset, _)) =
             self.build_actionable_summary_and_selected_assets(&account.as_view())?;
-        let recovery_reason = if summary.expired_close {
+        let recovery_reason = if summary.expired_close || summary.recovery_eligible {
             PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
         } else {
             PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow
@@ -12700,6 +12704,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     obs,
                     PermissionlessCrankActionV16::Liquidate(LiquidationRequestV16 { asset_index }),
                 )?)
+            }
+            AutoCrankPlanV16::AdvanceClose => {
+                let progressed = match self.advance_pending_close_residual_not_atomic(account) {
+                    Ok(outcome) => outcome,
+                    Err(error) => {
+                        let mode = decode_market_mode(self.header.mode)?;
+                        let reason = self.header.recovery_reason.try_to_runtime()?;
+                        V16Core::kernel_commit_declared_liquidation_recovery(error, mode, reason)?
+                    }
+                };
+                AutoCrankOutcomeV16::Progressed(progressed)
             }
             AutoCrankPlanV16::DeclareRecovery { reason } => {
                 // recovery declaration needs no observation.
@@ -13644,18 +13659,28 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &mut PortfolioV16ViewMut<'_>,
         asset_index: usize,
     ) -> V16Result<()> {
+        self.clear_leg_inner(account, asset_index, false)
+    }
+
+    fn clear_leg_inner(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        asset_index: usize,
+        allow_attributed_terminal_trade: bool,
+    ) -> V16Result<()> {
         let leg_slot = Self::require_active_leg_slot_for_asset(&account.as_view(), asset_index)?;
         let leg = account.header.legs[leg_slot].try_to_runtime()?;
         if !leg.active || leg.b_stale || leg.stale {
             return Err(V16Error::InvalidLeg);
         }
-        if account
-            .header
-            .close_progress
-            .try_to_runtime()?
-            .has_pending_residual()
-        {
-            return Err(V16Error::LockActive);
+        let close_progress = account.header.close_progress.try_to_runtime()?;
+        if close_progress.has_pending_residual() {
+            let attributed_terminal_trade = allow_attributed_terminal_trade
+                && close_progress.asset_index as usize == asset_index
+                && close_progress.domain_side == opposite_side(leg.side);
+            if !attributed_terminal_trade {
+                return Err(V16Error::LockActive);
+            }
         }
         if self.has_pending_domain_loss_barrier(asset_index, leg.side)? {
             return Err(V16Error::LockActive);
@@ -13851,7 +13876,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 self.set_asset_state(asset_index, asset)?;
                 return Ok(());
             }
-            return self.clear_leg(account, asset_index);
+            return self.clear_leg_inner(account, asset_index, !settle_existing);
         }
         if route == PositionRouteV16::Flip {
             self.require_asset_risk_change_allowed(asset_index, true)?;
@@ -14250,6 +14275,61 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             outcome.booked_loss,
             outcome.explicit_loss,
         )?;
+        Ok(outcome)
+    }
+
+    fn advance_pending_close_residual_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+    ) -> V16Result<PermissionlessProgressOutcomeV16> {
+        account.validate_with_market(&self.as_view())?;
+        if decode_market_mode(self.header.mode)? != MarketModeV16::Live {
+            return Err(V16Error::LockActive);
+        }
+        let ledger_before = account.header.close_progress.try_to_runtime()?;
+        if !ledger_before.has_pending_residual() {
+            return Err(V16Error::NonProgress);
+        }
+        self.ensure_close_progress_not_expired(ledger_before)?;
+        let asset_index = ledger_before.asset_index as usize;
+        let bankrupt_side = opposite_side(ledger_before.domain_side);
+
+        self.settle_negative_pnl_from_principal_core_not_atomic(account)?;
+        let insurance_used =
+            self.consume_domain_insurance_for_negative_pnl(asset_index, bankrupt_side, account)?;
+        if insurance_used != 0 {
+            self.advance_close_progress_ledger(account, 0, 0, insurance_used, 0, 0)?;
+        }
+
+        let residual = if account.header.pnl.get() < 0 {
+            account.header.pnl.get().unsigned_abs()
+        } else {
+            0
+        };
+        let outcome = if residual != 0 {
+            let outcome = self.book_bankruptcy_residual_chunk_for_account_core(
+                account,
+                asset_index,
+                bankrupt_side,
+                residual,
+            )?;
+            let new_pnl = V16Core::kernel_settle_resolved_pnl_after_booking(
+                account.header.pnl.get(),
+                outcome.booked_loss,
+                outcome.explicit_loss,
+            )?;
+            self.set_account_pnl(account, new_pnl)?;
+            PermissionlessProgressOutcomeV16::ResidualBooked(outcome)
+        } else {
+            PermissionlessProgressOutcomeV16::AccountCurrent
+        };
+
+        let ledger_after = account.header.close_progress.try_to_runtime()?;
+        if ledger_after.residual_remaining >= ledger_before.residual_remaining {
+            return Err(V16Error::NonProgress);
+        }
+        self.validate_account_audit_scan(&account.as_view())?;
+        self.validate_shape_audit_scan()?;
         Ok(outcome)
     }
 
@@ -14785,12 +14865,72 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(cert)
     }
 
+    fn terminal_trade_residual_asset_before_refresh(
+        account: &PortfolioV16View<'_>,
+    ) -> V16Result<Option<usize>> {
+        if account.header.pnl.get() < 0
+            || account
+                .header
+                .close_progress
+                .try_to_runtime()?
+                .has_pending_residual()
+            || active_bitmap_count_ones(account.header.active_bitmap.map(V16PodU64::get)) != 1
+        {
+            return Ok(None);
+        }
+        let mut slot = 0usize;
+        while slot < V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg = account.header.legs[slot].try_to_runtime()?;
+            if leg.active {
+                return Ok(Some(leg.asset_index as usize));
+            }
+            slot += 1;
+        }
+        Err(V16Error::HiddenLeg)
+    }
+
+    fn begin_terminal_trade_residual_if_needed(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+        asset_index: usize,
+        lookup: PositionDeltaLookupV16,
+        is_final_batch_fill: bool,
+        attributable_asset_before_refresh: Option<usize>,
+    ) -> V16Result<()> {
+        if !is_final_batch_fill
+            || attributable_asset_before_refresh != Some(asset_index)
+            || lookup.current_q == 0
+            || lookup.next_q != 0
+            || account.header.pnl.get() >= 0
+            || active_bitmap_count_ones(account.header.active_bitmap.map(V16PodU64::get)) != 1
+        {
+            return Ok(());
+        }
+        let leg_slot = lookup.existing_slot.ok_or(V16Error::InvalidLeg)?;
+        let leg = account.header.legs[leg_slot].try_to_runtime()?;
+        if !leg.active
+            || leg.asset_index as usize != asset_index
+            || signed_position(leg) != lookup.current_q
+        {
+            return Err(V16Error::InvalidLeg);
+        }
+        self.begin_close_progress_ledger(
+            account,
+            asset_index,
+            opposite_side(leg.side),
+            account.header.pnl.get().unsigned_abs(),
+        )
+    }
+
     fn apply_trade_after_refresh_not_atomic(
         &mut self,
         long_account: &mut PortfolioV16ViewMut<'_>,
         short_account: &mut PortfolioV16ViewMut<'_>,
         request: TradeRequestV16,
         recertify_after_fill: bool,
+        is_final_batch_fill: bool,
+        long_attributable_asset_before_refresh: Option<usize>,
+        short_attributable_asset_before_refresh: Option<usize>,
     ) -> V16Result<TradeApplyOutcomeV16> {
         let (abs_size_q, long_delta, short_delta) = Self::trade_signed_size_deltas(request.size_q)?;
         let trade_preflight = self.validate_trade_position_preflight(
@@ -14805,6 +14945,20 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let fee = checked_fee_bps(fee_notional, request.fee_bps)?;
         let fee_a = self.charge_account_fee_current_not_atomic(long_account, fee)?;
         let fee_b = self.charge_account_fee_current_not_atomic(short_account, fee)?;
+        self.begin_terminal_trade_residual_if_needed(
+            long_account,
+            request.asset_index,
+            trade_preflight.long_lookup,
+            is_final_batch_fill,
+            long_attributable_asset_before_refresh,
+        )?;
+        self.begin_terminal_trade_residual_if_needed(
+            short_account,
+            request.asset_index,
+            trade_preflight.short_lookup,
+            is_final_batch_fill,
+            short_attributable_asset_before_refresh,
+        )?;
         self.apply_current_position_delta_with_lookup(
             long_account,
             request.asset_index,
@@ -14993,6 +15147,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             self.validate_trade_request(requests[i])?;
             i += 1;
         }
+        // Residual attribution is sound only when the account entered this
+        // public batch nonnegative with exactly one live asset. A pre-existing
+        // deficit or multi-asset account has lost per-domain provenance in the
+        // account-global PnL scalar; if it later becomes flat, auto-crank routes
+        // it to conservative terminal Recovery instead of charging the last
+        // touched asset.
+        let long_attributable_asset_before_refresh =
+            Self::terminal_trade_residual_asset_before_refresh(&long_account.as_view())?;
+        let short_attributable_asset_before_refresh =
+            Self::terminal_trade_residual_asset_before_refresh(&short_account.as_view())?;
         self.settle_account_for_position_action_and_refresh_not_atomic(long_account)?;
         self.settle_account_for_position_action_and_refresh_not_atomic(short_account)?;
 
@@ -15017,6 +15181,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 short_account,
                 requests[i],
                 recertify_after_fill,
+                i + 1 == requests.len(),
+                long_attributable_asset_before_refresh,
+                short_attributable_asset_before_refresh,
             )?;
             long_requires_initial_margin |= applied.long_requires_initial_margin;
             short_requires_initial_margin |= applied.short_requires_initial_margin;

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -15144,9 +15144,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         // Residual attribution is sound only when the account entered this
         // public batch nonnegative with exactly one live asset. A pre-existing
         // deficit or multi-asset account has lost per-domain provenance in the
-        // account-global PnL scalar; if it later becomes flat, auto-crank routes
-        // it to conservative terminal Recovery instead of charging the last
-        // touched asset.
+        // account-global PnL scalar; if it later becomes flat, it waits for the
+        // explicit market-level resolution policy instead of charging the last
+        // touched asset or letting one account force market-wide Recovery.
         let long_attributable_asset_before_refresh =
             Self::terminal_trade_residual_asset_before_refresh(&long_account.as_view())?;
         let short_attributable_asset_before_refresh =

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -12375,8 +12375,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     ///   pending_close    — Live, a close-progress ledger is active
     ///   expired_close    — Live, that ledger is past its max-close slot
     ///   liquidatable     — Live, current cert with nonzero certified liq deficit
-    ///   recovery_eligible— Live sticky-h-lock completion or an unattributed
-    ///                      flat deficit that requires terminal Recovery
+    ///   recovery_eligible— reserved for selector-level proactive Recovery
     ///   resolved_winner  — Resolved, positive PnL, resolved payout ready
     /// Assembled via the proven actionable_summary_from_signals kernel. Live-only
     /// flags need cert currentness only where their entrypoint does (liquidate),
@@ -12442,18 +12441,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             && cert.certified_liq_deficit != 0
             && has_open_risk
             && reset_obligation_asset.is_none();
-        // Bankruptcy h-lock is intentionally sticky in Live mode. Once every
-        // negative-PnL account has been durably settled, there is no further Live
-        // work that can clear it. A flat negative account without a durable close
-        // ledger has also lost asset-local attribution, so it must not charge an
-        // arbitrary domain. Both states route to terminal Recovery instead of
-        // leaving favorable actions locked or inventing attribution.
-        let flat_unattributed_deficit = account.header.pnl.get() < 0
-            && active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get));
-        let recovery_eligible = live
-            && decode_bool(self.header.bankruptcy_hlock_active)?
-            && !close_outstanding
-            && (self.header.negative_pnl_account_count.get() == 0 || flat_unattributed_deficit);
+        // A completed account-local bankruptcy must not let that account force a
+        // market-wide Recovery. In particular, a permissionless asset can be
+        // attacker-controlled while unrelated assets remain healthy. Outstanding
+        // close expiry remains the proactive Recovery route above; completed or
+        // unattributed deficits wait for an explicit market-level resolution
+        // policy instead of inventing an asset domain or terminating the market.
+        let recovery_eligible = false;
         // resolved_winner routes to close_resolved, which LAZILY captures the
         // payout snapshot itself (initialize_resolved_payout_ledger_if_needed is
         // reached only via close_resolved -> create_resolved_payout_receipt) — so

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -1168,11 +1168,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         request: TradeRequestV16,
         recertify_after_fill: bool,
     ) -> V16Result<(u128, u128, u128, bool)> {
+        let long_attributable_asset_before_refresh =
+            Self::terminal_trade_residual_asset_before_refresh(&long_account.as_view())?;
+        let short_attributable_asset_before_refresh =
+            Self::terminal_trade_residual_asset_before_refresh(&short_account.as_view())?;
         let out = self.apply_trade_after_refresh_not_atomic(
             long_account,
             short_account,
             request,
             recertify_after_fill,
+            true,
+            long_attributable_asset_before_refresh,
+            short_attributable_asset_before_refresh,
         )?;
         Ok((out.fee_a, out.fee_b, out.notional, out.risk_increasing))
     }

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -16179,7 +16179,11 @@ fn proof_v16_auto_crank_pending_close_priority_is_total() {
         }
     );
 
-    let unattributed_flat_deficit = kani_select_auto_crank_plan(
+    // The selector remains total for a generic proactive-Recovery summary. The
+    // production classifier does not derive this flag from an account-local
+    // completed or unattributed deficit, because that would grant one account
+    // market-wide termination authority.
+    let proactive_recovery = kani_select_auto_crank_plan(
         ActionableSummaryV16 {
             stale: false,
             b_stale: false,
@@ -16195,7 +16199,7 @@ fn proof_v16_auto_crank_pending_close_priority_is_total() {
         PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
     );
     assert_eq!(
-        unattributed_flat_deficit,
+        proactive_recovery,
         AutoCrankPlanV16::DeclareRecovery {
             reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
         }

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -16104,7 +16104,7 @@ fn proof_v16_validator_sound_account_reserves() {
 // asset refresh and every other plan are dispatchable from committed state.
 // Pinning this truth table means a future arm that gates committed-state progress
 // on an observation contradicts a machine-checked theorem. Exhaustive over the
-// seven AutoCrankPlanV16 variants; the spec matrix ties the predicate to the real
+// eight AutoCrankPlanV16 variants; the spec matrix ties the predicate to the real
 // dispatch for each reachable class.
 #[kani::proof]
 fn proof_v16_auto_crank_refresh_is_unique_observation_requiring_plan() {
@@ -16124,6 +16124,7 @@ fn proof_v16_auto_crank_refresh_is_unique_observation_requiring_plan() {
         asset_index: i
     }));
     assert!(!needs_obs(&AutoCrankPlanV16::Liquidate { asset_index: i }));
+    assert!(!needs_obs(&AutoCrankPlanV16::AdvanceClose));
     assert!(!needs_obs(&AutoCrankPlanV16::NoAction));
     assert!(!needs_obs(&AutoCrankPlanV16::FinalizeRecovery));
     assert!(!needs_obs(&AutoCrankPlanV16::CloseResolved));
@@ -16132,6 +16133,73 @@ fn proof_v16_auto_crank_refresh_is_unique_observation_requiring_plan() {
     assert!(!needs_obs(&AutoCrankPlanV16::DeclareRecovery {
         reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
     }));
+}
+
+// Pending close is a production-dispatchable class, not merely a proof-summary
+// placeholder. It outranks B settlement, liquidation, and refresh, but remains
+// below terminal recovery and resolved close in the selector.
+#[kani::proof]
+fn proof_v16_auto_crank_pending_close_priority_is_total() {
+    let lower = kani_select_auto_crank_plan(
+        ActionableSummaryV16 {
+            stale: true,
+            b_stale: true,
+            pending_close: true,
+            expired_close: false,
+            liquidatable: true,
+            recovery_eligible: false,
+            resolved_winner: false,
+        },
+        3,
+        4,
+        Some(5),
+        PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+    );
+    assert_eq!(lower, AutoCrankPlanV16::AdvanceClose);
+
+    let terminal = kani_select_auto_crank_plan(
+        ActionableSummaryV16 {
+            stale: true,
+            b_stale: true,
+            pending_close: true,
+            expired_close: true,
+            liquidatable: true,
+            recovery_eligible: false,
+            resolved_winner: true,
+        },
+        3,
+        4,
+        Some(5),
+        PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+    );
+    assert_eq!(
+        terminal,
+        AutoCrankPlanV16::DeclareRecovery {
+            reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+        }
+    );
+
+    let unattributed_flat_deficit = kani_select_auto_crank_plan(
+        ActionableSummaryV16 {
+            stale: false,
+            b_stale: false,
+            pending_close: false,
+            expired_close: false,
+            liquidatable: false,
+            recovery_eligible: true,
+            resolved_winner: false,
+        },
+        0,
+        0,
+        None,
+        PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+    );
+    assert_eq!(
+        unattributed_flat_deficit,
+        AutoCrankPlanV16::DeclareRecovery {
+            reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+        }
+    );
 }
 
 // LoF — no free open interest: a risk-increasing fill with nonzero size, nonzero

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -4255,7 +4255,7 @@ fn v16_auto_crank_drives_stale_underwater_account_to_derisked_fixed_point() {
 }
 
 #[test]
-fn v16_trade_final_leg_residual_routes_through_close_and_terminal_recovery() {
+fn v16_trade_final_leg_residual_routes_through_close_without_forcing_market_recovery() {
     const SIZE_Q: u128 = 10 * POS_SCALE;
     let (mut header, mut markets) = market_fixture(1, 100);
     header.config.maintenance_margin_bps = V16PodU64::new(1_000);
@@ -4341,21 +4341,39 @@ fn v16_trade_final_leg_residual_routes_through_close_and_terminal_recovery() {
     let finalized = short.header.close_progress.try_to_runtime().unwrap();
     assert!(finalized.active && finalized.finalized && finalized.residual_remaining == 0);
 
-    let recovery = market
-        .permissionless_auto_crank_not_atomic(&mut short, work)
-        .expect("sticky bankruptcy lock must route to terminal recovery");
+    let observations = [AutoCrankObservationV16 {
+        asset_index: 0,
+        effective_price: 150,
+        funding_rate_e9: 0,
+    }];
+    let normalized = market
+        .permissionless_auto_crank_not_atomic(
+            &mut short,
+            AutoCrankWorkV16 {
+                now_slot: work.now_slot,
+                observations: &observations,
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("the completed close account must normalize its stale certificate");
     assert_eq!(
-        recovery.selected,
-        AutoCrankPlanV16::DeclareRecovery {
-            reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
-        }
+        normalized.selected,
+        AutoCrankPlanV16::RefreshAccount { asset_index: None }
     );
-    assert_eq!(market.header.mode, 2);
 
-    let resolved = market
+    let no_forced_recovery = market
         .permissionless_auto_crank_not_atomic(&mut short, work)
-        .expect("recovery must finalize permissionlessly");
-    assert_eq!(resolved.selected, AutoCrankPlanV16::FinalizeRecovery);
+        .expect("a completed account close is not market-wide recovery authority");
+    assert_eq!(
+        no_forced_recovery.selected,
+        AutoCrankPlanV16::NoAction,
+        "completed residual work must not terminate unrelated market activity"
+    );
+    assert_eq!(market.header.mode, 0);
+
+    market
+        .resolve_market_not_atomic(work.now_slot)
+        .expect("an explicit market-level transition can start terminal settlement");
     assert_eq!(market.header.mode, 1);
 
     let loser_close = market
@@ -4473,7 +4491,7 @@ fn v16_batch_trade_starts_terminal_residual_only_at_final_fill() {
 }
 
 #[test]
-fn v16_trade_does_not_charge_prior_multi_asset_deficit_to_last_closed_asset() {
+fn v16_trade_does_not_charge_prior_multi_asset_deficit_or_force_market_recovery() {
     const SIZE_Q: u128 = 10 * POS_SCALE;
     let (mut header, mut markets) = market_fixture(2, 100);
     header.config.maintenance_margin_bps = V16PodU64::new(1_000);
@@ -4554,28 +4572,25 @@ fn v16_trade_does_not_charge_prior_multi_asset_deficit_to_last_closed_asset() {
     let ledger = short.header.close_progress.try_to_runtime().unwrap();
     assert_eq!(ledger.residual_remaining, 0);
     assert!(
-        market
+        !market
             .build_actionable_summary(&short.as_view())
             .unwrap()
             .recovery_eligible,
-        "an unattributed flat deficit must recover, not charge asset 1"
+        "an unattributed account must not gain authority to recover the whole market"
     );
 
-    let work = AutoCrankWorkV16 {
-        now_slot: market.header.current_slot.get(),
-        observations: &[],
-        resolved_close_fee_rate_per_slot: 0,
-    };
-    let recovery = market
-        .permissionless_auto_crank_not_atomic(&mut short, work)
-        .expect("unattributed flat deficit must have a terminal continuation");
-    assert_eq!(
-        recovery.selected,
-        AutoCrankPlanV16::DeclareRecovery {
-            reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
-        }
-    );
-    assert_eq!(market.header.mode, 2);
+    assert_eq!(market.header.mode, 0);
+    market
+        .resolve_market_not_atomic(market.header.current_slot.get())
+        .expect("explicit market resolution handles unattributed terminal debt");
+    let loser_close = market
+        .close_resolved_account_not_atomic(&mut short, 0)
+        .expect("resolved settlement clears unattributed negative PnL without domain guessing");
+    assert!(matches!(
+        loser_close,
+        percolator::ResolvedCloseOutcomeV16::Closed { payout: 0 }
+    ));
+    assert_eq!(short.header.pnl.get(), 0);
     market.validate_shape().unwrap();
     long.validate_with_market(&market.as_view()).unwrap();
     short.validate_with_market(&market.as_view()).unwrap();

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -1,6 +1,6 @@
 use percolator::{
-    auto_crank_plan_requires_caller_observation, AutoCrankObservationV16, AutoCrankOutcomeV16,
-    AutoCrankPlanV16, AutoCrankWorkV16,
+    active_bitmap_is_empty, auto_crank_plan_requires_caller_observation, AutoCrankObservationV16,
+    AutoCrankOutcomeV16, AutoCrankPlanV16, AutoCrankWorkV16,
 };
 use percolator::{
     v16_domain_count_for_market_slots, AssetLifecycleV16, AssetStateV16Account,
@@ -15,6 +15,8 @@ use percolator::{
     V16Config, V16Error, V16OptionalRecoveryReasonAccount, V16PodI128, V16PodU128, V16PodU32,
     V16PodU64, V16_EMPTY_ACTIVE_BITMAP,
 };
+#[cfg(feature = "fuzz")]
+use percolator::{PermissionlessCrankActionV16, PermissionlessCrankRequestV16};
 use percolator::{ADL_ONE, BOUND_SCALE, CREDIT_RATE_SCALE, POS_SCALE};
 
 const FUNDING_COUNTER_PRICE: u64 = 1_000_000;
@@ -4253,6 +4255,333 @@ fn v16_auto_crank_drives_stale_underwater_account_to_derisked_fixed_point() {
 }
 
 #[test]
+fn v16_trade_final_leg_residual_routes_through_close_and_terminal_recovery() {
+    const SIZE_Q: u128 = 10 * POS_SCALE;
+    let (mut header, mut markets) = market_fixture(1, 100);
+    header.config.maintenance_margin_bps = V16PodU64::new(1_000);
+    header.config.initial_margin_bps = V16PodU64::new(1_000);
+    header.config.max_price_move_bps_per_slot = V16PodU64::new(500);
+    header.config.max_accrual_dt_slots = V16PodU64::new(1);
+    header.config.min_funding_lifetime_slots = V16PodU64::new(1);
+    let mut long_header = account_fixture(1, 61);
+    let mut short_header = account_fixture(1, 62);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market.deposit_not_atomic(&mut long, 1_000).unwrap();
+    market.deposit_not_atomic(&mut short, 250).unwrap();
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: signed_q(SIZE_Q),
+                exec_price: 100,
+                fee_bps: 0,
+            },
+        )
+        .unwrap();
+    for (offset, price) in (105u64..=150).step_by(5).enumerate() {
+        let slot = 2 + offset as u64;
+        market
+            .set_asset_raw_oracle_target_not_atomic(0, price)
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(0, slot, price, 0, true)
+            .unwrap();
+    }
+
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: -signed_q(SIZE_Q),
+                exec_price: 150,
+                fee_bps: 0,
+            },
+        )
+        .expect("risk-reducing final trade must remain available");
+
+    let pending = short.header.close_progress.try_to_runtime().unwrap();
+    assert!(active_bitmap_is_empty(
+        short.header.active_bitmap.map(V16PodU64::get)
+    ));
+    assert_eq!(short.header.capital.get(), 0);
+    assert_eq!(short.header.pnl.get(), -250);
+    assert!(pending.active && !pending.finalized && pending.residual_remaining != 0);
+    assert_eq!(pending.asset_index, 0);
+    assert_eq!(pending.domain_side, SideV16::Long);
+    assert_eq!(pending.residual_remaining, 250);
+    assert!(
+        market
+            .build_actionable_summary(&short.as_view())
+            .unwrap()
+            .pending_close
+    );
+
+    let work = AutoCrankWorkV16 {
+        now_slot: 11,
+        observations: &[],
+        resolved_close_fee_rate_per_slot: 0,
+    };
+    let booked = market
+        .permissionless_auto_crank_not_atomic(&mut short, work)
+        .expect("pending close must have a committed-state continuation");
+    assert_eq!(booked.selected, AutoCrankPlanV16::AdvanceClose);
+    assert!(matches!(
+        booked.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::ResidualBooked(_))
+    ));
+    assert_eq!(short.header.pnl.get(), 0);
+    assert_eq!(market.header.negative_pnl_account_count.get(), 0);
+    let finalized = short.header.close_progress.try_to_runtime().unwrap();
+    assert!(finalized.active && finalized.finalized && finalized.residual_remaining == 0);
+
+    let recovery = market
+        .permissionless_auto_crank_not_atomic(&mut short, work)
+        .expect("sticky bankruptcy lock must route to terminal recovery");
+    assert_eq!(
+        recovery.selected,
+        AutoCrankPlanV16::DeclareRecovery {
+            reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+        }
+    );
+    assert_eq!(market.header.mode, 2);
+
+    let resolved = market
+        .permissionless_auto_crank_not_atomic(&mut short, work)
+        .expect("recovery must finalize permissionlessly");
+    assert_eq!(resolved.selected, AutoCrankPlanV16::FinalizeRecovery);
+    assert_eq!(market.header.mode, 1);
+
+    let loser_close = market
+        .close_resolved_account_not_atomic(&mut short, 0)
+        .expect("the flat bankrupt account must close in Resolved mode");
+    assert!(matches!(
+        loser_close,
+        percolator::ResolvedCloseOutcomeV16::Closed { payout: 0 }
+    ));
+    let mut winner_closed = false;
+    let mut last_winner_close = None;
+    for _ in 0..8 {
+        let close = market
+            .close_resolved_account_not_atomic(&mut long, 0)
+            .expect("the loss-side obligation must make bounded resolved progress");
+        last_winner_close = Some(close);
+        if matches!(close, percolator::ResolvedCloseOutcomeV16::Closed { .. }) {
+            winner_closed = true;
+            break;
+        }
+    }
+    assert!(
+        winner_closed,
+        "the winner must reach terminal payout finitely: last={last_winner_close:?}, \
+         blockers={}, b_stale={}, stale={}, pnl={}, capital={}, bitmap={:?}, asset={:?}",
+        market.header.resolved_payout_blocker_count.get(),
+        long.header.b_stale_state,
+        long.header.stale_state,
+        long.header.pnl.get(),
+        long.header.capital.get(),
+        long.header.active_bitmap,
+        market.markets[0].engine.asset.try_to_runtime().unwrap(),
+    );
+    assert!(active_bitmap_is_empty(
+        long.header.active_bitmap.map(V16PodU64::get)
+    ));
+    assert_eq!(long.header.capital.get(), 0);
+    assert_eq!(long.header.pnl.get(), 0);
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+    short.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_batch_trade_starts_terminal_residual_only_at_final_fill() {
+    const HALF_Q: u128 = 5 * POS_SCALE;
+    let (mut header, mut markets) = market_fixture(2, 100);
+    header.config.maintenance_margin_bps = V16PodU64::new(1_000);
+    header.config.initial_margin_bps = V16PodU64::new(1_000);
+    header.config.max_price_move_bps_per_slot = V16PodU64::new(500);
+    header.config.max_accrual_dt_slots = V16PodU64::new(1);
+    header.config.min_funding_lifetime_slots = V16PodU64::new(1);
+    let mut long_header = account_fixture(2, 63);
+    let mut short_header = account_fixture(2, 64);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market.deposit_not_atomic(&mut long, 1_000).unwrap();
+    market.deposit_not_atomic(&mut short, 250).unwrap();
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: signed_q(2 * HALF_Q),
+                exec_price: 100,
+                fee_bps: 0,
+            },
+        )
+        .unwrap();
+    for (offset, price) in (105u64..=150).step_by(5).enumerate() {
+        let slot = 2 + offset as u64;
+        market
+            .set_asset_raw_oracle_target_not_atomic(0, price)
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(0, slot, price, 0, true)
+            .unwrap();
+    }
+
+    let outcome = market
+        .execute_batch_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            &[
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: -signed_q(HALF_Q),
+                    exec_price: 150,
+                    fee_bps: 0,
+                },
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: -signed_q(HALF_Q),
+                    exec_price: 150,
+                    fee_bps: 0,
+                },
+            ],
+        )
+        .expect("an intermediate partial close must not lock the final fill");
+
+    assert_eq!(outcome.fill_count, 2);
+    let pending = short.header.close_progress.try_to_runtime().unwrap();
+    assert_eq!(pending.close_id, 1);
+    assert_eq!(pending.gross_loss_at_close_start, 250);
+    assert_eq!(pending.residual_remaining, 250);
+    assert!(active_bitmap_is_empty(
+        short.header.active_bitmap.map(V16PodU64::get)
+    ));
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+    short.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
+fn v16_trade_does_not_charge_prior_multi_asset_deficit_to_last_closed_asset() {
+    const SIZE_Q: u128 = 10 * POS_SCALE;
+    let (mut header, mut markets) = market_fixture(2, 100);
+    header.config.maintenance_margin_bps = V16PodU64::new(1_000);
+    header.config.initial_margin_bps = V16PodU64::new(1_000);
+    header.config.max_price_move_bps_per_slot = V16PodU64::new(500);
+    header.config.max_accrual_dt_slots = V16PodU64::new(1);
+    header.config.min_funding_lifetime_slots = V16PodU64::new(1);
+    let mut long_header = account_fixture(2, 65);
+    let mut short_header = account_fixture(2, 66);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    market.deposit_not_atomic(&mut long, 2_000).unwrap();
+    market.deposit_not_atomic(&mut short, 250).unwrap();
+    for asset_index in 0..2 {
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index,
+                    size_q: signed_q(SIZE_Q),
+                    exec_price: 100,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+    }
+    for (offset, price) in (105u64..=150).step_by(5).enumerate() {
+        let slot = 2 + offset as u64;
+        market
+            .set_asset_raw_oracle_target_not_atomic(0, price)
+            .unwrap();
+        market
+            .accrue_asset_to_not_atomic(0, slot, price, 0, true)
+            .unwrap();
+    }
+
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 0,
+                size_q: -signed_q(SIZE_Q),
+                exec_price: 150,
+                fee_bps: 0,
+            },
+        )
+        .expect("the first risk-reducing close must remain available");
+    assert_eq!(short.header.pnl.get(), -250);
+    assert_eq!(
+        short
+            .header
+            .close_progress
+            .try_to_runtime()
+            .unwrap()
+            .residual_remaining,
+        0
+    );
+
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut long,
+            &mut short,
+            TradeRequestV16 {
+                asset_index: 1,
+                size_q: -signed_q(SIZE_Q),
+                exec_price: 100,
+                fee_bps: 0,
+            },
+        )
+        .expect("the final risk-reducing close must remain available");
+    assert!(active_bitmap_is_empty(
+        short.header.active_bitmap.map(V16PodU64::get)
+    ));
+    let ledger = short.header.close_progress.try_to_runtime().unwrap();
+    assert_eq!(ledger.residual_remaining, 0);
+    assert!(
+        market
+            .build_actionable_summary(&short.as_view())
+            .unwrap()
+            .recovery_eligible,
+        "an unattributed flat deficit must recover, not charge asset 1"
+    );
+
+    let work = AutoCrankWorkV16 {
+        now_slot: market.header.current_slot.get(),
+        observations: &[],
+        resolved_close_fee_rate_per_slot: 0,
+    };
+    let recovery = market
+        .permissionless_auto_crank_not_atomic(&mut short, work)
+        .expect("unattributed flat deficit must have a terminal continuation");
+    assert_eq!(
+        recovery.selected,
+        AutoCrankPlanV16::DeclareRecovery {
+            reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
+        }
+    );
+    assert_eq!(market.header.mode, 2);
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+    short.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_auto_crank_liquidates_current_account_without_observation() {
     let (mut header, mut markets) = market_fixture(1, 100);
     let mut account_header = account_fixture(1, 14);
@@ -4845,6 +5174,69 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
         0,
         10,
         AutoCrankPlanV16::SettleBChunk { asset_index: 0 },
+        false,
+    );
+
+    // --- A3 pending_close: the immutable close ledger carries all dispatch
+    // inputs, so AdvanceClose must not depend on a caller observation.
+    assert_observation_independent(
+        "pending_close",
+        || {
+            const SIZE_Q: u128 = 10 * POS_SCALE;
+            let (mut header, mut markets) = market_fixture(1, 100);
+            header.config.maintenance_margin_bps = V16PodU64::new(1_000);
+            header.config.initial_margin_bps = V16PodU64::new(1_000);
+            header.config.max_price_move_bps_per_slot = V16PodU64::new(500);
+            header.config.max_accrual_dt_slots = V16PodU64::new(1);
+            header.config.min_funding_lifetime_slots = V16PodU64::new(1);
+            header.config.public_b_chunk_atoms = V16PodU128::new(100);
+            let mut long_header = account_fixture(1, 211);
+            let mut short_header = account_fixture(1, 212);
+            {
+                let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+                let mut long = PortfolioV16ViewMut::new(&mut long_header);
+                let mut short = PortfolioV16ViewMut::new(&mut short_header);
+                market.deposit_not_atomic(&mut long, 1_000).unwrap();
+                market.deposit_not_atomic(&mut short, 250).unwrap();
+                market
+                    .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                        &mut long,
+                        &mut short,
+                        TradeRequestV16 {
+                            asset_index: 0,
+                            size_q: signed_q(SIZE_Q),
+                            exec_price: 100,
+                            fee_bps: 0,
+                        },
+                    )
+                    .unwrap();
+                for (offset, price) in (105u64..=150).step_by(5).enumerate() {
+                    let slot = 2 + offset as u64;
+                    market
+                        .set_asset_raw_oracle_target_not_atomic(0, price)
+                        .unwrap();
+                    market
+                        .accrue_asset_to_not_atomic(0, slot, price, 0, true)
+                        .unwrap();
+                }
+                market
+                    .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                        &mut long,
+                        &mut short,
+                        TradeRequestV16 {
+                            asset_index: 0,
+                            size_q: -signed_q(SIZE_Q),
+                            exec_price: 150,
+                            fee_bps: 0,
+                        },
+                    )
+                    .unwrap();
+            }
+            (header, markets, short_header)
+        },
+        0,
+        11,
+        AutoCrankPlanV16::AdvanceClose,
         false,
     );
 


### PR DESCRIPTION
## What changed

- preserve asset-local close attribution when an ordinary final-leg trade leaves a uniquely attributable residual deficit
- make pending close ledgers a production-reachable `AdvanceClose` auto-crank class
- book one bounded residual chunk per crank
- keep completed and unattributed account deficits scope-local: they cannot force unrelated live markets into Recovery
- leave terminal market settlement to the explicit market-level resolution policy when provenance is ambiguous or account-local booking is complete
- cover single, batch, multi-chunk selector priority, observation independence, terminal payout, and multi-asset attribution behavior

## Root cause

The proof selector modeled `pending_close`, but the production classifier hard-coded that class to false and the production dispatcher had no close-advance arm. An ordinary matched final-leg close could therefore consume all loser principal, clear the last leg, and leave negative account PnL under a sticky market-wide bankruptcy lock with no successful rank-decreasing crank.

## User impact

An uncooperative underfunded trader could reach the state through normal trade APIs. Honest permissionless cranks remained successful no-ops while funded winners could not convert or withdraw released PnL. The fix keeps the risk-reducing trade available, durably attributes a uniquely attributable residual, and provides one bounded public booking step without granting the affected account authority to terminate unrelated markets. The configured market-level resolution route remains the terminal fallback.

## Validation

- `cargo test` (50 library, 11 backing, 2 resolved, 83 v16 specification tests)
- `cargo kani --tests --features fuzz --harness proof_v16_auto_crank_pending_close_priority_is_total --harness proof_v16_auto_crank_refresh_is_unique_observation_requiring_plan` (2/2)
- wrapper PR 135 public LiteSVM route matrix covers single/batch CPI/no-CPI, account-local booking, scope locality, permissionless stale resolution, terminal payout, and exact SPL conservation
- `cargo fmt --all -- --check`
- `git diff --check`

Base is the exact engine integration commit pinned by wrapper PR 135 (`9ffc4749a4b7e486f814090c7b43fb01a6df5dcf`).