### PR TITLE
[REAL DoS] Release flat source liens through auto-crank

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -192,6 +192,7 @@ pub fn auto_crank_plan_requires_caller_observation(plan: &AutoCrankPlanV16) -> b
         AutoCrankPlanV16::AdvanceClose
         | AutoCrankPlanV16::SettleBChunk { .. }
         | AutoCrankPlanV16::Liquidate { .. }
+        | AutoCrankPlanV16::ReleaseSourceLiens
         | AutoCrankPlanV16::DeclareRecovery { .. }
         | AutoCrankPlanV16::FinalizeRecovery
         | AutoCrankPlanV16::CloseResolved
@@ -2262,7 +2263,8 @@ impl V16Core {
     /// bounded plan, carrying the engine-chosen asset (the caller chooses neither
     /// the action nor the asset). PROVES: TOTALITY (an actionable account yields a
     /// non-NoAction plan), PRIORITY DETERMINISM (the documented order: recovery >
-    /// resolved-close > pending-close > b-stale settle > liquidate > refresh), and
+    /// resolved-close > pending-close > b-stale settle > liquidate > source-lien
+    /// release > refresh), and
     /// SELECTED-ASSET fidelity (SettleBChunk/Liquidate carry exactly the provided
     /// engine-selected slot). Pure.
     #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|r: &AutoCrankPlanV16| {
@@ -2281,9 +2283,14 @@ impl V16Core {
                 !recovery && !summary.resolved_winner && !summary.pending_close
                     && !summary.b_stale && summary.liquidatable
                     && *asset_index == liq_slot,
+            AutoCrankPlanV16::ReleaseSourceLiens =>
+                !recovery && !summary.resolved_winner && !summary.pending_close
+                    && !summary.b_stale && !summary.liquidatable
+                    && summary.source_liens_releasable,
             AutoCrankPlanV16::RefreshAccount { asset_index } =>
                 !recovery && !summary.resolved_winner && !summary.pending_close
-                    && !summary.b_stale && !summary.liquidatable && summary.stale
+                    && !summary.b_stale && !summary.liquidatable
+                    && !summary.source_liens_releasable && summary.stale
                     && *asset_index == refresh_asset,
         }
     }))]
@@ -2310,6 +2317,8 @@ impl V16Core {
             AutoCrankPlanV16::Liquidate {
                 asset_index: liq_slot,
             }
+        } else if summary.source_liens_releasable {
+            AutoCrankPlanV16::ReleaseSourceLiens
         } else if summary.stale {
             AutoCrankPlanV16::RefreshAccount {
                 asset_index: refresh_asset,
@@ -2381,7 +2390,7 @@ impl V16Core {
     }
 
     /// PRODUCTION FIDELITY BUILDER (roadmap 3C step 4, actionable-state
-    /// classifier): assemble the ActionableState summary from the seven evaluated
+    /// classifier): assemble the ActionableState summary from the eight evaluated
     /// per-class eligibility signals. build_actionable_summary computes each
     /// signal from real account/market state (cert currentness, b-stale leg,
     /// close-ledger active/expired, certified liquidation deficit, resolved-
@@ -2394,6 +2403,7 @@ impl V16Core {
             && r.pending_close == pending_close
             && r.expired_close == expired_close
             && r.liquidatable == liquidatable
+            && r.source_liens_releasable == source_liens_releasable
             && r.recovery_eligible == recovery_eligible
             && r.resolved_winner == resolved_winner
     }))]
