### PR TITLE
[REAL DoS] Release cured counterparty obligations

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -12649,7 +12649,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &PortfolioV16View<'_>,
     ) -> V16Result<(
         ActionableSummaryV16,
-        (Option<usize>, Option<usize>, Option<usize>, Option<usize>),
+        (
+            Option<usize>,
+            Option<usize>,
+            Option<usize>,
+            Option<usize>,
+            Option<usize>,
+        ),
     )> {
         let mode = decode_market_mode(self.header.mode)?;
         let live = mode == MarketModeV16::Live;
@@ -12669,12 +12675,16 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let selected_assets = self.auto_crank_selected_assets(account)?;
         let liquidatable_asset = selected_assets.2;
         let reset_obligation_asset = selected_assets.3;
+        let released_obligation_asset = selected_assets.4;
         let has_open_risk = liquidatable_asset.is_some();
         // A close ledger with residual_remaining==0 is already fully booked/covered
         // (e.g. insurance absorbed the loss); only OUTSTANDING residual is real,
         // actionable close work. The `active` flag can linger past that.
         let close_outstanding = ledger.has_pending_residual();
-        let stale = live && (!cert_current || reset_obligation_asset.is_some());
+        let stale = live
+            && (!cert_current
+                || reset_obligation_asset.is_some()
+                || released_obligation_asset.is_some());
         let b_stale = live && Self::has_b_stale_leg(account)?;
         // A durable close ledger is independently actionable even after the trade
         // that created it cleared the bankrupt leg. AdvanceClose infers the asset
@@ -12757,11 +12767,23 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     fn auto_crank_selected_assets(
         &self,
         account: &PortfolioV16View<'_>,
-    ) -> V16Result<(Option<usize>, Option<usize>, Option<usize>, Option<usize>)> {
+    ) -> V16Result<(
+        Option<usize>,
+        Option<usize>,
+        Option<usize>,
+        Option<usize>,
+        Option<usize>,
+    )> {
         let bitmap = account.header.active_bitmap.map(V16PodU64::get);
+        let release_allowed = !account
+            .header
+            .close_progress
+            .try_to_runtime()?
+            .has_pending_residual();
         let mut refresh_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut liquidation_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut reset_obligation_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
+        let mut released_obligation_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut b_stale_flags = [false; V16_MAX_PORTFOLIO_ASSETS_N];
         let mut slot = 0usize;
         while slot < V16_MAX_PORTFOLIO_ASSETS_N {
@@ -12790,6 +12812,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 liquidation_flags[slot] = liquidatable;
                 reset_obligation_flags[slot] =
                     reset_obligation || Self::leg_has_exhausted_effective_oi(asset, leg);
+                released_obligation_flags[slot] = release_allowed
+                    && !leg.stale
+                    && !leg.b_stale
+                    && leg.basis_pos_q == 0
+                    && leg.loss_weight != 0
+                    && !self.has_pending_domain_loss_barrier(leg.asset_index as usize, leg.side)?;
             }
             slot += 1;
         }
@@ -12806,12 +12834,44 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let liquidatable_asset = asset_of(V16Core::first_actionable_slot(liquidation_flags))?;
         let reset_obligation_asset =
             asset_of(V16Core::first_actionable_slot(reset_obligation_flags))?;
+        let released_obligation_asset =
+            asset_of(V16Core::first_actionable_slot(released_obligation_flags))?;
         Ok((
             b_stale_asset,
             refresh_asset,
             liquidatable_asset,
             reset_obligation_asset,
+            released_obligation_asset,
         ))
+    }
+
+    fn released_obligation_is_current(
+        &self,
+        account: &PortfolioV16View<'_>,
+        asset_index: usize,
+    ) -> V16Result<bool> {
+        let Some(leg_slot) = Self::active_leg_slot_for_asset(account, asset_index)? else {
+            return Ok(false);
+        };
+        let leg = account.header.legs[leg_slot].try_to_runtime()?;
+        if !leg.active
+            || leg.b_stale
+            || leg.stale
+            || leg.basis_pos_q != 0
+            || leg.loss_weight == 0
+            || account
+                .header
+                .close_progress
+                .try_to_runtime()?
+                .has_pending_residual()
+            || self.has_pending_domain_loss_barrier(asset_index, leg.side)?
+        {
+            return Ok(false);
+        }
+        let (k_target, f_target) = self.kf_target_for_leg(asset_index, leg)?;
+        Ok(k_target == leg.k_snap
+            && f_target == leg.f_snap
+            && self.b_target_for_leg(asset_index, leg)? == leg.b_snap)
     }
 
     /// THE SINGLE PUBLIC PERMISSIONLESS CRANK (engine.md): the only crank the
