### PR TITLE
[REAL DoS] Restore live progress for impaired source liens

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Source-checkable counts in this checkout:
 | --- | ---: |
 | Plain Kani proofs in `tests/proofs_v16.rs` | 289 |
 | Plain Kani proofs in `tests/proofs_v16_arithmetic.rs` | 11 |
-| Plain Kani proofs in `src/v16_proofs.rs` | 38 |
+| Plain Kani proofs in `src/v16_proofs.rs` | 40 |
 | Function-contract proofs in `src/v16_proofs.rs` | 51 |
 | Production `kernel_*` helpers in `src/v16.rs` | 17 |
 | Public `*_not_atomic` engine APIs in `src/v16.rs` | 55 |

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -3493,6 +3493,52 @@ impl V16Core {
         (None, false)
     }
 
+    /// Select one bounded flat-account source-lien transition. Impaired
+    /// counterparty backing is crystallized before any other component in that
+    /// domain; otherwise every live component must be current and releasable so
+    /// the per-domain release remains atomic.
+    fn kernel_flat_source_lien_normalization(
+        source_claim_liened_num: u128,
+        counterparty_backing_num: u128,
+        insurance_backing_num: u128,
+        bucket_status: BackingBucketStatusV16,
+        bucket_expiry_slot: u64,
+        now_slot: u64,
+        bucket_valid_liened_num: u128,
+        bucket_impaired_liened_num: u128,
+        source_valid_liened_backing_num: u128,
+        source_impaired_liened_backing_num: u128,
+        reservation_valid_liened_insurance_num: u128,
+        source_valid_liened_insurance_num: u128,
+    ) -> FlatSourceLienNormalizationV16 {
+        if source_claim_liened_num == 0
+            || (counterparty_backing_num == 0 && insurance_backing_num == 0)
+        {
+            return FlatSourceLienNormalizationV16::None;
+        }
+        if counterparty_backing_num != 0
+            && bucket_status == BackingBucketStatusV16::Impaired
+            && bucket_impaired_liened_num >= counterparty_backing_num
+            && source_impaired_liened_backing_num >= counterparty_backing_num
+        {
+            return FlatSourceLienNormalizationV16::ImpairCounterparty;
+        }
+        let counterparty_releasable = counterparty_backing_num == 0
+            || (bucket_status == BackingBucketStatusV16::Fresh
+                && bucket_expiry_slot > now_slot
+                && bucket_valid_liened_num >= counterparty_backing_num
+                && source_valid_liened_backing_num >= counterparty_backing_num);
+        let insurance_releasable = insurance_backing_num == 0
+            || (insurance_backing_num % BOUND_SCALE == 0
+                && reservation_valid_liened_insurance_num >= insurance_backing_num
+                && source_valid_liened_insurance_num >= insurance_backing_num);
+        if counterparty_releasable && insurance_releasable {
+            FlatSourceLienNormalizationV16::Release
+        } else {
+            FlatSourceLienNormalizationV16::None
+        }
+    }
+
     /// PRODUCTION KERNEL: every Live account-local obligation serviced by the
     /// refresh continuation must make that continuation actionable. In
     /// particular, clock-driven backing expiry is independent of certificate
@@ -3505,6 +3551,17 @@ impl V16Core {
         lapsed_source_backing: bool,
     ) -> bool {
         live && (!cert_current || reset_obligation || released_obligation || lapsed_source_backing)
+    }
+
+    fn kernel_live_flat_source_lien_normalization_required(
+        live: bool,
+        cert_current: bool,
+        lapsed_source_backing: bool,
+        flat: bool,
+        margin_safe: bool,
+        normalizable_lien: bool,
+    ) -> bool {
+        live && cert_current && !lapsed_source_backing && flat && margin_safe && normalizable_lien
     }
 
     // Contract layer: lien release is the un-pledge relabel — valid liened
