### PR TITLE
[REAL LoF] Preserve domain attribution across multi-asset loss detach

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -314,6 +314,15 @@ fn uncovered_loss_remains_with_open_risk(
     uncovered_loss_after_principal != 0 && !active_bitmap_is_empty(remaining_active_bitmap)
 }
 
+#[inline]
+fn unattributed_loss_lock_after_pnl(
+    was_locked: bool,
+    active_bitmap: V16ActiveBitmap,
+    new_pnl: i128,
+) -> bool {
+    new_pnl < 0 && (was_locked || active_bitmap_count_ones(active_bitmap) > 1)
+}
+
 fn liquidation_risk_notional_ceil(abs_pos_q: u128, price: u64) -> V16Result<u128> {
     if abs_pos_q == 0 {
         return Ok(0);
@@ -12137,9 +12146,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         new_pnl: i128,
     ) -> V16Result<()> {
         let was_locked = decode_bool(account.header.liquidation_lock)?;
-        let multi_asset =
-            active_bitmap_count_ones(account.header.active_bitmap.map(V16PodU64::get)) > 1;
-        account.header.liquidation_lock = encode_bool(new_pnl < 0 && (was_locked || multi_asset));
+        account.header.liquidation_lock = encode_bool(unattributed_loss_lock_after_pnl(
+            was_locked,
+            account.header.active_bitmap.map(V16PodU64::get),
+            new_pnl,
+        ));
         Ok(())
     }
 

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -305,22 +305,13 @@ fn liquidation_uncovered_loss_after_principal(pnl: i128, capital: u128) -> u128 
 }
 
 #[inline]