@@ -2403,6 +2413,7 @@ impl V16Core {
         pending_close: bool,
         expired_close: bool,
         liquidatable: bool,
+        source_liens_releasable: bool,
         recovery_eligible: bool,
         resolved_winner: bool,
     ) -> ActionableSummaryV16 {
@@ -2412,6 +2423,7 @@ impl V16Core {
             pending_close,
             expired_close,
             liquidatable,
+            source_liens_releasable,
             recovery_eligible,
             resolved_winner,
         }
@@ -3494,7 +3506,6 @@ impl V16Core {
         live && (!cert_current || reset_obligation || released_obligation || lapsed_source_backing)
     }
 
-    #[cfg(any(kani, feature = "fuzz"))]
     // Contract layer: lien release is the un-pledge relabel — valid liened
     // returns to fresh unliened atom-for-atom, fresh_reserved and all stock
     // quantities untouched; zero-amount is the identity.
@@ -6049,7 +6060,7 @@ pub enum PositionRouteV16 {
     Resize,
 }
 
-/// Compact ActionableState summary (roadmap Phase 4 / 3A.4): which of the seven
+/// Compact ActionableState summary (roadmap Phase 4 / 3A.4): which of the eight
 /// ActionableState classes are live for an account/market. The liveness
 /// selector reads only this — never per-class witnesses that another active
 /// class could invalidate.
@@ -6059,13 +6070,14 @@ pub enum PositionRouteV16 {
 )]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ActionableSummaryV16 {
-    pub stale: bool,             // A1
-    pub b_stale: bool,           // A2
-    pub pending_close: bool,     // A3
-    pub expired_close: bool,     // A4
-    pub liquidatable: bool,      // A5
-    pub recovery_eligible: bool, // A6
-    pub resolved_winner: bool,   // A7
+    pub stale: bool,                   // A1
+    pub b_stale: bool,                 // A2
+    pub pending_close: bool,           // A3
+    pub expired_close: bool,           // A4
+    pub liquidatable: bool,            // A5
+    pub source_liens_releasable: bool, // A6
+    pub recovery_eligible: bool,       // A7
+    pub resolved_winner: bool,         // A8
 }
 
 impl ActionableSummaryV16 {
@@ -6075,6 +6087,7 @@ impl ActionableSummaryV16 {
             || self.pending_close
             || self.expired_close
             || self.liquidatable
+            || self.source_liens_releasable
             || self.recovery_eligible
             || self.resolved_winner
     }
@@ -6118,6 +6131,7 @@ pub enum AutoCrankPlanV16 {
     Liquidate {
         asset_index: usize,
     },
+    ReleaseSourceLiens,
     AdvanceClose,
     DeclareRecovery {
         reason: PermissionlessRecoveryReasonV16,
@@ -9322,6 +9336,15 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         domain: usize,
         amount: u128,
     ) -> V16Result<()> {
+        self.release_source_credit_lien_from_counterparty_core_not_atomic(domain, amount)?;
+        self.validate_shape()
+    }
+
+    fn release_source_credit_lien_from_counterparty_core_not_atomic(
+        &mut self,
+        domain: usize,
+        amount: u128,
+    ) -> V16Result<()> {
         self.domain_asset_side(domain)?;
         if amount == 0 {
             return Ok(());
@@ -9346,7 +9369,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.set_backing_bucket_for_domain(domain, bucket)?;
         self.set_source_credit_for_domain(domain, source)?;
         self.header.risk_epoch = V16PodU64::new(next_risk_epoch);
-        self.validate_shape()
+        Ok(())
     }
 
     // Expiry-agnostic counterparty lien release for terminal (Resolved) wind-down; see
@@ -9979,6 +10002,50 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             slot += 1;
         }
         false
+    }
+
+    fn account_source_credit_liens_are_fresh_and_releasable(
+        &self,
+        account: &PortfolioV16View<'_>,
+        now_slot: u64,
+    ) -> V16Result<bool> {
+        let mut found = false;
+        let mut slot = 0usize;
+        while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let source = account.source_domains()[slot];
+            if source.has_default_sparse_tag() && !source.is_occupied() {
+                break;
+            }
+            if source.is_occupied() && source.source_claim_liened_num.get() != 0 {
+                found = true;
+                let domain = source.domain.get() as usize;
+                self.domain_asset_side(domain)?;
+                let counterparty_backing = source.source_lien_counterparty_backing_num.get();
+                let insurance_backing = source.source_lien_insurance_backing_num.get();
+                let source_credit = self.source_credit_for_domain(domain)?;
+                if counterparty_backing != 0 {
+                    let bucket = self.backing_bucket_for_domain(domain)?;
+                    if bucket.status != BackingBucketStatusV16::Fresh
+                        || bucket.expiry_slot <= now_slot
+                        || bucket.valid_liened_backing_num < counterparty_backing
+                        || source_credit.valid_liened_backing_num < counterparty_backing
+                    {
+                        return Ok(false);
+                    }
+                }
+                if insurance_backing != 0 {
+                    let reservation = self.insurance_reservation_for_domain(domain)?;
+                    if insurance_backing % BOUND_SCALE != 0
+                        || reservation.valid_liened_insurance_num < insurance_backing
+                        || source_credit.valid_liened_insurance_num < insurance_backing
+                    {
+                        return Ok(false);
+                    }
+                }
+            }
+            slot += 1;
+        }
+        Ok(found)
     }
 
     fn source_claim_unliened_num(account: &PortfolioV16View<'_>, domain: usize) -> V16Result<u128> {
@@ -14127,6 +14194,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     ///   pending_close    — Live, a close-progress ledger is active
     ///   expired_close    — Live, that ledger is past its max-close slot
     ///   liquidatable     — Live, current cert with nonzero certified liq deficit
+    ///   source_liens_releasable — Live, flat, independently initial-margin safe,
+    ///                      current account whose obsolete source liens can be
+    ///                      returned without an oracle observation
     ///   recovery_eligible— reserved for selector-level proactive Recovery
     ///   resolved_winner  — Resolved, nonterminal account with a close step that
     ///                      can mutate now (or a positive payout that is ready)
@@ -14225,6 +14295,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             && cert.certified_liq_deficit != 0
             && has_open_risk
             && reset_obligation_asset.is_none();
+        let no_positive_equity = Self::account_no_positive_credit_equity(account)?;
+        let source_liens_releasable = live
+            && cert_current
+            && active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get))
+            && no_positive_equity >= 0
+            && (no_positive_equity as u128) >= cert.certified_initial_req
+            && self.account_source_credit_liens_are_fresh_and_releasable(account, now_slot)?;
         // A completed account-local bankruptcy must not let that account force a
         // market-wide Recovery. In particular, a permissionless asset can be
         // attacker-controlled while unrelated assets remain healthy. Outstanding
