### PR TITLE
[PARTIAL DoS] Keep reset obligations crankable in Recovery

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1880,6 +1880,20 @@ impl V16Core {
         !already_cleared && prior_reset_obligation && !pending_close_residual
     }
 
+    fn kernel_auto_crank_refresh_asset(
+        refresh_asset: Option<usize>,
+        reset_obligation_asset: Option<usize>,
+    ) -> Option<usize> {
+        refresh_asset.or(reset_obligation_asset)
+    }
+
+    fn kernel_refresh_detached_selected_leg(
+        selected_leg_before: bool,
+        selected_leg_after: bool,
+    ) -> bool {
+        selected_leg_before && !selected_leg_after
+    }
+
     /// PRODUCTION KERNEL: a liquidation error is successful public progress only
     /// when the same call committed the matching Recovery state. Every other
     /// error, including an incomplete Recovery marker, remains unchanged.
@@ -12993,7 +13007,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         let protective_progress = match request.action {
             PermissionlessCrankActionV16::Refresh => {
-                let touches_accrued_asset = request.asset_index
+                let selected_leg_before = request.asset_index
                     < self.header.config.max_market_slots.get() as usize
                     && Self::active_leg_slot_for_asset(&account.as_view(), request.asset_index)?
                         .is_some();
@@ -13015,7 +13029,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                         });
                     }
                 }
-                touches_accrued_asset
+                let selected_leg_after = request.asset_index
+                    < self.header.config.max_market_slots.get() as usize
+                    && Self::active_leg_slot_for_asset(&account.as_view(), request.asset_index)?
+                        .is_some();
+                if V16Core::kernel_refresh_detached_selected_leg(
+                    selected_leg_before,
+                    selected_leg_after,
+                ) {
+                    self.validate_shape_audit_scan()?;
+                    return Ok(PermissionlessProgressOutcomeV16::AccountCurrent);
+                }
+                selected_leg_before
             }
             PermissionlessCrankActionV16::SettleB { asset_index } => {
                 let out = self.settle_account_b_chunk(
@@ -13374,7 +13399,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         }
         let (
             summary,
-            (b_stale_asset, refresh_asset, liquidatable_asset, _, released_obligation_asset),
+            (
+                b_stale_asset,
+                refresh_asset,
+                liquidatable_asset,
+                reset_obligation_asset,
+                released_obligation_asset,
+            ),
         ) = self.build_actionable_summary_and_selected_assets(&account.as_view(), work.now_slot)?;
         let recovery_reason = if summary.expired_close || summary.recovery_eligible {
             PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress
@@ -13387,7 +13418,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             summary,
             b_stale_asset.unwrap_or(0),
             liquidatable_asset.unwrap_or(0),
-            refresh_asset,
+            V16Core::kernel_auto_crank_refresh_asset(refresh_asset, reset_obligation_asset),
             recovery_reason,
         );
 

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -47,6 +47,20 @@ pub fn kani_should_clear_prior_reset_obligation(
     )
 }
 