-fn liquidation_close_would_leave_uncovered_loss_with_open_risk(
+fn uncovered_loss_remains_with_open_risk(
     pnl: i128,
     capital: u128,
-    active_bitmap: V16ActiveBitmap,
-    leg_slot_index: usize,
-    close_q: u128,
-    leg_abs_q: u128,
-) -> V16Result<bool> {
+    remaining_active_bitmap: V16ActiveBitmap,
+) -> bool {
     let uncovered_loss_after_principal = liquidation_uncovered_loss_after_principal(pnl, capital);
-    let remaining_active_bitmap = liquidation_remaining_active_bitmap_after_close(
-        active_bitmap,
-        leg_slot_index,
-        close_q,
-        leg_abs_q,
-    )?;
-    Ok(uncovered_loss_after_principal != 0 && !active_bitmap_is_empty(remaining_active_bitmap))
+    uncovered_loss_after_principal != 0 && !active_bitmap_is_empty(remaining_active_bitmap)
 }
 
 fn liquidation_risk_notional_ceil(abs_pos_q: u128, price: u64) -> V16Result<u128> {
@@ -5266,6 +5257,10 @@ impl<'a> PortfolioV16View<'a> {
         let pnl = self.header.pnl.get();
         validate_non_min_i128(pnl)?;
         validate_fee_credits(self.header.fee_credits.get())?;
+        let liquidation_lock = decode_bool(self.header.liquidation_lock)?;
+        if liquidation_lock && pnl >= 0 {
+            return Err(V16Error::InvalidLeg);
+        }
         if self.header.reserved_pnl.get() > pnl.max(0) as u128 {
             return Err(V16Error::InvalidLeg);
         }
@@ -8686,6 +8681,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let pnl = account.header.pnl.get();
         validate_non_min_i128(pnl)?;
         validate_fee_credits(account.header.fee_credits.get())?;
+        let liquidation_lock = decode_bool(account.header.liquidation_lock)?;
+        if liquidation_lock && pnl >= 0 {
+            return Err(V16Error::InvalidLeg);
+        }
         if account.header.reserved_pnl.get() > pnl.max(0) as u128 {
             return Err(V16Error::InvalidLeg);
         }
@@ -12133,6 +12132,17 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         self.set_account_pnl_inner(account, new_pnl, None, 0)
     }
 
+    fn sync_unattributed_loss_lock(
+        account: &mut PortfolioV16ViewMut<'_>,
+        new_pnl: i128,
+    ) -> V16Result<()> {
+        let was_locked = decode_bool(account.header.liquidation_lock)?;
+        let multi_asset =
+            active_bitmap_count_ones(account.header.active_bitmap.map(V16PodU64::get)) > 1;
+        account.header.liquidation_lock = encode_bool(new_pnl < 0 && (was_locked || multi_asset));
+        Ok(())
+    }
+
     fn set_account_pnl_with_source(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
@@ -12327,6 +12337,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             }
             _ => {}
         }
+        Self::sync_unattributed_loss_lock(account, new_pnl)?;
         account.header.pnl = V16PodI128::new(new_pnl);
         account.header.health_cert.valid = 0;
         Ok(())
@@ -15369,7 +15380,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         let account_scoped = account.is_some();
         let bankruptcy_hlock_active = decode_bool(self.header.bankruptcy_hlock_active)?;
         if let Some(account) = account {
-            if decode_bool(account.header.stale_state)?
+            if decode_bool(account.header.liquidation_lock)?
+                || decode_bool(account.header.stale_state)?
                 || decode_bool(account.header.b_stale_state)?
                 || self.account_has_loss_stale_live_leg(account)?
             {
@@ -15742,6 +15754,19 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             || leg.stale
         {
             return Err(V16Error::InvalidLeg);
+        }
+        let remaining_active_bitmap =
+            active_bitmap_with_cleared(account.header.active_bitmap.map(V16PodU64::get), leg_slot)?;
+        // Account PnL is cross-margin and does not retain negative-loss provenance.
+        // Preserve that fact across the detach so later liquidation can reduce
+        // risk without charging the selected surviving asset domain.
+        if uncovered_loss_remains_with_open_risk(
+            account.header.pnl.get(),
+            account.header.capital.get(),
+            remaining_active_bitmap,
+        ) {
+            account.header.liquidation_lock = encode_bool(true);
+            account.header.health_cert.valid = 0;
         }
         let close_progress = account.header.close_progress.try_to_runtime()?;
         if close_progress.has_pending_residual() {
@@ -16608,14 +16633,36 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         )? {
             return Err(V16Error::LockActive);
         }
-        if liquidation_close_would_leave_uncovered_loss_with_open_risk(
-            account.header.pnl.get(),
-            account.header.capital.get(),
+        // A multi-asset deficit has no safe per-domain attribution in the
+        // account-global PnL scalar. Permissionless liquidation can still remove
+        // bounded risk, but it must not consume insurance or book B against the
+        // selected surviving asset.
+        if decode_bool(account.header.liquidation_lock)? {
+            self.reduce_position(account, request.asset_index, close_q)?;
+            self.certify_account_after_local_settlement_with_price_override(account, None)?;
+            self.begin_zero_oi_residue_resets(request.asset_index)?;
+            self.validate_liquidation_progress_from_score(before_score, &account.as_view())?;
+            self.validate_shape_audit_scan()?;
+            self.validate_account_audit_scan(&account.as_view())?;
+            return Ok(LiquidationOutcomeV16 {
+                closed_q: close_q,
+                insurance_used: 0,
+                residual_booked: 0,
+                explicit_loss: 0,
+                fee_charged: 0,
+            });
+        }
+        let remaining_active_bitmap = liquidation_remaining_active_bitmap_after_close(
             account.header.active_bitmap.map(V16PodU64::get),
             leg_slot,
             close_q,
             account_effective_q,
-        )? {
+        )?;
+        if uncovered_loss_remains_with_open_risk(
+            account.header.pnl.get(),
+            account.header.capital.get(),
+            remaining_active_bitmap,
+        ) {
             self.declare_permissionless_recovery(
                 PermissionlessRecoveryReasonV16::ActiveBankruptCloseCannotProgress,
             )?;
@@ -17325,6 +17372,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     .ok_or(V16Error::CounterUnderflow)?,
             );
         }
+        Self::sync_unattributed_loss_lock(account, new_pnl)?;
         account.header.pnl = V16PodI128::new(new_pnl);
         Ok(())
     }
@@ -19800,6 +19848,8 @@ pub struct PortfolioAccountV16Account {
     pub stale_state: u8,
     pub b_stale_state: u8,
     pub rebalance_lock: u8,
+    // Set while negative PnL has crossed more than one active asset and therefore
+    // cannot be safely charged to any one asset's insurance/B domain.
     pub liquidation_lock: u8,
     pub close_progress: CloseProgressLedgerV16Account,
     pub resolved_payout_receipt: ResolvedPayoutReceiptV16Account,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -174,6 +174,14 @@ pub fn kani_liquidation_close_would_leave_uncovered_loss_with_open_risk(
     ))
 }
 
+pub fn kani_unattributed_loss_lock_after_pnl(
+    was_locked: bool,
+    active_bitmap: V16ActiveBitmap,
+    new_pnl: i128,
+) -> bool {
+    unattributed_loss_lock_after_pnl(was_locked, active_bitmap, new_pnl)
+}
+
 pub fn kani_liquidation_projected_health_deficit_from_parts(
     certified_equity: i128,
     certified_maintenance_req: u128,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -161,14 +161,17 @@ pub fn kani_liquidation_close_would_leave_uncovered_loss_with_open_risk(
     close_q: u128,
     leg_abs_q: u128,
 ) -> V16Result<bool> {
-    liquidation_close_would_leave_uncovered_loss_with_open_risk(
-        pnl,
-        capital,
+    let remaining_active_bitmap = liquidation_remaining_active_bitmap_after_close(
         active_bitmap,
         leg_slot_index,
         close_q,
         leg_abs_q,
-    )
+    )?;
+    Ok(uncovered_loss_remains_with_open_risk(
+        pnl,
+        capital,
+        remaining_active_bitmap,
+    ))
 }
 
 pub fn kani_liquidation_projected_health_deficit_from_parts(

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -25,8 +25,9 @@ use percolator::v16::{
     kani_source_credit_state_realizable_support_for_claim_num,
     kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
     kani_terminal_claim_free_overlap_recredit, kani_trade_preexisting_oi_reduction_gate,
-    kani_trade_preflight_risk_gate, kani_validate_positive_pnl_source_attribution, AccrualStepV16,
-    ActionableSummaryV16, AssetLifecycleV16, AssetStateV16, AssetStateV16Account, AutoCrankPlanV16,
+    kani_trade_preflight_risk_gate, kani_unattributed_loss_lock_after_pnl,
+    kani_validate_positive_pnl_source_attribution, AccrualStepV16, ActionableSummaryV16,
+    AssetLifecycleV16, AssetStateV16, AssetStateV16Account, AutoCrankPlanV16,
     BackingBucketStatusV16, BackingBucketV16, BackingBucketV16Account, BatchTradeOutcomeV16,
     CloseProgressLedgerV16, CloseProgressLedgerV16Account, EngineAssetSlotV16Account, HLockLaneV16,
     HealthCertV16, HealthCertV16Account, InsuranceCreditReservationV16,
@@ -39,7 +40,7 @@ use percolator::v16::{
     ResolvedPayoutLedgerV16, ResolvedPayoutLedgerV16Account, ResolvedPayoutReceiptV16,
     ResolvedPayoutReceiptV16Account, SideModeV16, SideV16, SourceCreditStateV16,
     SourceCreditStateV16Account, StockReconciliationProofV16, TokenValueClassV16,
-    TokenValueFlowProofV16, V16Config, V16ConfigAccount, V16Error,
+    TokenValueFlowProofV16, V16ActiveBitmap, V16Config, V16ConfigAccount, V16Error,
     V16OptionalRecoveryReasonAccount, V16PodI128, V16PodU128, V16PodU32, V16PodU64,
     BACKING_FEE_RATE_DEN_E9, MAX_BACKING_FEE_RATE_E9_PER_SLOT, MAX_BACKING_FEE_UTIL_BPS,
     PORTFOLIO_SOURCE_DOMAIN_CAP, V16_EMPTY_ACTIVE_BITMAP, V16_MAX_PORTFOLIO_ASSETS_N,
@@ -5710,6 +5711,34 @@ fn proof_v16_liquidation_cannot_leave_uncovered_loss_with_other_open_risk() {
         uncovered && close_q < leg_abs_q
     );
     assert!(!covered_loss_with_other_risk);
+}
+
+#[kani::proof]
+#[kani::unwind(8)]
+fn proof_v16_unattributed_loss_lock_is_exact_and_sticky_until_repaid() {
+    let was_locked: bool = kani::any();
+    let active_bitmap: V16ActiveBitmap = kani::any();
+    let new_pnl: i128 = kani::any();
+    let active_assets = active_bitmap_count_ones(active_bitmap);
+    let locked = kani_unattributed_loss_lock_after_pnl(was_locked, active_bitmap, new_pnl);
+
+    assert_eq!(locked, new_pnl < 0 && (was_locked || active_assets > 1));
+    assert!(!locked || new_pnl < 0);
+    assert!(new_pnl >= 0 || !was_locked || locked);
+    assert!(new_pnl >= 0 || active_assets <= 1 || locked);
+
+    kani::cover!(
+        new_pnl < 0 && !was_locked && active_assets > 1 && locked,
+        "multi-asset negative PnL becomes unattributed"
+    );
+    kani::cover!(
+        new_pnl < 0 && was_locked && active_assets <= 1 && locked,
+        "unattributed negative PnL remains locked after a leg detaches"
+    );
+    kani::cover!(
+        new_pnl >= 0 && was_locked && !locked,
+        "repaying the deficit clears the unattributed-loss lock"
+    );
 }
 
 #[kani::proof]

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -7608,6 +7608,10 @@ fn v16_trade_does_not_charge_prior_multi_asset_deficit_or_force_market_recovery(
         .expect("the first risk-reducing close must remain available");
     assert_eq!(short.header.pnl.get(), -250);
     assert_eq!(
+        short.header.liquidation_lock, 1,
+        "detaching one leg from an uncovered multi-asset deficit must retain its unattributed-loss marker"
+    );
+    assert_eq!(
         short
             .header
             .close_progress
@@ -7632,6 +7636,7 @@ fn v16_trade_does_not_charge_prior_multi_asset_deficit_or_force_market_recovery(
     assert!(active_bitmap_is_empty(
         short.header.active_bitmap.map(V16PodU64::get)
     ));
+    assert_eq!(short.header.liquidation_lock, 1);
     let ledger = short.header.close_progress.try_to_runtime().unwrap();
     assert_eq!(ledger.residual_remaining, 0);
     assert!(
@@ -7654,6 +7659,7 @@ fn v16_trade_does_not_charge_prior_multi_asset_deficit_or_force_market_recovery(
         percolator::ResolvedCloseOutcomeV16::Closed { payout: 0 }
     ));
     assert_eq!(short.header.pnl.get(), 0);
+    assert_eq!(short.header.liquidation_lock, 0);
     market.validate_shape().unwrap();
     long.validate_with_market(&market.as_view()).unwrap();
     short.validate_with_market(&market.as_view()).unwrap();


### PR DESCRIPTION
Stacked on #186.

A finding-blind public LiteSVM trace on the parent pin opens two assets, realizes a loss, detaches the loss-bearing leg, and then invokes the sole automatic crank. Before this change, the surviving asset was treated as the loss source: 100,100 atoms of unrelated-domain insurance were spent and the attacker-controlled coalition extracted 95,500 atoms of profit.

The fix reuses the existing `liquidation_lock` field. Unattributed multi-asset loss remains locked across detach; automatic liquidation remains permissionless and risk-reducing, but cannot spend insurance, book B, assign explicit loss, or charge a fee to an arbitrary surviving domain. No layout or API changes are introduced.

Verification:
- engine `cargo test --features fuzz`: 129/129
- existing uncovered-loss Kani theorem: 0/103 failed, 2/2 covers
- sticky-lock lifecycle Kani theorem: 0/7 failed, 3/3 covers
- wrapper PR #135 exact SBF: 101/101 regressions, 205/205 stateful, 886/886 CU, 174/174 wrapper Kani
- fixed public trace: one strict risk-reducing crank, zero foreign insurance spend, zero coalition profit, exact no-progress rollback, bounded exit, exact SPL supply reconciliation