@@ -14264,6 +14341,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 pending_close,
                 expired_close,
                 liquidatable,
+                source_liens_releasable,
                 recovery_eligible,
                 resolved_winner,
             ),
@@ -14417,8 +14495,9 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
     ///    matches the observation that step needs, derives the liquidation fee from
     ///    CONFIG (never the caller), and dispatches one bounded primitive.
     /// 5. On `Ok(result)`, mirror any wrapper-owned token/custody movement keyed off
-    ///    `result.selected` (the `AutoCrankPlanV16`): refresh / settle-B move no
-    ///    custody; liquidate / close-resolved may. `NoAction` => nothing was needed.
+    ///    `result.selected` (the `AutoCrankPlanV16`): refresh / settle-B /
+    ///    source-lien release move no custody; liquidate / close-resolved may.
+    ///    `NoAction` => nothing was needed.
     ///    In Recovery, the next call selects `FinalizeRecovery` and performs the
     ///    value-neutral transition to Resolved so terminal account close remains
     ///    publicly reachable. `Err(NonProgress)` => the selected step needed an
@@ -14560,6 +14639,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
 
         let outcome = match plan {
             AutoCrankPlanV16::NoAction => AutoCrankOutcomeV16::NoAction,
+            AutoCrankPlanV16::ReleaseSourceLiens => {
+                self.release_account_source_credit_liens_if_unneeded_core_not_atomic(account)?;
+                AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
+            }
             AutoCrankPlanV16::RefreshAccount { asset_index } => {
                 // Accrue the engine-selected active asset from either a fresh
                 // observation or committed state; if no active asset exists, use
@@ -17773,13 +17856,18 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(converted)
     }
 
-    #[cfg(any(kani, feature = "fuzz"))]
-    pub fn release_account_source_credit_liens_if_unneeded_not_atomic(
+    fn release_account_source_credit_liens_if_unneeded_core_not_atomic(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
     ) -> V16Result<u128> {
         if decode_market_mode(self.header.mode)? != MarketModeV16::Live {
             return Err(V16Error::LockActive);
+        }
+        if !active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get))
+            || !Self::account_has_source_liens(&account.as_view())
+            || self.account_has_active_source_claim_exposure(&account.as_view())?
+        {
+            return Err(V16Error::NonProgress);
         }
         self.settle_account_side_effects_not_atomic(
             account,
@@ -17809,35 +17897,45 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             let counterparty_backing = source_snapshot.source_lien_counterparty_backing_num.get();
             let insurance_backing = source_snapshot.source_lien_insurance_backing_num.get();
             if counterparty_backing != 0 {
-                self.release_source_credit_lien_from_counterparty_not_atomic(
+                self.release_source_credit_lien_from_counterparty_core_not_atomic(
                     d,
                     counterparty_backing,
                 )?;
             }
             if insurance_backing != 0 {
-                self.release_source_credit_lien_from_insurance_not_atomic(d, insurance_backing)?;
+                self.release_source_credit_lien_from_insurance_core_not_atomic(
+                    d,
+                    insurance_backing,
+                )?;
             }
-            if effective != 0 {
-                released_effective = released_effective
-                    .checked_add(effective)
-                    .ok_or(V16Error::ArithmeticOverflow)?;
-                let source = &mut account.header.source_domains[slot];
-                source.source_claim_liened_num = V16PodU128::new(0);
-                source.source_claim_counterparty_liened_num = V16PodU128::new(0);
-                source.source_claim_insurance_liened_num = V16PodU128::new(0);
-                source.source_lien_effective_reserved = V16PodU128::new(0);
-                source.source_lien_counterparty_backing_num = V16PodU128::new(0);
-                source.source_lien_insurance_backing_num = V16PodU128::new(0);
-                source.source_lien_fee_last_slot = V16PodU64::new(0);
-                account.reset_source_domain_slot_if_empty(slot);
-            }
+            released_effective = released_effective
+                .checked_add(effective)
+                .ok_or(V16Error::ArithmeticOverflow)?;
+            let source = &mut account.header.source_domains[slot];
+            source.source_claim_liened_num = V16PodU128::new(0);
+            source.source_claim_counterparty_liened_num = V16PodU128::new(0);
+            source.source_claim_insurance_liened_num = V16PodU128::new(0);
+            source.source_lien_effective_reserved = V16PodU128::new(0);
+            source.source_lien_counterparty_backing_num = V16PodU128::new(0);
+            source.source_lien_insurance_backing_num = V16PodU128::new(0);
+            source.source_lien_fee_last_slot = V16PodU64::new(0);
+            account.reset_source_domain_slot_if_empty(slot);
             slot += 1;
         }
         account.compact_source_domains();
         account.header.health_cert.valid = 0;
+        self.recertify_account_after_source_lien_change(account)?;
         account.validate_with_market(&self.as_view())?;
         self.validate_shape()?;
         Ok(released_effective)
+    }
+
+    #[cfg(any(kani, feature = "fuzz"))]
+    pub fn release_account_source_credit_liens_if_unneeded_not_atomic(
+        &mut self,
+        account: &mut PortfolioV16ViewMut<'_>,
+    ) -> V16Result<u128> {
+        self.release_account_source_credit_liens_if_unneeded_core_not_atomic(account)
     }
 
     #[cfg(any(kani, feature = "fuzz"))]

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -2197,12 +2197,13 @@ pub enum ResolvedCloseStepV16 {
 )]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ProgressContinuationV16 {
-    DeclareRecovery, // A4 expired close / A6 recovery-eligible: terminal recovery
-    CloseResolved,   // A7 resolved winner: terminal realization
-    AdvanceClose,    // A3 pending close residual: close-ledger rank step
-    SettleBChunk,    // A2 b-stale leg: B-advance rank step
-    Liquidate,       // A5 liquidatable: risk-reduction
-    RefreshAccount,  // A1 stale account: protective accrual segment
+    DeclareRecovery,    // A4 expired close / A7 recovery-eligible: terminal recovery
+    CloseResolved,      // A8 resolved winner: terminal realization
+    AdvanceClose,       // A3 pending close residual: close-ledger rank step
+    SettleBChunk,       // A2 b-stale leg: B-advance rank step
+    Liquidate,          // A5 liquidatable: risk-reduction
+    ReleaseSourceLiens, // A6 flat source claim: release obsolete encumbrance
+    RefreshAccount,     // A1 stale account: protective accrual segment
 }
 
 impl V16Core {
@@ -2211,7 +2212,8 @@ impl V16Core {
     /// cally select a public continuation that makes progress, by a fixed
     /// priority that resolves OVERLAPPING active classes (terminal/safety first):
     /// expired-close/recovery -> resolved -> pending-close -> b-stale ->
-    /// liquidate -> refresh. Proves the no-DoS existential robustly: an actionable
+    /// liquidate -> source-lien release -> refresh. Proves the no-DoS existential
+    /// robustly: an actionable
     /// state ALWAYS selects Some continuation (totality), the selected
     /// continuation's class is ACTUALLY active (non-blocked — never picks a
     /// continuation for an inactive class, so one active class cannot invalidate
@@ -2236,9 +2238,14 @@ impl V16Core {
                     ProgressContinuationV16::Liquidate =>
                         !recovery && !summary.resolved_winner && !summary.pending_close
                             && !summary.b_stale && summary.liquidatable,
+                    ProgressContinuationV16::ReleaseSourceLiens =>
+                        !recovery && !summary.resolved_winner && !summary.pending_close
+                            && !summary.b_stale && !summary.liquidatable
+                            && summary.source_liens_releasable,
                     ProgressContinuationV16::RefreshAccount =>
                         !recovery && !summary.resolved_winner && !summary.pending_close
-                            && !summary.b_stale && !summary.liquidatable && summary.stale,
+                            && !summary.b_stale && !summary.liquidatable
+                            && !summary.source_liens_releasable && summary.stale,
                 }
             }
         }