@@ -6957,6 +7014,13 @@ enum SourceCreditBackingSourceV16 {
     Insurance,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FlatSourceLienNormalizationV16 {
+    None,
+    ImpairCounterparty,
+    Release,
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RebalanceRequestV16 {
@@ -10036,12 +10100,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         false
     }
 
-    fn account_source_credit_liens_are_fresh_and_releasable(
+    fn account_has_normalizable_source_credit_lien(
         &self,
         account: &PortfolioV16View<'_>,
         now_slot: u64,
     ) -> V16Result<bool> {
-        let mut found = false;
         let mut slot = 0usize;
         while slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
             let source = account.source_domains()[slot];
@@ -10049,35 +10112,34 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 break;
             }
             if source.is_occupied() && source.source_claim_liened_num.get() != 0 {
-                found = true;
                 let domain = source.domain.get() as usize;
                 self.domain_asset_side(domain)?;
                 let counterparty_backing = source.source_lien_counterparty_backing_num.get();
                 let insurance_backing = source.source_lien_insurance_backing_num.get();
                 let source_credit = self.source_credit_for_domain(domain)?;
-                if counterparty_backing != 0 {
-                    let bucket = self.backing_bucket_for_domain(domain)?;
-                    if bucket.status != BackingBucketStatusV16::Fresh
-                        || bucket.expiry_slot <= now_slot
-                        || bucket.valid_liened_backing_num < counterparty_backing
-                        || source_credit.valid_liened_backing_num < counterparty_backing
-                    {
-                        return Ok(false);
-                    }
-                }
-                if insurance_backing != 0 {
-                    let reservation = self.insurance_reservation_for_domain(domain)?;
-                    if insurance_backing % BOUND_SCALE != 0
-                        || reservation.valid_liened_insurance_num < insurance_backing
-                        || source_credit.valid_liened_insurance_num < insurance_backing
-                    {
-                        return Ok(false);
-                    }
+                let bucket = self.backing_bucket_for_domain(domain)?;
+                let reservation = self.insurance_reservation_for_domain(domain)?;
+                if V16Core::kernel_flat_source_lien_normalization(
+                    source.source_claim_liened_num.get(),
+                    counterparty_backing,
+                    insurance_backing,
+                    bucket.status,
+                    bucket.expiry_slot,
+                    now_slot,
+                    bucket.valid_liened_backing_num,
+                    bucket.impaired_liened_backing_num,
+                    source_credit.valid_liened_backing_num,
+                    source_credit.impaired_liened_backing_num,
+                    reservation.valid_liened_insurance_num,
+                    source_credit.valid_liened_insurance_num,
+                ) != FlatSourceLienNormalizationV16::None
+                {
+                    return Ok(true);
                 }
             }
             slot += 1;
         }
-        Ok(found)
+        Ok(false)
     }
 
     fn source_claim_unliened_num(account: &PortfolioV16View<'_>, domain: usize) -> V16Result<u128> {
@@ -14342,12 +14404,23 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             && has_open_risk
             && reset_obligation_asset.is_none();
         let no_positive_equity = Self::account_no_positive_credit_equity(account)?;
-        let source_liens_releasable = live
-            && cert_current
-            && active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get))
-            && no_positive_equity >= 0
-            && (no_positive_equity as u128) >= cert.certified_initial_req
-            && self.account_source_credit_liens_are_fresh_and_releasable(account, now_slot)?;
+        let flat = active_bitmap_is_empty(account.header.active_bitmap.map(V16PodU64::get));
+        let source_lien_margin_safe =
+            no_positive_equity >= 0 && (no_positive_equity as u128) >= cert.certified_initial_req;
+        let normalizable_source_lien =
+            if live && cert_current && !lapsed_source_backing && flat && source_lien_margin_safe {
+                self.account_has_normalizable_source_credit_lien(account, now_slot)?
+            } else {
+                false
+            };
+        let source_liens_releasable = V16Core::kernel_live_flat_source_lien_normalization_required(
+            live,
+            cert_current,
+            lapsed_source_backing,
+            flat,
+            source_lien_margin_safe,
+            normalizable_source_lien,
+        );
         // A completed account-local bankruptcy must not let that account force a
         // market-wide Recovery. In particular, a permissionless asset can be
         // attacker-controlled while unrelated assets remain healthy. Outstanding
@@ -17979,9 +18052,12 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Err(V16Error::LockActive);
         }
 