@@ -12855,8 +12915,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 outcome: AutoCrankOutcomeV16::RecoveryResolved,
             });
         }
-        let (summary, (b_stale_asset, refresh_asset, liquidatable_asset, _)) =
-            self.build_actionable_summary_and_selected_assets(&account.as_view())?;
+        let (
+            summary,
+            (b_stale_asset, refresh_asset, liquidatable_asset, _, released_obligation_asset),
+        ) = self.build_actionable_summary_and_selected_assets(&account.as_view())?;
         let recovery_reason = if summary.expired_close || summary.recovery_eligible {
             PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
         } else {
@@ -12871,6 +12933,26 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             refresh_asset,
             recovery_reason,
         );
+
+        // Once the originating domain barrier is gone, a current zero-basis leg
+        // carries only a released loss obligation. Detach it directly so the
+        // account and market counters cannot remain locked behind a current
+        // health certificate that would otherwise classify as NoAction.
+        if matches!(plan, AutoCrankPlanV16::RefreshAccount { .. }) {
+            if let Some(asset_index) = released_obligation_asset {
+                if self.released_obligation_is_current(&account.as_view(), asset_index)? {
+                    self.validate_unconfigured_market_tail()?;
+                    self.clear_leg(account, asset_index)?;
+                    self.validate_shape_audit_scan()?;
+                    return Ok(AutoCrankResultV16 {
+                        selected: plan,
+                        outcome: AutoCrankOutcomeV16::Progressed(
+                            PermissionlessProgressOutcomeV16::AccountCurrent,
+                        ),
+                    });
+                }
+            }
+        }
 
         let obs_or_current_asset = |me: &Self, i: usize| -> V16Result<AutoCrankObservationV16> {
             match work

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -4706,6 +4706,204 @@ fn proof_v16_pending_domain_loss_barrier_allows_only_same_side_reductions() {
     }
 }
 