@@ -2256,6 +2263,8 @@ impl V16Core {
             Some(ProgressContinuationV16::SettleBChunk)
         } else if summary.liquidatable {
             Some(ProgressContinuationV16::Liquidate)
+        } else if summary.source_liens_releasable {
+            Some(ProgressContinuationV16::ReleaseSourceLiens)
         } else if summary.stale {
             Some(ProgressContinuationV16::RefreshAccount)
         } else {

--- a/src/v16_proofs.rs
+++ b/src/v16_proofs.rs
@@ -2616,6 +2616,7 @@ fn contract_check_actionable_summary_from_signals() {
         kani::any(),
         kani::any(),
         kani::any(),
+        kani::any(),
     );
 }
 

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -18224,6 +18224,7 @@ fn proof_v16_auto_crank_refresh_is_unique_observation_requiring_plan() {
         asset_index: i
     }));
     assert!(!needs_obs(&AutoCrankPlanV16::Liquidate { asset_index: i }));
+    assert!(!needs_obs(&AutoCrankPlanV16::ReleaseSourceLiens));
     assert!(!needs_obs(&AutoCrankPlanV16::AdvanceClose));
     assert!(!needs_obs(&AutoCrankPlanV16::NoAction));
     assert!(!needs_obs(&AutoCrankPlanV16::FinalizeRecovery));