-        // Release a fixed number of domains per call. Each domain touches both
-        // account-local and market-wide attribution; releasing the full sparse
-        // table in one SBF instruction can exceed the transaction CU meter.
+        // Normalize a fixed number of domains per call. Each domain touches both
+        // account-local and market-wide attribution; processing the full sparse
+        // table in one SBF instruction can exceed the transaction CU meter. A
+        // globally impaired counterparty lien must first move into the account's
+        // impaired-claim lane. Otherwise a flat account can retain a live lien
+        // that is neither releasable nor visible to the lapsed-bucket selector.
         let mut released_effective = 0u128;
         let mut released_domains = 0usize;
         let mut slot = 0usize;
@@ -18003,6 +18079,47 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             let effective = source_snapshot.source_lien_effective_reserved.get();
             let counterparty_backing = source_snapshot.source_lien_counterparty_backing_num.get();
             let insurance_backing = source_snapshot.source_lien_insurance_backing_num.get();
+            let bucket = self.backing_bucket_for_domain(d)?;
+            let source_credit = self.source_credit_for_domain(d)?;
+            let reservation = self.insurance_reservation_for_domain(d)?;
+            match V16Core::kernel_flat_source_lien_normalization(
+                source_snapshot.source_claim_liened_num.get(),
+                counterparty_backing,
+                insurance_backing,
+                bucket.status,
+                bucket.expiry_slot,
+                self.header.current_slot.get(),
+                bucket.valid_liened_backing_num,
+                bucket.impaired_liened_backing_num,
+                source_credit.valid_liened_backing_num,
+                source_credit.impaired_liened_backing_num,
+                reservation.valid_liened_insurance_num,
+                source_credit.valid_liened_insurance_num,
+            ) {
+                FlatSourceLienNormalizationV16::ImpairCounterparty => {
+                    self.collect_account_backing_utilization_fee_for_domain_not_atomic(account, d)?;
+                    self.retire_source_credit_lien_from_counterparty_impaired_not_atomic(
+                        d,
+                        counterparty_backing,
+                    )?;
+                    let impaired_effective =
+                        Self::impair_account_source_credit_counterparty_lien_fields(account, d)?;
+                    released_effective = released_effective
+                        .checked_add(impaired_effective)
+                        .ok_or(V16Error::ArithmeticOverflow)?;
+                    released_domains += 1;
+                    slot += 1;
+                    if released_domains == V16_SOURCE_LIEN_RELEASE_CHUNK_DOMAINS {
+                        break;
+                    }
+                    continue;
+                }
+                FlatSourceLienNormalizationV16::None => {
+                    slot += 1;
+                    continue;
+                }
+                FlatSourceLienNormalizationV16::Release => {}
+            }
             if counterparty_backing != 0 {
                 self.release_source_credit_lien_from_counterparty_core_not_atomic(
                     d,

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -1090,6 +1090,58 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         )
     }
 