+fn install_flat_pending_obligation(
+    header: &mut MarketGroupV16HeaderAccount,
+    markets: &mut [Market<u64>; 1],
+    account: &mut PortfolioAccountV16Account,
+    side: SideV16,
+    weight: u128,
+    barrier_active: bool,
+) {
+    let market_id = markets[0].engine.asset.market_id.get();
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    match side {
+        SideV16::Long => {
+            asset.stored_pos_count_long = 1;
+            asset.pending_obligation_count_long = 1;
+            asset.loss_weight_sum_long = weight;
+            if barrier_active {
+                markets[0].engine.pending_domain_loss_barrier_long = V16PodU64::new(1);
+            }
+        }
+        SideV16::Short => {
+            asset.stored_pos_count_short = 1;
+            asset.pending_obligation_count_short = 1;
+            asset.loss_weight_sum_short = weight;
+            if barrier_active {
+                markets[0].engine.pending_domain_loss_barrier_short = V16PodU64::new(1);
+            }
+        }
+    }
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(1 + u64::from(barrier_active));
+    header.materialized_portfolio_count = V16PodU64::new(1);
+
+    account.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id,
+        side,
+        basis_pos_q: 0,
+        a_basis: ADL_ONE,
+        k_snap: 0,
+        f_snap: 0,
+        epoch_snap: 0,
+        loss_weight: weight,
+        b_snap: 0,
+        b_rem: 0,
+        b_epoch_snap: 0,
+        b_stale: false,
+        stale: false,
+    });
+    let mut bitmap = account.active_bitmap.map(V16PodU64::get);
+    active_bitmap_set(&mut bitmap, 0).unwrap();
+    account.active_bitmap = bitmap.map(V16PodU64::new);
+    account.health_cert = HealthCertV16Account::from_runtime(&HealthCertV16 {
+        cert_oracle_epoch: header.oracle_epoch.get(),
+        cert_funding_epoch: header.funding_epoch.get(),
+        cert_risk_epoch: header.risk_epoch.get(),
+        cert_asset_set_epoch: header.asset_set_epoch.get(),
+        active_bitmap_at_cert: bitmap,
+        valid: true,
+        ..HealthCertV16::default()
+    });
+}
+
+#[kani::proof]
+#[kani::unwind(24)]
+#[kani::solver(cadical)]
+fn proof_v16_released_flat_pending_obligation_is_publicly_actionable() {
+    let is_short: bool = kani::any();
+    let barrier_active: bool = kani::any();
+    let weight_units: u8 = kani::any();
+    kani::assume((1..=8).contains(&weight_units));
+    let weight = (weight_units as u128) * POS_SCALE;
+    let side = if is_short {
+        SideV16::Short
+    } else {
+        SideV16::Long
+    };
+
+    let (mut header, mut markets, mut account_header) = one_market_view_fixture();
+    install_flat_pending_obligation(
+        &mut header,
+        &mut markets,
+        &mut account_header,
+        side,
+        weight,
+        barrier_active,
+    );
+
+    let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let account = PortfolioV16ViewMut::new(&mut account_header);
+    let summary = market.build_actionable_summary(&account.as_view()).unwrap();
+
+    kani::cover!(
+        is_short && barrier_active && weight_units > 4,
+        "classifier retains a blocked nontrivial short obligation"
+    );
+    kani::cover!(
+        is_short && !barrier_active && weight_units > 4,
+        "classifier releases a nontrivial short obligation"
+    );
+    kani::cover!(
+        !is_short && barrier_active && weight_units > 4,
+        "classifier retains a blocked nontrivial long obligation"
+    );
+    kani::cover!(
+        !is_short && !barrier_active && weight_units > 4,
+        "classifier releases a nontrivial long obligation"
+    );
+    assert_eq!(summary.stale, !barrier_active);
+    assert_eq!(summary.is_actionable(), !barrier_active);
+}
+
+#[kani::proof]
+#[kani::unwind(24)]
+#[kani::solver(cadical)]
+fn proof_v16_released_flat_pending_obligation_detach_is_value_neutral_progress() {
+    let is_short: bool = kani::any();
+    let weight_units: u8 = kani::any();
+    kani::assume((1..=8).contains(&weight_units));
+    let weight = (weight_units as u128) * POS_SCALE;
+    let side = if is_short {
+        SideV16::Short
+    } else {
+        SideV16::Long
+    };
+
+    let (mut header, mut markets, mut account_header) = one_market_view_fixture();
+    install_flat_pending_obligation(
+        &mut header,
+        &mut markets,
+        &mut account_header,
+        side,
+        weight,
+        false,
+    );
+    let asset_before = markets[0].engine.asset.try_to_runtime().unwrap();
+    let wrapper_before = markets[0].wrapper;
+    let vault_before = header.vault;
+    let c_tot_before = header.c_tot;
+    let insurance_before = header.insurance;
+    let capital_before = account_header.capital;
+    let pnl_before = account_header.pnl;
+    let reserved_before = account_header.reserved_pnl;
+    let fee_credits_before = account_header.fee_credits;
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market.kani_clear_leg(&mut account, 0).unwrap();
+
+    kani::cover!(
+        is_short && weight_units > 4,
+        "detach nontrivial short obligation"
+    );
+    kani::cover!(
+        !is_short && weight_units > 4,
+        "detach nontrivial long obligation"
+    );
+    assert!(active_bitmap_is_empty(
+        account.header.active_bitmap.map(V16PodU64::get)
+    ));
+    assert!(account.header.legs[0].try_to_runtime().unwrap().is_empty());
+    let asset_after = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert!(
+        asset_after.oi_eff_long_q == 0
+            && asset_after.oi_eff_short_q == 0
+            && asset_after.stored_pos_count_long == 0
+            && asset_after.stored_pos_count_short == 0
+            && asset_after.pending_obligation_count_long == 0
+            && asset_after.pending_obligation_count_short == 0
+            && asset_after.loss_weight_sum_long == 0
+            && asset_after.loss_weight_sum_short == 0
+    );
+    assert!(
+        asset_after.market_id == asset_before.market_id
+            && asset_after.lifecycle == asset_before.lifecycle
+            && asset_after.a_long == asset_before.a_long
+            && asset_after.a_short == asset_before.a_short
+            && asset_after.k_long == asset_before.k_long
+            && asset_after.k_short == asset_before.k_short
+            && asset_after.f_long_num == asset_before.f_long_num
+            && asset_after.f_short_num == asset_before.f_short_num
+            && asset_after.b_long_num == asset_before.b_long_num
+            && asset_after.b_short_num == asset_before.b_short_num
+    );
+    assert!(
+        market.markets[0].wrapper == wrapper_before
+            && market.header.vault == vault_before
+            && market.header.c_tot == c_tot_before
+            && market.header.insurance == insurance_before
+            && market.header.resolved_payout_blocker_count.get() == 0
+            && market.header.materialized_portfolio_count.get() == 1
+            && account.header.capital == capital_before
+            && account.header.pnl == pnl_before
+            && account.header.reserved_pnl == reserved_before
+            && account.header.fee_credits == fee_credits_before
+    );
+}
+
 #[kani::proof]
 #[kani::unwind(8)]
 #[kani::solver(cadical)]

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3850,6 +3850,120 @@ fn v16_auto_crank_classifies_fresh_account_stale_then_refreshes_to_clean() {
 }
 
 #[test]