@@ -18233,6 +18234,49 @@ fn proof_v16_auto_crank_refresh_is_unique_observation_requiring_plan() {
     assert!(!needs_obs(&AutoCrankPlanV16::DeclareRecovery {
         reason: PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
     }));
+}
+
+// A flat account whose independently funded source-credit lien is no longer
+// needed has a committed-state continuation. The selector must choose that
+// release ahead of an ordinary refresh, but never ahead of liquidation or the
+// higher-priority close/B/recovery classes.
+#[kani::proof]
+fn proof_v16_auto_crank_source_lien_release_is_total_and_prioritized() {
+    let release = kani_select_auto_crank_plan(
+        ActionableSummaryV16 {
+            stale: true,
+            b_stale: false,
+            pending_close: false,
+            expired_close: false,
+            liquidatable: false,
+            source_liens_releasable: true,
+            recovery_eligible: false,
+            resolved_winner: false,
+        },
+        0,
+        0,
+        None,
+        PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+    );
+    assert_eq!(release, AutoCrankPlanV16::ReleaseSourceLiens);
+
+    let liquidation = kani_select_auto_crank_plan(
+        ActionableSummaryV16 {
+            stale: true,
+            b_stale: false,
+            pending_close: false,
+            expired_close: false,
+            liquidatable: true,
+            source_liens_releasable: true,
+            recovery_eligible: false,
+            resolved_winner: false,
+        },
+        0,
+        7,
+        None,
+        PermissionlessRecoveryReasonV16::ExplicitLossOrDustAuditOverflow,
+    );
+    assert_eq!(liquidation, AutoCrankPlanV16::Liquidate { asset_index: 7 });
 }
 
 // Pending close is a production-dispatchable class, not merely a proof-summary
@@ -18247,6 +18291,7 @@ fn proof_v16_auto_crank_pending_close_priority_is_total() {
             pending_close: true,
             expired_close: false,
             liquidatable: true,
+            source_liens_releasable: true,
             recovery_eligible: false,
             resolved_winner: false,
         },
@@ -18264,6 +18309,7 @@ fn proof_v16_auto_crank_pending_close_priority_is_total() {
             pending_close: true,
             expired_close: true,
             liquidatable: true,
+            source_liens_releasable: true,
             recovery_eligible: false,
             resolved_winner: true,
         },