+    pub fn kani_live_flat_source_lien_normalization_required(
+        live: bool,
+        cert_current: bool,
+        lapsed_source_backing: bool,
+        flat: bool,
+        margin_safe: bool,
+        normalizable_lien: bool,
+    ) -> bool {
+        V16Core::kernel_live_flat_source_lien_normalization_required(
+            live,
+            cert_current,
+            lapsed_source_backing,
+            flat,
+            margin_safe,
+            normalizable_lien,
+        )
+    }
+
+    pub fn kani_flat_source_lien_normalization(
+        source_claim_liened_num: u128,
+        counterparty_backing_num: u128,
+        insurance_backing_num: u128,
+        bucket_status: BackingBucketStatusV16,
+        bucket_expiry_slot: u64,
+        now_slot: u64,
+        bucket_valid_liened_num: u128,
+        bucket_impaired_liened_num: u128,
+        source_valid_liened_backing_num: u128,
+        source_impaired_liened_backing_num: u128,
+        reservation_valid_liened_insurance_num: u128,
+        source_valid_liened_insurance_num: u128,
+    ) -> u8 {
+        match V16Core::kernel_flat_source_lien_normalization(
+            source_claim_liened_num,
+            counterparty_backing_num,
+            insurance_backing_num,
+            bucket_status,
+            bucket_expiry_slot,
+            now_slot,
+            bucket_valid_liened_num,
+            bucket_impaired_liened_num,
+            source_valid_liened_backing_num,
+            source_impaired_liened_backing_num,
+            reservation_valid_liened_insurance_num,
+            source_valid_liened_insurance_num,
+        ) {
+            FlatSourceLienNormalizationV16::None => 0,
+            FlatSourceLienNormalizationV16::ImpairCounterparty => 1,
+            FlatSourceLienNormalizationV16::Release => 2,
+        }
+    }
+
     pub fn kani_source_credit_lien_amounts_for_effective(
         effective_credit: u128,
         credit_rate_num: u128,

--- a/src/v16_proofs.rs
+++ b/src/v16_proofs.rs
@@ -2268,6 +2268,172 @@ fn composition_attach_value_conservation_under_axiom() {
     assert_eq!(leg_basis, basis);
 }
 
+// Credit-rate arithmetic is already discharged against an independent model
+// in rounding_residue_fuzz. This abstraction preserves the exact extrema used
+// by the source-lien unwind (zero available backing => zero rate; no claim or
+// enough available backing => full rate) and over-approximates only the
+// division-bearing partial-haircut branch, which this composition never uses.
+#[cfg(all(kani, feature = "closure"))]
+fn axiom_source_credit_rate_extrema(state: SourceCreditStateV16) -> V16Result<u128> {
+    V16Core::validate_source_credit_state_shape_static(state)?;
+    let available = V16Core::available_backing_num_for_source_credit_state(state)?;
+    if state.positive_claim_bound_num == 0 || available >= state.positive_claim_bound_num {
+        return Ok(CREDIT_RATE_SCALE);
+    }
+    if available == 0 {
+        return Ok(0);
+    }
+    let rate: u128 = kani::any();
+    kani::assume(rate < CREDIT_RATE_SCALE);
+    Ok(rate)
+}
+
+#[cfg(all(kani, feature = "closure"))]
+fn complete_counterparty_source_lien_fixture(
+    claim: u128,
+) -> (
+    MarketGroupV16HeaderAccount,
+    [Market<u64>; 1],
+    PortfolioAccountV16Account,
+) {
+    let face_num = claim * BOUND_SCALE;
+    let cfg = V16Config::public_user_fund_with_market_slots(1, 1, 0, 10);
+    let mut header = MarketGroupV16HeaderAccount::new_dynamic([1u8; 32], cfg, 1, 0).unwrap();
+    let mut markets = [Market::new(0u64, EngineAssetSlotV16Account::default())];
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        market.activate_empty_market_not_atomic(0, 100, 1).unwrap();
+    }
+    let mut account = PortfolioAccountV16Account::default();
+    account
+        .init_empty_in_place(ProvenanceHeaderV16Account::from_runtime(
+            &ProvenanceHeaderV16::new([1u8; 32], [2u8; 32], [3u8; 32]),
+        ))
+        .unwrap();
+    let market_id = markets[0].engine.asset.market_id.get();
+    header.vault = V16PodU128::new(claim);
+    header.pnl_pos_tot = V16PodU128::new(claim);
+    header.pnl_pos_bound_tot = V16PodU128::new(claim);
+    header.pnl_pos_bound_tot_num = V16PodU128::new(face_num);
+    header.source_claim_bound_total_num = V16PodU128::new(face_num);
+    header.source_fresh_backing_total_num = V16PodU128::new(face_num);
+    account.pnl = V16PodI128::new(claim as i128);
+    account.source_domains[0] = PortfolioSourceDomainV16Account {
+        domain: V16PodU32::new(0),
+        source_claim_market_id: V16PodU64::new(market_id),
+        source_claim_bound_num: V16PodU128::new(face_num),
+        source_claim_liened_num: V16PodU128::new(face_num),
+        source_claim_counterparty_liened_num: V16PodU128::new(face_num),
+        source_lien_effective_reserved: V16PodU128::new(claim),
+        source_lien_counterparty_backing_num: V16PodU128::new(face_num),
+        ..PortfolioSourceDomainV16Account::default()
+    };
+    markets[0].engine.backing_long = BackingBucketV16Account::from_runtime(&BackingBucketV16 {
+        market_id,
+        valid_liened_backing_num: face_num,
+        expiry_slot: 100,
+        status: BackingBucketStatusV16::Fresh,
+        ..BackingBucketV16::EMPTY
+    });
+    markets[0].engine.source_credit_long =
+        SourceCreditStateV16Account::from_runtime(&SourceCreditStateV16 {
+            positive_claim_bound_num: face_num,
+            exact_positive_claim_num: face_num,
+            fresh_reserved_backing_num: face_num,
+            valid_liened_backing_num: face_num,
+            credit_rate_num: 0,
+            ..SourceCreditStateV16::EMPTY
+        });
+    (header, markets, account)
+}
+
+// Nonvacuity companion for the whole-setter composition below. Keeping the
+// fixture in one constructor prevents the validity proof and mutation proof
+// from silently drifting while avoiding three full validation scans in one
+// CBMC query.
+#[cfg(all(kani, feature = "closure"))]
+#[kani::proof]
+#[kani::unwind(48)]
+#[kani::solver(cadical)]
+#[kani::stub(
+    V16Core::expected_source_credit_rate_num_for_state,
+    axiom_source_credit_rate_extrema
+)]
+fn composition_complete_counterparty_source_lien_fixture_is_valid_under_rate_axiom() {
+    let claim_raw: u8 = kani::any();
+    kani::assume((1..=8).contains(&claim_raw));
+    let (mut header, mut markets, mut account_header) =
+        complete_counterparty_source_lien_fixture(claim_raw as u128);
+    let market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let account = PortfolioV16ViewMut::new(&mut account_header);
+
+    assert_eq!(market.validate_shape(), Ok(()));
+    assert_eq!(account.validate_with_market(&market.as_view()), Ok(()));
+    kani::cover!(claim_raw > 1, "nontrivial valid complete source lien");
+}
+
+// INV-071/073 whole-setter composition: a valid live positive-PnL claim whose
+// complete face is counterparty-liened cannot survive the canonical PnL setter
+// crossing below zero. Every close-producing route uses this setter before it
+// can install a pending residual, so a source-lien release cannot remain hidden
+// behind the higher-priority close continuation.
+#[cfg(all(kani, feature = "closure"))]
+#[kani::proof]
+#[kani::unwind(48)]
+#[kani::solver(cadical)]
+#[kani::stub(
+    V16Core::expected_source_credit_rate_num_for_state,
+    axiom_source_credit_rate_extrema
+)]
+fn composition_positive_to_negative_pnl_consumes_complete_source_lien_under_rate_axiom() {
+    let claim_raw: u8 = kani::any();
+    let loss_raw: u8 = kani::any();
+    kani::assume((1..=8).contains(&claim_raw));
+    kani::assume((1..=8).contains(&loss_raw));
+    let claim = claim_raw as u128;
+    let face_num = claim * BOUND_SCALE;
+    let loss = loss_raw as i128;
+
+    let (mut header, mut markets, mut account_header) =
+        complete_counterparty_source_lien_fixture(claim);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut account = PortfolioV16ViewMut::new(&mut account_header);
+
+    market.set_account_pnl(&mut account, -loss).unwrap();
+
+    kani::cover!(
+        claim > 1 && loss > 1,
+        "nontrivial source-lien loss crossing"
+    );
+    assert_eq!(account.header.pnl.get(), -loss);
+    assert!(account
+        .header
+        .source_domains
+        .iter()
+        .all(|source| source.source_claim_bound_num.get() == 0
+            && source.source_claim_liened_num.get() == 0
+            && source.source_claim_impaired_num.get() == 0));
+    let bucket = market.markets[0]
+        .engine
+        .backing_long
+        .try_to_runtime()
+        .unwrap();
+    let source = market.markets[0]
+        .engine
+        .source_credit_long
+        .try_to_runtime()
+        .unwrap();
+    assert_eq!(bucket.fresh_unliened_backing_num, face_num);
+    assert_eq!(bucket.valid_liened_backing_num, 0);
+    assert_eq!(source.positive_claim_bound_num, 0);
+    assert_eq!(source.exact_positive_claim_num, 0);
+    assert_eq!(source.valid_liened_backing_num, 0);
+    assert_eq!(market.header.pnl_pos_tot.get(), 0);
+    assert_eq!(market.header.pnl_pos_bound_tot_num.get(), 0);
+    assert_eq!(market.header.source_claim_bound_total_num.get(), 0);
+}
+
 // VALUE-CONSERVATION composition for the CLEAR body — the inverse of attach,
 // and a second instance of the helper-stub recipe (the review's named next
 // candidate). clear has NO division (it subtracts the leg's STORED weight), so

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -7917,6 +7917,145 @@ fn proof_v16_lapsed_source_backing_forces_live_refresh_even_with_current_cert() 
 }
 
 #[kani::proof]