+pub fn kani_auto_crank_refresh_asset(
+    refresh_asset: Option<usize>,
+    reset_obligation_asset: Option<usize>,
+) -> Option<usize> {
+    V16Core::kernel_auto_crank_refresh_asset(refresh_asset, reset_obligation_asset)
+}
+
+pub fn kani_refresh_detached_selected_leg(
+    selected_leg_before: bool,
+    selected_leg_after: bool,
+) -> bool {
+    V16Core::kernel_refresh_detached_selected_leg(selected_leg_before, selected_leg_after)
+}
+
 pub fn kani_first_actionable_slot(flags: [bool; V16_MAX_PORTFOLIO_ASSETS_N]) -> Option<usize> {
     V16Core::first_actionable_slot(flags)
 }

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -7,7 +7,7 @@ use percolator::v16::{
     kani_adl_scaled_accrual_index_deltas, kani_apply_backing_provider_earnings_withdraw,
     kani_apply_backing_utilization_fee_charge, kani_apply_resolved_payout_receipt_payment,
     kani_auto_crank_leg_flags, kani_auto_crank_lifecycle_dispatchable,
-    kani_available_backing_num_for_source_credit_state,
+    kani_auto_crank_refresh_asset, kani_available_backing_num_for_source_credit_state,
     kani_backing_utilization_fee_quote_atoms_for_lien,
     kani_backing_utilization_rate_e9_for_source_state, kani_cert_is_current,
     kani_commit_declared_liquidation_recovery, kani_expected_source_credit_rate_num_for_state,
@@ -19,8 +19,9 @@ use percolator::v16::{
     kani_liquidation_projected_healthy_after_close, kani_loss_stale_trade_scope_allowed,
     kani_pending_domain_loss_barrier_blocks_position_change,
     kani_position_change_requires_unit_adl, kani_position_delta_increases_risk,
-    kani_prepare_asset_recovery_transition, kani_select_auto_crank_plan,
-    kani_should_clear_prior_reset_obligation, kani_source_claim_domain_first_burn_partition,
+    kani_prepare_asset_recovery_transition, kani_refresh_detached_selected_leg,
+    kani_select_auto_crank_plan, kani_should_clear_prior_reset_obligation,
+    kani_source_claim_domain_first_burn_partition,
     kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
     kani_terminal_claim_free_overlap_recredit, kani_trade_preexisting_oi_reduction_gate,
     kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution, AccrualStepV16,
@@ -18000,6 +18001,43 @@ fn proof_v16_backing_utilization_zero_fee_carries_accrual_forward() {
     assert_eq!(market.header.c_tot.get(), c_tot_before);
     assert_eq!(market.header.vault.get(), vault_before);
     assert_eq!(market.header.insurance.get(), insurance_before);
+}
+
+// Recovery can preserve a prior ResetPending obligation while ordinary accrual
+// is disabled for that asset. The auto-crank refresh target must therefore fall
+// back to the reset obligation, but a live accrual target retains priority when
+// both exist. Exhaustive over both Option-presence bits and full-width indices.
+#[kani::proof]
+fn proof_v16_auto_crank_refresh_target_includes_recovery_reset_obligation() {
+    let has_refresh: bool = kani::any();
+    let has_reset: bool = kani::any();
+    let refresh_index: usize = kani::any();
+    let reset_index: usize = kani::any();
+    let refresh = has_refresh.then_some(refresh_index);
+    let reset = has_reset.then_some(reset_index);
+    let selected = kani_auto_crank_refresh_asset(refresh, reset);
+
+    if has_refresh {
+        assert_eq!(selected, Some(refresh_index));
+    } else if has_reset {
+        assert_eq!(selected, Some(reset_index));
+    } else {
+        assert_eq!(selected, None);
+    }
+}
+
+// A full refresh that detached its selected prior-reset leg already committed
+// bounded progress. It must return before the generic post-refresh accrual,
+// because Recovery assets deliberately reject ordinary accrual. Exhaustive over
+// the complete two-bit before/after domain.
+#[kani::proof]
+fn proof_v16_detached_refresh_leg_skips_post_refresh_accrual() {
+    let selected_leg_before: bool = kani::any();
+    let selected_leg_after: bool = kani::any();
+    assert_eq!(
+        kani_refresh_detached_selected_leg(selected_leg_before, selected_leg_after),
+        selected_leg_before && !selected_leg_after
+    );
 }
 
 // Permissionless mixed-lifecycle liveness theorem. Symbolic masks cover every

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -5003,6 +5003,84 @@ fn v16_auto_crank_skips_recovery_first_leg_for_live_refresh() {
 }
 
 #[test]
+fn v16_auto_crank_detaches_prior_reset_obligation_after_asset_recovery() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 23);
+    header.current_slot = V16PodU64::new(10);
+    header.slot_last = V16PodU64::new(10);
+
+    let mut asset = markets[0].engine.asset.try_to_runtime().unwrap();
+    asset.lifecycle = AssetLifecycleV16::Recovery;
+    asset.slot_last = 10;
+    asset.epoch_long = 1;
+    asset.mode_long = SideModeV16::ResetPending;
+    asset.oi_eff_long_q = 0;
+    asset.oi_eff_short_q = 0;
+    asset.loss_weight_sum_long = 0;
+    asset.loss_weight_sum_short = 0;
+    asset.stored_pos_count_long = 1;
+    markets[0].engine.asset = AssetStateV16Account::from_runtime(&asset);
+    header.resolved_payout_blocker_count = V16PodU64::new(1);
+
+    account_header.legs[0] = PortfolioLegV16Account::from_runtime(&PortfolioLegV16 {
+        active: true,
+        asset_index: 0,
+        market_id: asset.market_id,
+        side: SideV16::Long,
+        basis_pos_q: POS_SCALE as i128,
+        a_basis: ADL_ONE,
+        k_snap: asset.k_epoch_start_long,
+        f_snap: asset.f_epoch_start_long_num,
+        epoch_snap: 0,
+        loss_weight: POS_SCALE,
+        b_snap: asset.b_epoch_start_long_num,
+        b_rem: 0,
+        b_epoch_snap: 0,
+        b_stale: false,
+        stale: false,
+    });
+    account_header.active_bitmap[0] = V16PodU64::new(1);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    let cleanup = market
+        .permissionless_auto_crank_not_atomic(
+            &mut account,
+            AutoCrankWorkV16 {
+                now_slot: 10,
+                observations: &[],
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("Recovery must retain permissionless prior-reset cleanup");
+
+    assert_eq!(
+        cleanup.selected,
+        AutoCrankPlanV16::RefreshAccount {
+            asset_index: Some(0)
+        }
+    );
+    assert_eq!(
+        cleanup.outcome,
+        AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+    );
+    assert_eq!(account.header.active_bitmap[0].get(), 0);
+    assert!(!account.header.legs[0].try_to_runtime().unwrap().active);
+    let cleaned = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(cleaned.lifecycle, AssetLifecycleV16::Recovery);
+    assert_eq!(cleaned.mode_long, SideModeV16::ResetPending);
+    assert_eq!(cleaned.stored_pos_count_long, 0);
+    market
+        .finalize_side_reset_not_atomic(0, SideV16::Long)
+        .expect("the cleaned Recovery side must finalize");
+    let finalized = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(finalized.lifecycle, AssetLifecycleV16::Recovery);
+    assert_eq!(finalized.mode_long, SideModeV16::Normal);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_auto_crank_skips_prior_reset_obligation_for_live_liquidation() {
     let (mut header, mut markets) = market_fixture(2, 100);
     let mut account_header = account_fixture(2, 23);


### PR DESCRIPTION
## Problem

A public unilateral reduction can leave a prior-epoch `ResetPending` leg. If asset shutdown lands before its cleanup crank, the asset enters Recovery while preserving that reset obligation. The auto-crank classifier marks the account stale/actionable, but selects no refresh asset and dispatches ordinary accrual against Recovery, returning `LockActive`. Owner forfeit and delayed force-close still provide exits, so this is a partial crankability DoS and a contradiction of the selector totality claim, not a permanent funds lock.

## Fix

- use the reset-obligation asset as the refresh fallback when no accrual-eligible asset exists
- treat detachment of the selected leg during refresh as completed progress and skip post-refresh Recovery accrual
- add a direct production-body regression and two exhaustive selector/accrual Kani kernels

## Verification

- `cargo test --quiet`
- `cargo test --quiet --test v16_spec_tests v16_auto_crank` (16/16)
- `cargo kani --tests --features fuzz --harness proof_v16_auto_crank_refresh_target_includes_recovery_reset_obligation`
- `cargo kani --tests --features fuzz --harness proof_v16_detached_refresh_leg_skips_post_refresh_accrual`
- public LiteSVM composition is owned by wrapper PR 135