@@ -18290,6 +18336,7 @@ fn proof_v16_auto_crank_pending_close_priority_is_total() {
             pending_close: false,
             expired_close: false,
             liquidatable: false,
+            source_liens_releasable: false,
             recovery_eligible: true,
             resolved_winner: false,
         },
@@ -18562,6 +18609,7 @@ fn proof_v16_recovery_legs_cannot_starve_dispatchable_auto_crank_work() {
             pending_close: false,
             expired_close: false,
             liquidatable: false,
+            source_liens_releasable: false,
             recovery_eligible: false,
             resolved_winner: false,
         },
@@ -18603,6 +18651,7 @@ fn proof_v16_recovery_legs_cannot_starve_dispatchable_auto_crank_work() {
                 pending_close: false,
                 expired_close: false,
                 liquidatable: true,
+                source_liens_releasable: false,
                 recovery_eligible: false,
                 resolved_winner: false,
             },
@@ -18755,6 +18804,7 @@ fn proof_v16_prior_reset_cleanup_cannot_starve_live_liquidation() {
                     pending_close: false,
                     expired_close: false,
                     liquidatable: false,
+                    source_liens_releasable: false,
                     recovery_eligible: false,
                     resolved_winner: false,
                 },
@@ -18808,6 +18858,7 @@ fn proof_v16_prior_reset_cleanup_cannot_starve_live_liquidation() {
             pending_close: false,
             expired_close: false,
             liquidatable: true,
+            source_liens_releasable: false,
             recovery_eligible: false,
             resolved_winner: false,
         },

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -4985,6 +4985,120 @@ fn v16_residual_reward_credit_uses_real_principal_not_notional() {
     market.validate_shape().unwrap();
 }
 