+fn v16_auto_crank_releases_current_flat_pending_obligations_on_both_sides() {
+    for side in [SideV16::Long, SideV16::Short] {
+        let (mut header, mut markets) = market_fixture(1, 100);
+        let mut account_header = account_fixture(1, 22);
+        let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+        match side {
+            SideV16::Long => {
+                asset.stored_pos_count_long = 1;
+                asset.pending_obligation_count_long = 1;
+                asset.loss_weight_sum_long = POS_SCALE;
+            }
+            SideV16::Short => {
+                asset.stored_pos_count_short = 1;
+                asset.pending_obligation_count_short = 1;
+                asset.loss_weight_sum_short = POS_SCALE;
+            }
+        }
+        markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+        header.resolved_payout_blocker_count = V16PodU64::new(1);
+        header.materialized_portfolio_count = V16PodU64::new(1);
+
+        account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+            active: true,
+            asset_index: 0,
+            market_id: asset.market_id,
+            side,
+            basis_pos_q: 0,
+            a_basis: ADL_ONE,
+            k_snap: match side {
+                SideV16::Long => asset.k_long,
+                SideV16::Short => asset.k_short,
+            },
+            f_snap: match side {
+                SideV16::Long => asset.f_long_num,
+                SideV16::Short => asset.f_short_num,
+            },
+            epoch_snap: match side {
+                SideV16::Long => asset.epoch_long,
+                SideV16::Short => asset.epoch_short,
+            },
+            loss_weight: POS_SCALE,
+            b_snap: match side {
+                SideV16::Long => asset.b_long_num,
+                SideV16::Short => asset.b_short_num,
+            },
+            b_rem: 0,
+            b_epoch_snap: match side {
+                SideV16::Long => asset.epoch_long,
+                SideV16::Short => asset.epoch_short,
+            },
+            b_stale: false,
+            stale: false,
+        });
+        account_header.active_bitmap[0] = V16PodU64::new(1);
+        account_header.health_cert = HealthCertV16Account::from_runtime(&HealthCertV16 {
+            cert_oracle_epoch: header.oracle_epoch.get(),
+            cert_funding_epoch: header.funding_epoch.get(),
+            cert_risk_epoch: header.risk_epoch.get(),
+            cert_asset_set_epoch: header.asset_set_epoch.get(),
+            active_bitmap_at_cert: account_header.active_bitmap.map(V16PodU64::get),
+            valid: true,
+            ..HealthCertV16::default()
+        });
+
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut account_header);
+        market.validate_shape().unwrap();
+        account.validate_with_market(&market.as_view()).unwrap();
+        assert!(
+            market
+                .build_actionable_summary(&account.as_view())
+                .unwrap()
+                .stale
+        );
+
+        let result = market
+            .permissionless_auto_crank_not_atomic(
+                &mut account,
+                AutoCrankWorkV16 {
+                    now_slot: 0,
+                    observations: &[],
+                    resolved_close_fee_rate_per_slot: 0,
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            result.selected,
+            AutoCrankPlanV16::RefreshAccount {
+                asset_index: Some(0)
+            }
+        );
+        assert_eq!(
+            result.outcome,
+            AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+        );
+        assert_eq!(account.header.active_bitmap[0].get(), 0);
+        let after = market.markets[0].engine.asset.try_to_runtime().unwrap();
+        assert_eq!(after.stored_pos_count_long, 0);
+        assert_eq!(after.stored_pos_count_short, 0);
+        assert_eq!(after.pending_obligation_count_long, 0);
+        assert_eq!(after.pending_obligation_count_short, 0);
+        assert_eq!(after.loss_weight_sum_long, 0);
+        assert_eq!(after.loss_weight_sum_short, 0);
+        assert_eq!(market.header.resolved_payout_blocker_count.get(), 0);
+        market.validate_shape().unwrap();
+        account.validate_with_market(&market.as_view()).unwrap();
+        market
+            .deregister_empty_materialized_portfolio_not_atomic(&account.as_view())
+            .unwrap();
+        assert_eq!(market.header.materialized_portfolio_count.get(), 0);
+    }
+}
+
+#[test]
 fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
     let (mut header, mut markets) = market_fixture(2, 100);
     let mut account_header = account_fixture(2, 22);


