### PR TITLE
[REAL DoS] Keep cross-domain source losses crankable

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -3932,20 +3932,29 @@ impl V16Core {
         Ok((reservation, source))
     }
 
+    // Source domains settle whole quote atoms independently. Round before a
+    // caller aggregates domains so fractional backing cannot become phantom support.
+    fn source_credit_state_realizable_support_for_claim_num(
+        state: SourceCreditStateV16,
+        claim_num: u128,
+    ) -> V16Result<u128> {
+        if claim_num == 0 || state.positive_claim_bound_num == 0 {
+            return Ok(0);
+        }
+        let credited_num =
+            Self::mul_div_floor_u128_or_wide(claim_num, state.credit_rate_num, CREDIT_RATE_SCALE)?;
+        Ok((credited_num / BOUND_SCALE)
+            .min(Self::available_backing_num_for_source_credit_state(state)? / BOUND_SCALE))
+    }
+
     fn source_credit_state_realizable_support_for_face(
         state: SourceCreditStateV16,
         face_claim: u128,
     ) -> V16Result<u128> {
-        if face_claim == 0 || state.positive_claim_bound_num == 0 {
-            return Ok(0);
-        }
-        let credited_num = Self::mul_div_floor_u128_or_wide(
+        Self::source_credit_state_realizable_support_for_claim_num(
+            state,
             Self::bound_num_from_amount(face_claim)?,
-            state.credit_rate_num,
-            CREDIT_RATE_SCALE,
-        )?;
-        Ok((credited_num / BOUND_SCALE)
-            .min(Self::available_backing_num_for_source_credit_state(state)? / BOUND_SCALE))
+        )
     }
 
     fn target_effective_lag_loss_penalty(
@@ -10479,7 +10488,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Ok(0);
         }
         let mut remaining_num = V16Core::bound_num_from_amount(face_claim)?;
-        let mut support_num = 0u128;
+        let mut support = 0u128;
         let mut slot = 0usize;
         while slot < PORTFOLIO_SOURCE_DOMAIN_CAP && remaining_num != 0 {
             let source = account.source_domains()[slot];
@@ -10499,17 +10508,21 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             if locked > source.source_claim_bound_num.get() {
                 return Err(V16Error::InvalidLeg);
             }
-            let valid_lien_effective_num = source
+            let valid_lien_effective = source
                 .source_lien_effective_reserved
                 .get()
-                .checked_mul(BOUND_SCALE)
-                .ok_or(V16Error::ArithmeticOverflow)?
-                .min(remaining_num);
-            if valid_lien_effective_num != 0 {
-                support_num = support_num
-                    .checked_add(valid_lien_effective_num)
+                .min(remaining_num / BOUND_SCALE);
+            if valid_lien_effective != 0 {
+                support = support
+                    .checked_add(valid_lien_effective)
                     .ok_or(V16Error::ArithmeticOverflow)?;
-                remaining_num -= valid_lien_effective_num;
+                remaining_num = remaining_num
+                    .checked_sub(
+                        valid_lien_effective
+                            .checked_mul(BOUND_SCALE)
+                            .ok_or(V16Error::ArithmeticOverflow)?,
+                    )
+                    .ok_or(V16Error::CounterUnderflow)?;
             }
             let claim_num = source
                 .source_claim_bound_num
@@ -10519,22 +10532,22 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .min(remaining_num);
             if claim_num != 0 {
                 self.validate_source_domain_ledger_current(d)?;
-                let rate = self.source_credit_for_domain(d)?.credit_rate_num;
-                if rate > CREDIT_RATE_SCALE {
-                    return Err(V16Error::InvalidConfig);
-                }
-                let credited_num =
-                    V16Core::mul_div_floor_u128_or_wide(claim_num, rate, CREDIT_RATE_SCALE)?;
-                support_num = support_num
-                    .checked_add(credited_num)
+                let source_credit = self.source_credit_for_domain(d)?;
+                let credited = V16Core::source_credit_state_realizable_support_for_claim_num(
+                    source_credit,
+                    claim_num,
+                )?;
+                support = support
+                    .checked_add(credited)
                     .ok_or(V16Error::ArithmeticOverflow)?;
                 remaining_num -= claim_num;
             }
             slot += 1;
         }
-        Ok(support_num / BOUND_SCALE)
+        Ok(support)
     }
 