+fn flat_source_credit_lien_fixture() -> (
+    MarketGroupV16HeaderAccount,
+    Vec<Market<u64>>,
+    PortfolioAccountV16Account,
+) {
+    let (mut header, mut markets) = market_fixture(1, 1);
+    let mut winner_header = account_fixture(1, 10);
+    let mut counterparty_header = account_fixture(1, 11);
+    let claim = 100;
+    let claim_num = claim * BOUND_SCALE;
+    winner_header.pnl = V16PodI128::new(claim as i128);
+    winner_header.source_domains[0].domain = V16PodU32::new(0);
+    winner_header.source_domains[0].source_claim_market_id = V16PodU64::new(1);
+    winner_header.source_domains[0].source_claim_bound_num = V16PodU128::new(claim_num);
+    header.pnl_pos_tot = V16PodU128::new(claim);
+    header.pnl_pos_bound_tot_num = V16PodU128::new(claim_num);
+    header.pnl_pos_bound_tot = V16PodU128::new(claim);
+    header.source_claim_bound_total_num = V16PodU128::new(claim_num);
+    header.vault = V16PodU128::new(claim);
+    header.source_fresh_backing_total_num = V16PodU128::new(claim_num);
+    markets[0].engine.source_credit_long =
+        SourceCreditStateV16Account::from_runtime(&SourceCreditStateV16 {
+            positive_claim_bound_num: claim_num,
+            exact_positive_claim_num: claim_num,
+            fresh_reserved_backing_num: claim_num,
+            credit_rate_num: CREDIT_RATE_SCALE,
+            ..SourceCreditStateV16::EMPTY
+        });
+    markets[0].engine.backing_long = BackingBucketV16Account::from_runtime(&BackingBucketV16 {
+        market_id: 1,
+        fresh_unliened_backing_num: claim_num,
+        expiry_slot: 100,
+        status: BackingBucketStatusV16::Fresh,
+        ..BackingBucketV16::EMPTY
+    });
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut counterparty = PortfolioV16ViewMut::new(&mut counterparty_header);
+        market.deposit_not_atomic(&mut counterparty, 1_000).unwrap();
+    }
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut winner = PortfolioV16ViewMut::new(&mut winner_header);
+    let mut counterparty = PortfolioV16ViewMut::new(&mut counterparty_header);
+    let open = TradeRequestV16 {
+        asset_index: 0,
+        size_q: signed_q(10 * POS_SCALE),
+        exec_price: 1,
+        fee_bps: 0,
+    };
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(&mut winner, &mut counterparty, open)
+        .unwrap();
+    market
+        .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+            &mut winner,
+            &mut counterparty,
+            TradeRequestV16 {
+                size_q: -open.size_q,
+                ..open
+            },
+        )
+        .unwrap();
+    drop(market);
+    drop(winner);
+    drop(counterparty);
+    (header, markets, winner_header)
+}
+
+#[test]
+fn v16_auto_crank_releases_flat_source_credit_lien_for_conversion() {
+    const CLAIM: u128 = 100;
+    let (mut header, mut markets, mut winner_header) = flat_source_credit_lien_fixture();
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut winner = PortfolioV16ViewMut::new(&mut winner_header);
+
+    assert!(active_bitmap_is_empty(
+        winner.header.active_bitmap.map(V16PodU64::get)
+    ));
+    assert_ne!(
+        winner.header.source_domains[0]
+            .source_claim_liened_num
+            .get(),
+        0,
+        "the public trades must reach the flat retained-lien state"
+    );
+    let result = market
+        .permissionless_auto_crank_not_atomic(
+            &mut winner,
+            AutoCrankWorkV16 {
+                now_slot: market.header.current_slot.get(),
+                observations: &[],
+                resolved_close_fee_rate_per_slot: 0,
+            },
+        )
+        .expect("a flat funded source claim must have a bounded crank continuation");
+    assert_eq!(result.selected, AutoCrankPlanV16::ReleaseSourceLiens);
+    assert_eq!(
+        winner.header.source_domains[0]
+            .source_claim_liened_num
+            .get(),
+        0,
+        "the crank must release the obsolete source-credit encumbrance"
+    );
+    assert_eq!(
+        market
+            .convert_released_pnl_to_capital_not_atomic(&mut winner)
+            .expect("released source-backed PnL must become convertible"),
+        CLAIM
+    );
+    winner.validate_with_market(&market.as_view()).unwrap();
+    market.validate_shape().unwrap();
+}
+
 #[test]
 fn v16_residual_reward_credit_is_capped_by_available_crystallized_loss() {
     let (mut header, mut markets) = market_fixture(1, 1_000);
@@ -5310,6 +5424,7 @@ fn v16_auto_crank_classifies_fresh_account_stale_then_refreshes_to_clean() {
             && !summary.pending_close
             && !summary.expired_close
             && !summary.liquidatable
+            && !summary.source_liens_releasable
             && !summary.recovery_eligible
             && !summary.resolved_winner,
         "no other actionable class on a fresh empty account"
@@ -8342,6 +8457,17 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
         false,
     );
 
+    // --- A6 flat source lien: release uses only the current certificate and
+    // committed source ledgers, so no oracle observation may gate the exit.
+    assert_observation_independent(
+        "flat_source_lien",
+        flat_source_credit_lien_fixture,
+        0,
+        0,
+        AutoCrankPlanV16::ReleaseSourceLiens,
+        false,
+    );
+
     // --- A4 expired_close: DeclareRecovery needs no price -> observation REDUNDANT.
     assert_observation_independent(
         "expired_close",
@@ -8382,7 +8508,7 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
         false,
     );
 
-    // --- A6 terminal Recovery: the next step is a value-neutral transition to
+    // --- A7 terminal Recovery: the next step is a value-neutral transition to
     // Resolved and needs no oracle observation.
     assert_observation_independent(
         "finalize_recovery",
@@ -8401,7 +8527,7 @@ fn v16_auto_crank_progress_realizable_without_observation_for_every_class() {
         false,
     );
 
-    // --- A7 resolved_winner: CloseResolved needs no price -> observation REDUNDANT.
+    // --- A8 resolved_winner: CloseResolved needs no price -> observation REDUNDANT.
     // (Previously only its CLASSIFICATION was tested; the empty-observation DISPATCH
     // — including a legitimate RecoveryRequired terminal — was uncovered.)
     assert_observation_independent(


### PR DESCRIPTION
A publicly reachable flat portfolio can retain a source-credit lien after its backing provider withdraws. The existing selector reports NoAction, while conversion and close remain blocked, leaving funded positive PnL without a bounded exit.

This adds a bounded, observation-free ReleaseSourceLiens auto-crank class, dispatches the existing validated release transition in production, and proves selector totality/priority. The wrapper LiteSVM public-route regression is being added to percolator-prog PR 135 against this exact commit.

Verified: cargo test (185), cargo test --features fuzz (234), the new Kani selector proof, observation predicate proof, and selector/progress/summary function contracts.