### PR TITLE
[PARTIAL LoF] Prevent split-account margin under-reservation

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -194,7 +194,7 @@ price_funding_loss_X  = ceil(X * loss_budget_num / (10_000 * FUNDING_DEN))
 worst_liq_notional_X  = ceil(X * (10_000 + price_budget_bps) / 10_000)
 liq_fee_raw_X         = ceil(worst_liq_notional_X * cfg_liquidation_fee_bps / 10_000)
 liq_fee_X             = min(max(liq_fee_raw_X, cfg_min_liquidation_abs), cfg_liquidation_fee_cap)
-mm_req_X              = max(floor(X * cfg_maintenance_bps / 10_000), cfg_min_nonzero_mm_req)
+mm_req_X              = max(ceil(X * cfg_maintenance_bps / 10_000), cfg_min_nonzero_mm_req)
 require price_funding_loss_X + liq_fee_X <= mm_req_X
 ```
 

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -351,8 +351,11 @@ fn liquidation_leg_maintenance_requirement(
     let adverse_delta =
         V16Core::target_effective_lag_adverse_delta(side, effective_price, raw_target_price);
     let target_lag_penalty = liquidation_risk_notional_ceil(abs_q, adverse_delta)?;
-    let base = ((risk_notional * config.maintenance_margin_bps as u128) / MAX_MARGIN_BPS as u128)
-        .max(config.min_nonzero_mm_req);
+    let base = margin_requirement(
+        risk_notional,
+        config.maintenance_margin_bps,
+        config.min_nonzero_mm_req,
+    )?;
     base.checked_add(target_lag_penalty)
         .ok_or(V16Error::ArithmeticOverflow)
 }
@@ -4278,15 +4281,8 @@ impl V16Config {
     }
 
     fn maintenance_requirement_for_notional(&self, n: u128) -> V16Result<u128> {
-        let mm_prop = if let Some(product) = n.checked_mul(self.maintenance_margin_bps as u128) {
-            product / 10_000
-        } else {
-            U256::from_u128(n)
-                .checked_mul(U256::from_u128(self.maintenance_margin_bps as u128))
-                .and_then(|v| v.checked_div(U256::from_u128(10_000)))
-                .and_then(|v| v.try_into_u128())
-                .ok_or(V16Error::InvalidConfig)?
-        };
+        let mm_prop =
+            Self::checked_mul_div_ceil_to_u128(n, self.maintenance_margin_bps as u128, 10_000)?;
         Ok(core::cmp::max(mm_prop, self.min_nonzero_mm_req))
     }
 
@@ -4494,16 +4490,11 @@ impl V16Config {
             return Err(V16Error::InvalidConfig);
         }
 
-        let floor_region_max = U256::from_u128(
-            self.min_nonzero_mm_req
-                .checked_add(1)
-                .ok_or(V16Error::InvalidConfig)?,
-        )
-        .checked_mul(ten_thousand)
-        .and_then(|v| v.checked_sub(U256::ONE))
-        .and_then(|v| v.checked_div(U256::from_u128(self.maintenance_margin_bps as u128)))
-        .and_then(|v| v.try_into_u128())
-        .ok_or(V16Error::InvalidConfig)?;
+        let floor_region_max = U256::from_u128(self.min_nonzero_mm_req)
+            .checked_mul(ten_thousand)
+            .and_then(|v| v.checked_div(U256::from_u128(self.maintenance_margin_bps as u128)))
+            .and_then(|v| v.try_into_u128())
+            .ok_or(V16Error::InvalidConfig)?;
         let floor_region_end = core::cmp::min(floor_region_max, domain_max);
         if floor_region_end != 0
             && !self.solvency_envelope_holds_for_notional(
@@ -19664,10 +19655,7 @@ fn margin_requirement(notional: u128, bps: u64, floor: u128) -> V16Result<u128> 
     if notional == 0 {
         return Ok(0);
     }
-    if let Some(product) = notional.checked_mul(bps as u128) {
-        return Ok((product / MAX_MARGIN_BPS as u128).max(floor));
-    }
-    let raw = wide_mul_div_floor_u128(notional, bps as u128, MAX_MARGIN_BPS as u128);
+    let raw = V16Core::mul_div_ceil_u128_or_wide(notional, bps as u128, MAX_MARGIN_BPS as u128)?;
     Ok(raw.max(floor))
 }
 

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -57,6 +57,58 @@ fn ids() -> ([u8; 32], [u8; 32], [u8; 32]) {
     ([1; 32], [2; 32], [3; 32])
 }
 
+#[kani::proof]
+#[kani::solver(cadical)]
+fn proof_v16_margin_requirement_cannot_decrease_when_partitioned_under_division_axiom() {
+    let first_notional_nonzero: bool = kani::any();
+    let second_notional_nonzero: bool = kani::any();
+    let first_quotient: u16 = kani::any();
+    let second_quotient: u16 = kani::any();
+    let first_remainder: u16 = kani::any();
+    let second_remainder: u16 = kani::any();
+    let minimum: u16 = kani::any();
+    kani::assume(first_remainder < MAX_MARGIN_BPS as u16);
+    kani::assume(second_remainder < MAX_MARGIN_BPS as u16);
+    kani::assume(first_notional_nonzero || (first_quotient == 0 && first_remainder == 0));
+    kani::assume(second_notional_nonzero || (second_quotient == 0 && second_remainder == 0));
+
+    let remainder_sum = u32::from(first_remainder) + u32::from(second_remainder);
+    let margin_denominator = MAX_MARGIN_BPS as u32;
+    let aggregate_carry = u32::from(remainder_sum >= margin_denominator);
+    let aggregate_remainder = if aggregate_carry == 0 {
+        remainder_sum
+    } else {
+        remainder_sum - margin_denominator
+    };
+    let first_raw = u32::from(first_quotient) + u32::from(first_remainder != 0);
+    let second_raw = u32::from(second_quotient) + u32::from(second_remainder != 0);
+    let aggregate_raw = u32::from(first_quotient)
+        + u32::from(second_quotient)
+        + aggregate_carry
+        + u32::from(aggregate_remainder != 0);
+    let first = if first_notional_nonzero {
+        first_raw.max(u32::from(minimum))
+    } else {
+        0
+    };
+    let second = if second_notional_nonzero {
+        second_raw.max(u32::from(minimum))
+    } else {
+        0
+    };
+    let aggregate = if first_notional_nonzero || second_notional_nonzero {
+        aggregate_raw.max(u32::from(minimum))
+    } else {
+        0
+    };
+    let partitioned = first + second;
+
+    kani::cover!(first_remainder != 0 && second_remainder != 0 && aggregate_carry == 0);
+    kani::cover!(aggregate_carry == 1);
+    kani::cover!(partitioned > aggregate);
+    assert!(partitioned >= aggregate);
+}
+
 // Shared liquidation/rebalance theorem for partially ADL-reduced positions.
 // Live assets have equal effective OI on both sides, while an account's stored
 // basis can be larger. The production capacity prevents OI underflow and makes

--- a/tests/rounding_residue_fuzz.rs
+++ b/tests/rounding_residue_fuzz.rs
@@ -11,6 +11,18 @@ use percolator::SourceCreditStateV16;
 use percolator::{BOUND_SCALE, CREDIT_RATE_SCALE, POS_SCALE};
 use proptest::prelude::*;
 
+#[test]
+fn margin_requirement_partition_regression() {
+    let aggregate = kani_margin_requirement(52_470, 500, 1).unwrap();
+    let partitioned = kani_margin_requirement(26_235, 500, 1)
+        .unwrap()
+        .checked_mul(2)
+        .unwrap();
+
+    assert_eq!(aggregate, 2_624);
+    assert_eq!(partitioned, aggregate);
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(2000))]
 
@@ -44,12 +56,10 @@ proptest! {
         prop_assert!(ceil * POS_SCALE + POS_SCALE > exact_num);
     }
 
-    /// Margin requirement is exactly floor(n*bps/10^4).max(min_floor): the
-    /// per-step floor is compensated by the CEILED risk notional upstream
-    /// (kani_risk_notional_ceil, asserted in notional_floor_le_ceil), so the
-    /// composed requirement never understates the true obligation.
+    /// Margin requirement is exactly ceil(n*bps/10^4).max(min_floor), so a
+    /// portfolio never receives fractional-atom collateral credit.
     #[test]
-    fn margin_requirement_is_exact_floored_with_min(
+    fn margin_requirement_is_exact_ceiled_with_min(
         notional in 0u128..=u128::MAX / 20_000,
         bps in 0u64..=10_000u64,
         min_req in 0u128..=1_000_000u128,
@@ -58,8 +68,31 @@ proptest! {
         if notional == 0 {
             prop_assert_eq!(req, 0);
         } else {
-            prop_assert_eq!(req, (notional * bps as u128 / 10_000).max(min_req));
+            let product = notional * bps as u128;
+            let expected = (product / 10_000 + u128::from(product % 10_000 != 0)).max(min_req);
+            prop_assert_eq!(req, expected);
         }
+    }
+
+    /// Splitting one risk notional across two portfolios cannot lower the
+    /// aggregate requirement. This is the arithmetic property needed by the
+    /// public split/merge invariant; the former per-portfolio floor violated it.
+    #[test]
+    fn margin_requirement_is_conservative_under_partition(
+        first in 0u128..=u128::MAX / 40_000,
+        second in 0u128..=u128::MAX / 40_000,
+        bps in 0u64..=10_000u64,
+        min_req in 0u128..=1_000_000u128,
+    ) {
+        let aggregate = kani_margin_requirement(first + second, bps, min_req).unwrap();
+        let partitioned = kani_margin_requirement(first, bps, min_req)
+            .unwrap()
+            .checked_add(kani_margin_requirement(second, bps, min_req).unwrap())
+            .unwrap();
+        prop_assert!(
+            partitioned >= aggregate,
+            "partitioned requirement {partitioned} fell below aggregate {aggregate}"
+        );
     }
 
     /// ADL scaling: the scaled delta never exceeds the unscaled basis delta

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -3497,8 +3497,8 @@ fn v16_liquidation_engine_selects_healthy_partial_before_margin_floor() {
     const PRICE: u64 = POS_SCALE as u64;
     const POSITION_Q: u128 = 10_000;
     const ACCOUNT_CAPITAL: u128 = 980;
-    const EXPECTED_CLOSE_Q: u128 = 981;
-    const EXPECTED_FEE: u128 = 79;
+    const EXPECTED_CLOSE_Q: u128 = 1_000;
+    const EXPECTED_FEE: u128 = 80;
 
     let (mut header, mut markets) = market_fixture(1, PRICE);
     header.config.maintenance_margin_bps = V16PodU64::new(1_000);
@@ -3569,8 +3569,8 @@ fn v16_liquidation_engine_selects_healthy_partial_before_margin_floor() {
     );
     let cert = account.header.health_cert.try_to_runtime().unwrap();
     assert_eq!(cert.certified_liq_deficit, 0);
-    assert_eq!(cert.certified_equity, 901);
-    assert_eq!(cert.certified_maintenance_req, 901);
+    assert_eq!(cert.certified_equity, 900);
+    assert_eq!(cert.certified_maintenance_req, 900);
     market.validate_shape().unwrap();
     account.validate_with_market(&market.as_view()).unwrap();
 }


### PR DESCRIPTION
## Finding

An independently generated public LiteSVM route showed that splitting one proportional risk increase across two portfolios reserved one fewer quote atom of source-credit lien than the aggregate trade. The engine ceiled risk notional but then floored each portfolio's margin requirement, so partitioning could reduce aggregate admission and backing requirements.

This is publicly reachable and violates split/merge conservatism. The demonstrated advantage is one quote atom per additional portfolio; the repro does not by itself establish a full vault drain, so this is labeled partial LoF.

## Fix

- ceil proportional initial and maintenance requirements
- use the same canonical requirement in liquidation planning and post-state certification
- align config-envelope validation and the v16.8 spec
- add a deterministic regression, randomized deployed-arithmetic property, and division-axiom Kani composition theorem

## Verification

- `cargo test`: 181/181
- `cargo test --features fuzz`: 226/226
- focused Kani: 0/21 failures, 3/3 covers
- independent public LiteSVM red/green coverage is retained in wrapper PR 135