### PR DESCRIPTION
## What changed

Auto-crank now classifies a released, zero-basis pending-loss obligation as actionable after its originating domain barrier is gone. If its K/F/B snapshots are current, the selected refresh step detaches it through the existing checked `clear_leg` transition; otherwise normal refresh settles it first.

## Root cause and impact

A public trade/cure sequence can cancel a bankrupt close while leaving the winning counterparty with a current zero-basis leg, nonzero loss weight, and one pending obligation. The sole public auto-crank previously returned `NoAction`, so repeated permissionless cranks committed byte-identical no-ops and the funded winner could not withdraw. This is an account-scoped persistent DoS reachable from normal public transitions.

This PR targets the `0a23b5f5fc85ddb0223089c66c29cbf1600be62b` engine lineage currently consumed by `percolator-prog` PR 135.

## Verification

- `cargo test`: 150/150 tests passed, including a bilateral long/short regression.
- Kani `proof_v16_released_flat_pending_obligation_is_publicly_actionable`: 0/4,199 checks failed; 4/4 covers reached.
- Kani `proof_v16_released_flat_pending_obligation_detach_is_value_neutral_progress`: 0/4,245 checks failed; 2/2 covers reached.
- A public LiteSVM TDD route in `percolator-prog` PR 135 reproduces the pre-fix lock and will be pinned to this commit for end-to-end validation.