+    #[cfg(any(kani, feature = "fuzz"))]
     fn account_unliened_source_realizable_support(
         &self,
         account: &PortfolioV16View<'_>,
@@ -10544,7 +10557,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Ok(0);
         }
         let mut remaining_num = V16Core::bound_num_from_amount(face_claim)?;
-        let mut support_num = 0u128;
+        let mut support = 0u128;
         let mut slot = 0usize;
         while slot < PORTFOLIO_SOURCE_DOMAIN_CAP && remaining_num != 0 {
             let source = account.source_domains()[slot];
@@ -10555,24 +10568,22 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 slot += 1;
                 continue;
             }
-            let d = source.domain.get() as usize;
-            let claim_num = Self::source_claim_unliened_num(account, d)?.min(remaining_num);
+            let domain = source.domain.get() as usize;
+            let claim_num = Self::source_claim_unliened_num(account, domain)?.min(remaining_num);
             if claim_num != 0 {
-                self.validate_source_domain_ledger_current(d)?;
-                let rate = self.source_credit_for_domain(d)?.credit_rate_num;
-                if rate > CREDIT_RATE_SCALE {
-                    return Err(V16Error::InvalidConfig);
-                }
-                let credited_num =
-                    V16Core::mul_div_floor_u128_or_wide(claim_num, rate, CREDIT_RATE_SCALE)?;
-                support_num = support_num
-                    .checked_add(credited_num)
+                self.validate_source_domain_ledger_current(domain)?;
+                let credited = V16Core::source_credit_state_realizable_support_for_claim_num(
+                    self.source_credit_for_domain(domain)?,
+                    claim_num,
+                )?;
+                support = support
+                    .checked_add(credited)
                     .ok_or(V16Error::ArithmeticOverflow)?;
                 remaining_num -= claim_num;
             }
             slot += 1;
         }
-        Ok(support_num / BOUND_SCALE)
+        Ok(support)
     }
 
     fn source_credit_available_backing_num(&self, domain: usize) -> V16Result<u128> {
@@ -11456,12 +11467,15 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(recredited_total)
     }
 
-    fn create_and_consume_validated_account_source_credit_for_effective_not_atomic(
+    // Loss settlement may consume whatever whole-atom support exists; routes
+    // promising an exact conversion set require_full and retain fail-closed behavior.
+    fn consume_validated_account_source_credit_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
         effective_credit: u128,
         burn_account_claims: bool,
-    ) -> V16Result<(SourceCreditConsumptionV16, u128)> {
+        require_full: bool,
+    ) -> V16Result<(SourceCreditConsumptionV16, u128, u128)> {
         if effective_credit == 0 {
             return Ok((
                 SourceCreditConsumptionV16 {
@@ -11469,6 +11483,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     counterparty_credit_consumed: 0,
                     insurance_credit_consumed: 0,
                 },
+                0,
                 0,
             ));
         }
@@ -11515,13 +11530,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 .checked_sub(locked)
                 .ok_or(V16Error::CounterUnderflow)?;
             if rate != 0 && unliened != 0 {
-                let soft_num =
-                    V16Core::mul_div_floor_u128_or_wide(unliened, rate, CREDIT_RATE_SCALE)?;
-                let by_claim = soft_num / BOUND_SCALE;
-                let by_backing =
-                    V16Core::available_backing_num_for_source_credit_state(source_credit)?
-                        / BOUND_SCALE;
-                let take = remaining.min(by_claim).min(by_backing);
+                let consumable = V16Core::source_credit_state_realizable_support_for_claim_num(
+                    source_credit,
+                    unliened,
+                )?;
+                let take = remaining.min(consumable);
                 if take != 0 {
                     let (face_num, backing_num) =
                         V16Core::source_credit_lien_amounts_for_effective(take, rate)?;
@@ -11580,7 +11593,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
             slot += 1;
         }
-        if remaining != 0 {
+        let consumed = counterparty_credit_consumed
+            .checked_add(insurance_credit_consumed)
+            .ok_or(V16Error::ArithmeticOverflow)?;
+        if consumed
+            != effective_credit
+                .checked_sub(remaining)
+                .ok_or(V16Error::CounterUnderflow)?
+        {
+            return Err(V16Error::InvalidConfig);
+        }
+        if require_full && consumed != effective_credit {
             return Err(V16Error::LockActive);
         }
         if burn_account_claims {
@@ -11597,6 +11620,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             } else {
                 0
             },
+            consumed,
         ))
     }
 