+fn proof_v16_lapsed_source_backing_preempts_flat_lien_normalization() {
+    let live: bool = kani::any();
+    let cert_current: bool = kani::any();
+    let lapsed_source_backing: bool = kani::any();
+    let flat: bool = kani::any();
+    let margin_safe: bool = kani::any();
+    let normalizable_lien: bool = kani::any();
+    let selected = MarketGroupV16ViewMut::<u64>::kani_live_flat_source_lien_normalization_required(
+        live,
+        cert_current,
+        lapsed_source_backing,
+        flat,
+        margin_safe,
+        normalizable_lien,
+    );
+    assert_eq!(
+        selected,
+        live && cert_current && !lapsed_source_backing && flat && margin_safe && normalizable_lien
+    );
+    if lapsed_source_backing {
+        assert!(!selected);
+    }
+
+    kani::cover!(
+        live && cert_current && lapsed_source_backing && flat && margin_safe && normalizable_lien
+    );
+    kani::cover!(selected);
+    kani::cover!(!live && !selected);
+}
+
+#[kani::proof]
+fn proof_v16_flat_source_lien_normalization_is_total_and_fail_closed() {
+    let claim_live: bool = kani::any();
+    let counterparty_units: u8 = kani::any();
+    let insurance_units: u8 = kani::any();
+    let malformed_insurance: bool = kani::any();
+    let status_raw: u8 = kani::any();
+    let expiry_slot: u64 = kani::any();
+    let now_slot: u64 = kani::any();
+    let bucket_valid: u8 = kani::any();
+    let bucket_impaired: u8 = kani::any();
+    let source_valid: u8 = kani::any();
+    let source_impaired: u8 = kani::any();
+    let reservation_insurance: u8 = kani::any();
+    let source_insurance: u8 = kani::any();
+    kani::assume(status_raw < 3);
+
+    let counterparty_backing = u128::from(counterparty_units);
+    let insurance_backing = u128::from(insurance_units) * BOUND_SCALE
+        + u128::from(malformed_insurance && insurance_units != 0);
+    let source_claim_liened = if claim_live { 1 } else { 0 };
+    let status = match status_raw {
+        0 => BackingBucketStatusV16::Fresh,
+        1 => BackingBucketStatusV16::Impaired,
+        _ => BackingBucketStatusV16::Expired,
+    };
+    let bucket_valid = u128::from(bucket_valid);
+    let bucket_impaired = u128::from(bucket_impaired);
+    let source_valid = u128::from(source_valid);
+    let source_impaired = u128::from(source_impaired);
+    let reservation_insurance = u128::from(reservation_insurance) * BOUND_SCALE;
+    let source_insurance = u128::from(source_insurance) * BOUND_SCALE;
+
+    let selected = MarketGroupV16ViewMut::<u64>::kani_flat_source_lien_normalization(
+        source_claim_liened,
+        counterparty_backing,
+        insurance_backing,
+        status,
+        expiry_slot,
+        now_slot,
+        bucket_valid,
+        bucket_impaired,
+        source_valid,
+        source_impaired,
+        reservation_insurance,
+        source_insurance,
+    );
+    let has_backing = counterparty_backing != 0 || insurance_backing != 0;
+    let impair = source_claim_liened != 0
+        && counterparty_backing != 0
+        && status == BackingBucketStatusV16::Impaired
+        && bucket_impaired >= counterparty_backing
+        && source_impaired >= counterparty_backing;
+    let counterparty_releasable = counterparty_backing == 0
+        || (status == BackingBucketStatusV16::Fresh
+            && expiry_slot > now_slot
+            && bucket_valid >= counterparty_backing
+            && source_valid >= counterparty_backing);
+    let insurance_releasable = insurance_backing == 0
+        || (insurance_backing % BOUND_SCALE == 0
+            && reservation_insurance >= insurance_backing
+            && source_insurance >= insurance_backing);
+    let release = source_claim_liened != 0
+        && has_backing
+        && !impair
+        && counterparty_releasable
+        && insurance_releasable;
+    let expected = if impair {
+        1
+    } else if release {
+        2
+    } else {
+        0
+    };
+    assert_eq!(selected, expected);
+    assert!(selected <= 2);
+    if selected == 1 {
+        assert!(impair && !release);
+    }
+    if selected == 2 {
+        assert!(release && !impair);
+    }
+
+    kani::cover!(
+        selected == 1 && insurance_backing != 0,
+        "impaired counterparty is normalized before a sibling insurance component"
+    );
+    kani::cover!(
+        selected == 2 && counterparty_backing != 0 && insurance_backing != 0,
+        "both fresh components release atomically"
+    );
+    kani::cover!(
+        status == BackingBucketStatusV16::Fresh
+            && expiry_slot == now_slot
+            && counterparty_backing != 0
+            && selected == 0,
+        "equal-slot lapsed backing cannot be released"
+    );
+    kani::cover!(
+        malformed_insurance && insurance_backing != 0 && selected == 0,
+        "malformed insurance backing fails closed"
+    );
+    kani::cover!(
+        !claim_live && has_backing && selected == 0,
+        "backing without a live account lien is not actionable"
+    );
+}
+
+#[kani::proof]
 #[kani::unwind(48)]
 #[kani::solver(cadical)]
 fn proof_v16_public_counterparty_backing_withdraw_debits_vault_and_scaled_source_state() {

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -5153,6 +5153,118 @@ fn v16_auto_crank_releases_source_liens_in_strict_chunks() {
 }
 
 #[test]
+fn v16_auto_crank_normalizes_impaired_flat_lien_before_releasing_fresh_sibling() {
+    const CLAIM: u128 = 100;
+    const EXPIRY_SLOT: u64 = 5;
+    let claim_num = CLAIM * BOUND_SCALE;
+    let (mut header, mut markets, mut winner_header) = flat_source_credit_lien_fixture(2);
+    markets[0].engine.backing_long.expiry_slot = V16PodU64::new(EXPIRY_SLOT);
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    let mut winner = PortfolioV16ViewMut::new(&mut winner_header);
+    let observations = [AutoCrankObservationV16 {
+        asset_index: 0,
+        effective_price: market.markets[0].engine.asset.effective_price.get(),
+        funding_rate_e9: 0,
+    }];
+    let work = AutoCrankWorkV16 {
+        now_slot: EXPIRY_SLOT,
+        observations: &observations,
+        resolved_close_fee_rate_per_slot: 0,
+    };
+
+    assert_eq!(
+        winner.header.source_domains[0]
+            .source_claim_counterparty_liened_num
+            .get(),
+        claim_num,
+        "global expiry cannot mutate an account that was not part of that transition"
+    );
+
+    let mut release_steps = 0usize;
+    let mut saw_expiry = false;
+    for _ in 0..6 {
+        let summary = market
+            .build_actionable_summary_at_slot(&winner.as_view(), EXPIRY_SLOT)
+            .unwrap();
+        if !summary.is_actionable() {
+            break;
+        }
+        let result = market
+            .permissionless_auto_crank_not_atomic(&mut winner, work)
+            .expect("each selected flat-lien continuation must succeed");
+        release_steps += usize::from(result.selected == AutoCrankPlanV16::ReleaseSourceLiens);
+        saw_expiry |= result.outcome
+            == AutoCrankOutcomeV16::Progressed(
+                PermissionlessProgressOutcomeV16::SourceBackingExpired { domain: 0 },
+            );
+    }
+    assert!(
+        saw_expiry,
+        "authenticated expiry must be selected in finite cranks"
+    );
+    assert_eq!(release_steps, 2, "one bounded step per source domain");
+    assert_eq!(
+        market.markets[0]
+            .engine
+            .backing_long
+            .try_to_runtime()
+            .unwrap()
+            .status,
+        BackingBucketStatusV16::Expired
+    );
+    let impaired_claim_num = winner
+        .header
+        .source_domains
+        .iter()
+        .map(|source| source.source_claim_impaired_num.get())
+        .sum::<u128>();
+    assert_eq!(
+        impaired_claim_num, claim_num,
+        "impaired claim attribution was not retained: {:?}",
+        winner.header.source_domains
+    );
+    assert_eq!(
+        winner.header.source_domains[0]
+            .source_claim_liened_num
+            .get(),
+        0
+    );
+    assert_eq!(
+        winner.header.source_domains[1]
+            .source_claim_liened_num
+            .get(),
+        0
+    );
+    assert_eq!(
+        market.markets[0]
+            .engine
+            .backing_long
+            .impaired_liened_backing_num
+            .get(),
+        0
+    );
+    assert_eq!(
+        market.markets[0]
+            .engine
+            .backing_short
+            .valid_liened_backing_num
+            .get(),
+        0
+    );
+
+    assert_eq!(
+        market
+            .convert_released_pnl_to_capital_not_atomic(&mut winner)
+            .expect("the independently fresh source claim must remain convertible"),
+        CLAIM
+    );
+    assert_eq!(winner.header.pnl.get(), CLAIM as i128);
+    winner.validate_with_market(&market.as_view()).unwrap();
+    market.validate_shape().unwrap();
+}
+
+#[test]
 fn v16_released_pnl_conversion_consumes_the_backed_source_claim_exactly_once() {
     const CLAIM: u128 = 100;
     const BACKING: u128 = 2 * CLAIM;


### PR DESCRIPTION
## Counterexample

A public trade-created flat account can retain a live source-claim lien after one backing bucket expires while a sibling source remains fresh. After authenticated expiry commits, the expired bucket is `Impaired`, so the lapsed-Fresh scan no longer finds it; the old release predicate requires every lien to be fresh, so auto-crank reports no action. The fresh sibling claim and provider encumbrance remain blocked indefinitely in a Live market.

This is stacked on the canonical source-domain-order change because the public two-domain invariant trace that found it depends on deterministic source ordering.

## Fix

- classify one bounded flat source-lien normalization from production state
- make authenticated backing expiry preempt any release at the same slot
- crystallize an impaired counterparty lien into the account impaired-claim lane
- retire the matching market impaired encumbrance
- release independently fresh sibling liens on subsequent bounded cranks
- keep the public crank API and persisted layout unchanged

## Verification

- `cargo test --all-targets`: 189 passed
- `proof_v16_flat_source_lien_normalization_is_total_and_fail_closed`: 24/24 assertions, 5/5 covers
- `proof_v16_lapsed_source_backing_preempts_flat_lien_normalization`: 2/2 assertions, 3/3 covers
- native finite-sequence regression proves expiry, two one-domain normalization steps, retained impaired attribution, and conversion of the fresh sibling claim