### PR TITLE
[REAL LoF] Preserve source-local backing attribution

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -17755,7 +17755,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Ok(0);
         }
         let has_source_claims = Self::account_has_source_claims(&account.as_view())?;
-        if has_source_claims && self.account_has_active_source_claim_exposure(&account.as_view())? {
+        if has_source_claims
+            && (Self::account_has_source_liens(&account.as_view())
+                || self.account_has_active_source_claim_exposure(&account.as_view())?)
+        {
             return Err(V16Error::LockActive);
         }
         let converted = if has_source_claims {
@@ -17785,29 +17788,34 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         has_source_claims: bool,
         disposition: ReleasedPnlConversionDispositionV16,
     ) -> V16Result<u128> {
-        let consumption = if has_source_claims {
-            self.consume_validated_account_source_credit_not_atomic(
-                account, converted, false, true,
-            )?
-            .0
+        let (consumption, preburned_source_claim_num) = if has_source_claims {
+            let (consumption, preburned_source_claim_num, _) = self
+                .consume_validated_account_source_credit_not_atomic(
+                    account, converted, true, true,
+                )?;
+            (consumption, preburned_source_claim_num)
         } else {
             let residual = self.residual();
             let junior_bound = self.junior_claim_bound();
-            SourceCreditConsumptionV16 {
-                face_burn: self.face_claim_to_burn_for_support(
-                    converted,
-                    residual,
-                    junior_bound,
-                )?,
-                counterparty_credit_consumed: 0,
-                insurance_credit_consumed: 0,
-            }
+            (
+                SourceCreditConsumptionV16 {
+                    face_burn: self.face_claim_to_burn_for_support(
+                        converted,
+                        residual,
+                        junior_bound,
+                    )?,
+                    counterparty_credit_consumed: 0,
+                    insurance_credit_consumed: 0,
+                },
+                0,
+            )
         };
         self.apply_released_pnl_conversion_with_consumption_core_not_atomic(
             account,
             pos,
             converted,
             consumption,
+            preburned_source_claim_num,
             disposition,
         )
     }
@@ -17818,6 +17826,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         pos: u128,
         converted: u128,
         consumption: SourceCreditConsumptionV16,
+        preburned_source_claim_num: u128,
         disposition: ReleasedPnlConversionDispositionV16,
     ) -> V16Result<u128> {
         if converted == 0 || converted > pos.saturating_sub(account.header.reserved_pnl.get()) {
@@ -17844,12 +17853,19 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             .ok_or(V16Error::ArithmeticOverflow)?;
         match disposition {
             ReleasedPnlConversionDispositionV16::ConsumeHaircutFace => {
-                self.set_account_pnl(account, new_pnl)?;
+                self.set_account_pnl_after_source_claim_burn(
+                    account,
+                    new_pnl,
+                    preburned_source_claim_num,
+                )?;
             }
             ReleasedPnlConversionDispositionV16::RetainHaircutFaceForTerminalDomain {
                 source_domain,
                 source_claim_num,
             } => {
+                if preburned_source_claim_num != 0 {
+                    return Err(V16Error::InvalidConfig);
+                }
                 self.burn_account_source_claim_bound_num_domain_first(
                     account,
                     source_domain,
@@ -18427,6 +18443,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                     pos,
                     converted,
                     consumption,
+                    0,
                     ReleasedPnlConversionDispositionV16::RetainHaircutFaceForTerminalDomain {
                         source_domain,
                         source_claim_num,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -1305,7 +1305,8 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account: &PortfolioV16View<'_>,
     ) -> V16Result<bool> {
         Ok(Self::account_has_source_claims(account)?
-            && self.account_has_active_source_claim_exposure(account)?)
+            && (Self::account_has_source_liens(account)
+                || self.account_has_active_source_claim_exposure(account)?))
     }
 
     pub fn kani_preflight_convert_released_pnl_to_capital(

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -4197,6 +4197,45 @@ fn proof_v16_open_source_claim_exposure_blocks_convert() {
     assert!(blocked);
 }
 
+#[kani::proof]
+#[kani::unwind(48)]
+#[kani::solver(cadical)]
+fn proof_v16_flat_source_claim_lien_blocks_convert() {
+    let claim_raw: u8 = kani::any();
+    kani::assume(claim_raw > 0);
+    let claim = claim_raw as u128;
+    let face_num = claim * BOUND_SCALE;
+    let (mut header, mut markets, mut account_header) = one_market_view_fixture();
+    let market_id = markets[0].engine.asset.market_id.get();
+
+    account_header.pnl = V16PodI128::new(claim as i128);
+    account_header.source_domains[0] = PortfolioSourceDomainV16Account {
+        domain: V16PodU32::new(0),
+        source_claim_market_id: V16PodU64::new(market_id),
+        source_claim_bound_num: V16PodU128::new(face_num),
+        source_claim_liened_num: V16PodU128::new(face_num),
+        source_claim_counterparty_liened_num: V16PodU128::new(face_num),
+        source_lien_effective_reserved: V16PodU128::new(claim),
+        source_lien_counterparty_backing_num: V16PodU128::new(face_num),
+        ..PortfolioSourceDomainV16Account::default()
+    };
+    let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let account = PortfolioV16ViewMut::new(&mut account_header);
+
+    let blocked = market
+        .kani_convert_source_claim_exposure_guard(&account.as_view())
+        .unwrap();
+
+    kani::cover!(
+        blocked && claim > 10,
+        "flat source claim with a live lien reaches convert guard"
+    );
+    assert!(blocked);
+    assert!(active_bitmap_is_empty(
+        account.header.active_bitmap.map(V16PodU64::get)
+    ));
+}
+
 // Public-path favorable-action freshness: conversion preflight accepts exactly
 // the current/unlocked branch and rejects stale certificates or h-lock lanes
 // before value mutation. This links the cert-currentness/h-lock kernels to the

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -5153,6 +5153,92 @@ fn v16_auto_crank_releases_source_liens_in_strict_chunks() {
 }
 
 #[test]
+fn v16_released_pnl_conversion_consumes_the_backed_source_claim_exactly_once() {
+    const CLAIM: u128 = 100;
+    const BACKING: u128 = 2 * CLAIM;
+    let claim_num = CLAIM * BOUND_SCALE;
+    let backing_num = BACKING * BOUND_SCALE;
+    let (mut header, mut markets) = market_fixture(1, 1);
+    let mut winner_header = account_fixture(1, 12);
+
+    winner_header.pnl = V16PodI128::new((2 * CLAIM) as i128);
+    for domain in 0..2 {
+        winner_header.source_domains[domain].domain = V16PodU32::new(domain as u32);
+        winner_header.source_domains[domain].source_claim_market_id = V16PodU64::new(1);
+        winner_header.source_domains[domain].source_claim_bound_num = V16PodU128::new(claim_num);
+    }
+    header.pnl_pos_tot = V16PodU128::new(2 * CLAIM);
+    header.pnl_pos_bound_tot_num = V16PodU128::new(2 * claim_num);
+    header.pnl_pos_bound_tot = V16PodU128::new(2 * CLAIM);
+    header.source_claim_bound_total_num = V16PodU128::new(2 * claim_num);
+    header.source_fresh_backing_total_num = V16PodU128::new(backing_num);
+    header.vault = V16PodU128::new(BACKING);
+
+    markets[0].engine.source_credit_long =
+        SourceCreditStateV16Account::from_runtime(&SourceCreditStateV16 {
+            positive_claim_bound_num: claim_num,
+            exact_positive_claim_num: claim_num,
+            credit_rate_num: 0,
+            ..SourceCreditStateV16::EMPTY
+        });
+    markets[0].engine.backing_long = BackingBucketV16Account::from_runtime(&BackingBucketV16 {
+        market_id: 1,
+        ..BackingBucketV16::EMPTY
+    });
+    markets[0].engine.source_credit_short =
+        SourceCreditStateV16Account::from_runtime(&SourceCreditStateV16 {
+            positive_claim_bound_num: claim_num,
+            exact_positive_claim_num: claim_num,
+            fresh_reserved_backing_num: backing_num,
+            credit_rate_num: CREDIT_RATE_SCALE,
+            ..SourceCreditStateV16::EMPTY
+        });
+    markets[0].engine.backing_short = BackingBucketV16Account::from_runtime(&BackingBucketV16 {
+        market_id: 1,
+        fresh_unliened_backing_num: backing_num,
+        expiry_slot: 100,
+        status: BackingBucketStatusV16::Fresh,
+        ..BackingBucketV16::EMPTY
+    });
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut winner = PortfolioV16ViewMut::new(&mut winner_header);
+    market
+        .validate_shape()
+        .expect("cross-domain fixture must be a valid market state");
+    winner
+        .validate_with_market(&market.as_view())
+        .expect("cross-domain fixture must be a valid portfolio state");
+    market.full_account_refresh_not_atomic(&mut winner).unwrap();
+
+    assert_eq!(
+        market
+            .convert_released_pnl_to_capital_not_atomic(&mut winner)
+            .expect("the funded source claim must convert"),
+        CLAIM
+    );
+    assert_eq!(winner.header.capital.get(), CLAIM);
+    assert_eq!(winner.header.pnl.get(), CLAIM as i128);
+    assert_eq!(winner.header.source_domains[0].domain.get(), 0);
+    assert_eq!(
+        winner.header.source_domains[0].source_claim_bound_num.get(),
+        claim_num,
+        "the unfunded source claim must not be burned for another domain's backing"
+    );
+    assert_eq!(winner.header.source_domains[1], Default::default());
+
+    market.full_account_refresh_not_atomic(&mut winner).unwrap();
+    assert_eq!(
+        market.convert_released_pnl_to_capital_not_atomic(&mut winner),
+        Err(V16Error::LockActive),
+        "the same funded source backing must not convert a second source claim"
+    );
+    assert_eq!(winner.header.capital.get(), CLAIM);
+    winner.validate_with_market(&market.as_view()).unwrap();
+    market.validate_shape().unwrap();
+}
+
+#[test]
 fn v16_residual_reward_credit_is_capped_by_available_crystallized_loss() {
     let (mut header, mut markets) = market_fixture(1, 1_000);
     header.config.initial_margin_bps = V16PodU64::new(500);


### PR DESCRIPTION
## Impact
A portfolio with equal claims in two source domains could consume backing from the funded domain while the generic PnL update burned the first, unfunded claim. The remaining funded claim could then consume the same backing a second time and become withdrawable value.

## Fix
- burn each source claim in the same bounded loop that consumes that source backing
- carry the preburned face into the canonical PnL update
- block conversion while source liens remain so non-atomic engine callers cannot observe partial mutation
- add exact-once runtime coverage and symbolic proofs for both flat source liens and active source exposure

No layout, API, or persisted-state change.

## Verification
- `cargo test --all-targets`: 187/187
- `proof_v16_flat_source_claim_lien_blocks_convert`: pass, cover satisfied
- `proof_v16_open_source_claim_exposure_blocks_convert`: pass, cover satisfied
- wrapper fixed-seed and generated LiteSVM invariant coverage passes on exact pin `422893fa`