@@ -12291,42 +12315,47 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             });
         }
         let has_source_claims = Self::account_has_source_claims(&account.as_view())?;
-        let effective_available = if has_source_claims {
-            self.account_unliened_source_realizable_support(&account.as_view(), old_positive_face)?
-        } else if decode_market_mode(self.header.mode)? == MarketModeV16::Live {
-            0
-        } else {
-            self.haircut_effective_support(
-                old_positive_face,
-                self.residual(),
-                self.junior_claim_bound(),
-            )?
-        };
-        let support_consumed = effective_available.min(loss_abs);
+        let (support_consumed, mut junior_face_burned, preburned_source_claim_num) =
+            if has_source_claims {
+                let source_support_limit = loss_abs.min(old_positive_face);
+                let (consumption, preburned_source_claim_num, support_consumed) = self
+                    .consume_validated_account_source_credit_not_atomic(
+                        account,
+                        source_support_limit,
+                        true,
+                        false,
+                    )?;
+                (
+                    support_consumed,
+                    consumption.face_burn.min(old_positive_face),
+                    preburned_source_claim_num,
+                )
+            } else {
+                let effective_available =
+                    if decode_market_mode(self.header.mode)? == MarketModeV16::Live {
+                        0
+                    } else {
+                        self.haircut_effective_support(
+                            old_positive_face,
+                            self.residual(),
+                            self.junior_claim_bound(),
+                        )?
+                    };
+                let support_consumed = effective_available.min(loss_abs);
+                let junior_face_burned = if support_consumed == 0 {
+                    0
+                } else {
+                    self.face_claim_to_burn_for_support(
+                        support_consumed,
+                        self.residual(),
+                        self.junior_claim_bound(),
+                    )?
+                };
+                (support_consumed, junior_face_burned, 0)
+            };
         let remaining_loss = loss_abs
             .checked_sub(support_consumed)
             .ok_or(V16Error::ArithmeticOverflow)?;
-        let (mut junior_face_burned, preburned_source_claim_num) = if has_source_claims {
-            let (consumption, preburned_source_claim_num) = self
-                .create_and_consume_validated_account_source_credit_for_effective_not_atomic(
-                    account,
-                    support_consumed,
-                    true,
-                )?;
-            (
-                consumption.face_burn.min(old_positive_face),
-                preburned_source_claim_num,
-            )
-        } else if support_consumed == 0 {
-            (0, 0)
-        } else {
-            let residual = self.residual();
-            let junior_bound = self.junior_claim_bound();
-            (
-                self.face_claim_to_burn_for_support(support_consumed, residual, junior_bound)?,
-                0,
-            )
-        };
         if remaining_loss != 0 {
             junior_face_burned = old_positive_face;
         }
