### PR TITLE
[PARTIAL DoS] Clamp Recovery pair work to effective OI

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -17448,6 +17448,62 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
+    /// Closes one opposite-side pair in Recovery while treating caller quantity as a work budget.
+    /// The canonical effective quantities, rather than retained raw bases, bound the landed close.
+    pub fn force_close_recovery_pair_not_atomic(
+        &mut self,
+        account_a: &mut PortfolioV16ViewMut<'_>,
+        account_b: &mut PortfolioV16ViewMut<'_>,
+        asset_index: usize,
+        close_request_q: u128,
+    ) -> V16Result<u128> {
+        if decode_market_mode(self.header.mode)? != MarketModeV16::Live {
+            return Err(V16Error::LockActive);
+        }
+        if close_request_q == 0 {
+            return Err(V16Error::InvalidConfig);
+        }
+        self.validate_configured_asset_index(asset_index)?;
+        let asset = self.asset_state(asset_index)?;
+        if asset.lifecycle != AssetLifecycleV16::Recovery {
+            return Err(V16Error::LockActive);
+        }
+        let leg_a = Self::active_leg_for_asset(&account_a.as_view(), asset_index)?;
+        let leg_b = Self::active_leg_for_asset(&account_b.as_view(), asset_index)?;
+        if !leg_a.active || !leg_b.active || leg_a.side == leg_b.side {
+            return Err(V16Error::InvalidLeg);
+        }
+        let effective_a = V16Core::effective_abs_quantity_for_leg(asset, leg_a)?;
+        let effective_b = V16Core::effective_abs_quantity_for_leg(asset, leg_b)?;
+        let close_q = close_request_q
+            .min(effective_a)
+            .min(effective_b)
+            .min(asset.oi_eff_long_q)
+            .min(asset.oi_eff_short_q);
+        if close_q == 0 {
+            return Err(V16Error::NonProgress);
+        }
+        let size_q = i128::try_from(close_q).map_err(|_| V16Error::ArithmeticOverflow)?;
+        let request = TradeRequestV16 {
+            asset_index,
+            size_q,
+            exec_price: asset.effective_price,
+            fee_bps: 0,
+        };
+        // Positive `size_q` is applied to the first account and its negation to the second.
+        // Put the short first so both signed deltas move the existing legs toward zero.
+        if leg_a.side == SideV16::Short {
+            self.execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                account_a, account_b, request,
+            )?;
+        } else {
+            self.execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                account_b, account_a, request,
+            )?;
+        }
+        Ok(close_q)
+    }
+
     pub fn execute_trade_with_fee_loss_stale_scoped_not_atomic(
         &mut self,
         long_account: &mut PortfolioV16ViewMut<'_>,

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -303,6 +303,93 @@ fn v16_post_quantity_adl_bankrupt_effective_full_close_stays_live() {
 }
 
 #[test]
+fn v16_recovery_pair_close_clamps_stale_work_to_dual_adl_effective_oi() {
+    const PRICE: u64 = 100;
+    const OPEN_Q: u128 = 2 * POS_SCALE;
+    const FIRST_REDUCE_Q: u128 = POS_SCALE / 100;
+    const SECOND_REDUCE_Q: u128 = POS_SCALE / 100;
+
+    let (mut header, mut markets) = market_fixture(1, PRICE);
+    let mut long_header = account_fixture(1, 229);
+    let mut short_header = account_fixture(1, 230);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut long = PortfolioV16ViewMut::new(&mut long_header);
+        let mut short = PortfolioV16ViewMut::new(&mut short_header);
+        market.deposit_not_atomic(&mut long, 10_000).unwrap();
+        market.deposit_not_atomic(&mut short, 10_000).unwrap();
+        market
+            .execute_trade_with_fee_loss_stale_scoped_not_atomic(
+                &mut long,
+                &mut short,
+                TradeRequestV16 {
+                    asset_index: 0,
+                    size_q: signed_q(OPEN_Q),
+                    exec_price: PRICE,
+                    fee_bps: 0,
+                },
+            )
+            .unwrap();
+        market
+            .rebalance_reduce_position_not_atomic(
+                &mut long,
+                RebalanceRequestV16 {
+                    asset_index: 0,
+                    reduce_q: FIRST_REDUCE_Q,
+                },
+            )
+            .unwrap();
+        market
+            .rebalance_reduce_position_not_atomic(
+                &mut short,
+                RebalanceRequestV16 {
+                    asset_index: 0,
+                    reduce_q: SECOND_REDUCE_Q,
+                },
+            )
+            .unwrap();
+    }
+
+    let before = markets[0].engine.asset.try_to_runtime().unwrap();
+    let long_raw_q = long_header.legs[0]
+        .try_to_runtime()
+        .unwrap()
+        .basis_pos_q
+        .unsigned_abs();
+    let short_raw_q = short_header.legs[0]
+        .try_to_runtime()
+        .unwrap()
+        .basis_pos_q
+        .unsigned_abs();
+    assert!(before.a_long < ADL_ONE && before.a_short < ADL_ONE);
+    assert_eq!(before.oi_eff_long_q, before.oi_eff_short_q);
+    assert!(long_raw_q > before.oi_eff_long_q);
+    assert!(short_raw_q > before.oi_eff_short_q);
+    let effective_q = before.oi_eff_long_q;
+
+    let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+    market.force_asset_recovery_not_atomic(0, 1).unwrap();
+    let mut long = PortfolioV16ViewMut::new(&mut long_header);
+    let mut short = PortfolioV16ViewMut::new(&mut short_header);
+    let landed_q = market
+        .force_close_recovery_pair_not_atomic(
+            &mut long,
+            &mut short,
+            0,
+            effective_q.checked_add(1).unwrap(),
+        )
+        .expect("stale Recovery work must clamp to canonical effective OI");
+
+    assert_eq!(landed_q, effective_q);
+    let after = market.markets[0].engine.asset.try_to_runtime().unwrap();
+    assert_eq!(after.oi_eff_long_q, 0);
+    assert_eq!(after.oi_eff_short_q, 0);
+    market.validate_shape().unwrap();
+    long.validate_with_market(&market.as_view()).unwrap();
+    short.validate_with_market(&market.as_view()).unwrap();
+}
+
+#[test]
 fn v16_sub_minimum_drain_only_adl_leg_refreshes_and_exits() {
     let (mut header, mut markets) = market_fixture(1, 100);
     let mut long_header = account_fixture(1, 231);


### PR DESCRIPTION
## Finding

Recovery pair force-close work is caller supplied and may be stale by landing time. The wrapper previously bounded it with retained raw basis, but after quantity ADL the executable quantity is lower effective OI. When both side ADL indices are non-unit, effective + 1 reaches the engine and rejects instead of landing the maximal valid close.

This is a permissionless-progress reliability violation, not a proven permanent funds lock: an exact fresh quantity still succeeds.

## Fix

Add force_close_recovery_pair_not_atomic, which treats the requested quantity as a work budget, clamps it to both canonical effective leg quantities and both OI lanes, then dispatches the matched reduction in the correct signed orientation.

## Verification

- New engine regression constructs both non-unit ADL sides through normal trades and owner reductions.
- effective + 1 lands exactly effective and clears both OI lanes.
- CARGO_INCREMENTAL=0 cargo test: 191 tests passed.

Stacked on the current source-domain branch because the wrapper invariant branch is pinned to that engine lineage.