@@ -17614,8 +17643,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         disposition: ReleasedPnlConversionDispositionV16,
     ) -> V16Result<u128> {
         let consumption = if has_source_claims {
-            self.create_and_consume_validated_account_source_credit_for_effective_not_atomic(
-                account, converted, false,
+            self.consume_validated_account_source_credit_not_atomic(
+                account, converted, false, true,
             )?
             .0
         } else {

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -371,6 +371,13 @@ pub fn kani_source_credit_state_realizable_support_for_face(
     V16Core::source_credit_state_realizable_support_for_face(state, face_claim)
 }
 
+pub fn kani_source_credit_state_realizable_support_for_claim_num(
+    state: SourceCreditStateV16,
+    claim_num: u128,
+) -> V16Result<u128> {
+    V16Core::source_credit_state_realizable_support_for_claim_num(state, claim_num)
+}
+
 pub fn kani_terminal_claim_free_overlap_recredit(
     provider_receivable_atoms: u128,
     paired_domain_insurance_spent: u128,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -22,6 +22,7 @@ use percolator::v16::{
     kani_prepare_asset_recovery_transition, kani_refresh_detached_selected_leg,
     kani_select_auto_crank_plan, kani_settle_kf_stale_cohort,
     kani_should_clear_prior_reset_obligation, kani_source_claim_domain_first_burn_partition,
+    kani_source_credit_state_realizable_support_for_claim_num,
     kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
     kani_terminal_claim_free_overlap_recredit, kani_trade_preexisting_oi_reduction_gate,
     kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution, AccrualStepV16,
@@ -9071,6 +9072,25 @@ fn proof_v16_unliened_source_support_is_capped_by_realizable_backing() {
     if backing == claim {
         assert_eq!(support, claim);
     }
+}
+
+#[kani::proof]
+fn proof_v16_source_support_rounds_per_domain_before_aggregation() {
+    let state = SourceCreditStateV16 {
+        positive_claim_bound_num: BOUND_SCALE,
+        exact_positive_claim_num: BOUND_SCALE,
+        fresh_reserved_backing_num: BOUND_SCALE,
+        credit_rate_num: CREDIT_RATE_SCALE / 2,
+        ..SourceCreditStateV16::EMPTY
+    };
+    let first =
+        kani_source_credit_state_realizable_support_for_claim_num(state, BOUND_SCALE).unwrap();
+    let second =
+        kani_source_credit_state_realizable_support_for_claim_num(state, BOUND_SCALE).unwrap();
+
+    assert_eq!(first, 0);
+    assert_eq!(second, 0);
+    assert_eq!(first.checked_add(second), Some(0));
 }
 
 // Cross-account solvency: two independent winners holding positive-PnL claims

--- a/tests/rounding_residue_fuzz.rs
+++ b/tests/rounding_residue_fuzz.rs
@@ -25,6 +25,27 @@ fn margin_requirement_partition_regression() {
     assert_eq!(partitioned, aggregate);
 }
 
+#[test]
+fn source_support_rounds_each_domain_before_aggregation() {
+    let state = SourceCreditStateV16 {
+        positive_claim_bound_num: BOUND_SCALE,
+        exact_positive_claim_num: BOUND_SCALE,
+        fresh_reserved_backing_num: BOUND_SCALE,
+        credit_rate_num: CREDIT_RATE_SCALE / 2,
+        ..SourceCreditStateV16::EMPTY
+    };
+    let per_domain =
+        kani_source_credit_state_realizable_support_for_claim_num(state, BOUND_SCALE).unwrap();
+
+    assert_eq!(per_domain, 0);
+    assert_eq!(per_domain.checked_add(per_domain), Some(0));
+    assert_eq!(
+        (BOUND_SCALE / 2).checked_add(BOUND_SCALE / 2).unwrap() / BOUND_SCALE,
+        1,
+        "aggregating fractional domain credit first would invent one unusable atom"
+    );
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(2000))]
 

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -517,6 +517,67 @@ fn account_fixture(market_slots: u32, account_seed: u8) -> PortfolioAccountV16Ac
     account
 }
 
+#[cfg(feature = "fuzz")]
+#[test]
+fn v16_cross_domain_fractional_source_loss_settles_without_locking() {
+    let (mut header, mut markets) = market_fixture(1, 100);
+    let mut account_header = account_fixture(1, 250);
+    let half_atom_num = BOUND_SCALE / 2;
+    let asset_market_id = markets[0].engine.asset.market_id.get();
+    let source = SourceCreditStateV16 {
+        positive_claim_bound_num: BOUND_SCALE,
+        exact_positive_claim_num: BOUND_SCALE,
+        fresh_reserved_backing_num: half_atom_num,
+        credit_rate_num: CREDIT_RATE_SCALE / 2,
+        ..SourceCreditStateV16::EMPTY
+    };
+    let backing = BackingBucketV16 {
+        market_id: asset_market_id,
+        fresh_unliened_backing_num: half_atom_num,
+        expiry_slot: 100,
+        status: BackingBucketStatusV16::Fresh,
+        ..BackingBucketV16::EMPTY
+    };
+    markets[0].engine.source_credit_long = SourceCreditStateV16Account::from_runtime(&source);
+    markets[0].engine.source_credit_short = SourceCreditStateV16Account::from_runtime(&source);
+    markets[0].engine.backing_long = BackingBucketV16Account::from_runtime(&backing);
+    markets[0].engine.backing_short = BackingBucketV16Account::from_runtime(&backing);
+
+    account_header.pnl = V16PodI128::new(2);
+    for (slot, domain) in [0u32, 1u32].into_iter().enumerate() {
+        account_header.source_domains[slot].domain = V16PodU32::new(domain);
+        account_header.source_domains[slot].source_claim_market_id =
+            V16PodU64::new(asset_market_id);
+        account_header.source_domains[slot].source_claim_bound_num = V16PodU128::new(BOUND_SCALE);
+    }
+    header.vault = V16PodU128::new(1);
+    header.pnl_pos_tot = V16PodU128::new(2);
+    header.pnl_pos_bound_tot = V16PodU128::new(2);
+    header.pnl_pos_bound_tot_num = V16PodU128::new(2 * BOUND_SCALE);
+    header.source_claim_bound_total_num = V16PodU128::new(2 * BOUND_SCALE);
+    header.source_fresh_backing_total_num = V16PodU128::new(BOUND_SCALE);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+    market
+        .validate_shape()
+        .expect("fractional source fixture must be a valid market state");
+    account
+        .validate_with_market(&market.as_view())
+        .expect("fractional source fixture must be a valid portfolio state");
+    let outcome = market
+        .kani_apply_signed_kf_delta_to_pnl(&mut account, -1, None)
+        .expect("an unbacked fractional-domain loss must remain settleable");
+
+    assert_eq!(outcome, (0, 2));
+    assert_eq!(account.header.pnl.get(), -1);
+    assert_eq!(market.header.pnl_pos_tot.get(), 0);
+    assert_eq!(market.header.source_claim_bound_total_num.get(), 0);
+    assert_eq!(market.header.vault.get(), 1);
+    market.validate_shape().unwrap();
+    account.validate_with_market(&market.as_view()).unwrap();
+}
+
 fn signed_q(q: u128) -> i128 {
     i128::try_from(q).unwrap()
 }


### PR DESCRIPTION
## Bug\nA publicly reachable multi-asset account can hold source-attributed positive PnL in several domains whose fractional realizable backing sums to a whole atom. Health/loss estimation aggregated those fractions before atom rounding, while consumption rounded each domain independently. A permissionless refresh then demanded an unconsumable exact atom and returned LockActive, so every canonical crank rolled back.\n\n## Fix\n- round realizable support independently per source domain through one backing-capped helper\n- let loss settlement consume the whole-atom support actually available instead of requiring an overestimated exact amount\n- preserve fail-closed exact consumption for conversion routes\n\n## Evidence\n- valid-state engine transition regression for two half-atom domains\n- per-domain rounding fuzz regression\n- focused Kani proof\n- public LiteSVM regression lives on wrapper PR #135 and reaches the failure with three authenticated mark pushes\n\n## Verification\n- cargo test: 184/184\n- cargo test --features fuzz: 233/233\n- focused Kani: 1/1\n- wrapper SBF build + focused public LiteSVM regression: green