### PR TITLE
[PARTIAL DoS] Expire live backing at authenticated crank slot

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -15145,6 +15145,24 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
                 AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
             }
             AutoCrankPlanV16::RefreshAccount { asset_index } => {
+                // Classification uses the authenticated execution slot, so dispatch must expire
+                // the same account-scoped prerequisite at that slot. Using header.current_slot
+                // inside the legacy refresh path can leave a newly lapsed bucket Fresh, after
+                // which K/F settlement rejects Stale and the selected plan cannot progress.
+                if let Some(domain) = self.first_lapsed_source_backing_for_account_at_slot(
+                    &account.as_view(),
+                    work.now_slot,
+                )? {
+                    self.expire_source_backing_bucket_not_atomic(domain, work.now_slot)?;
+                    self.validate_shape_audit_scan()?;
+                    account.validate_with_market(&self.as_view())?;
+                    return Ok(AutoCrankResultV16 {
+                        selected: plan,
+                        outcome: AutoCrankOutcomeV16::Progressed(
+                            PermissionlessProgressOutcomeV16::SourceBackingExpired { domain },
+                        ),
+                    });
+                }
                 // Accrue the engine-selected active asset from either a fresh
                 // observation or committed state; if no active asset exists, use
                 // the first supplied observation to give the refresh a price.

--- a/tests/v16_spec_tests.rs
+++ b/tests/v16_spec_tests.rs
@@ -6681,7 +6681,7 @@ fn v16_auto_crank_expires_one_lapsed_live_source_domain_per_step() {
 }
 
 #[test]
-fn v16_auto_crank_classifies_lapsed_source_backing_with_current_certificate() {
+fn v16_auto_crank_expires_authenticated_slot_backing_before_live_refresh() {
     let (mut header, mut markets) = market_fixture(1, 100);
     let mut account_header = account_fixture(1, 23);
     let mut counterparty_header = account_fixture(1, 24);
@@ -6741,6 +6741,33 @@ fn v16_auto_crank_classifies_lapsed_source_backing_with_current_certificate() {
                 .stale
         );
 
+        let expiry = market
+            .permissionless_auto_crank_not_atomic(
+                &mut account,
+                AutoCrankWorkV16 {
+                    now_slot: 10,
+                    observations: &[],
+                    resolved_close_fee_rate_per_slot: 0,
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            expiry.outcome,
+            AutoCrankOutcomeV16::Progressed(
+                PermissionlessProgressOutcomeV16::SourceBackingExpired { domain: 1 }
+            )
+        );
+        assert!(market.header.current_slot.get() < 10);
+        assert_eq!(
+            market.markets[0]
+                .engine
+                .backing_short
+                .try_to_runtime()
+                .unwrap()
+                .status,
+            BackingBucketStatusV16::Expired
+        );
+
         let catchup = market
             .permissionless_auto_crank_not_atomic(
                 &mut account,
@@ -6756,32 +6783,6 @@ fn v16_auto_crank_classifies_lapsed_source_backing_with_current_certificate() {
             AutoCrankOutcomeV16::Progressed(PermissionlessProgressOutcomeV16::AccountCurrent)
         );
         assert_eq!(market.header.current_slot.get(), 10);
-        assert_eq!(
-            market.markets[0]
-                .engine
-                .backing_short
-                .try_to_runtime()
-                .unwrap()
-                .status,
-            BackingBucketStatusV16::Fresh
-        );
-
-        let result = market
-            .permissionless_auto_crank_not_atomic(
-                &mut account,
-                AutoCrankWorkV16 {
-                    now_slot: 10,
-                    observations: &[],
-                    resolved_close_fee_rate_per_slot: 0,
-                },
-            )
-            .unwrap();
-        assert_eq!(
-            result.outcome,
-            AutoCrankOutcomeV16::Progressed(
-                PermissionlessProgressOutcomeV16::SourceBackingExpired { domain: 1 }
-            )
-        );
         let bucket = market.markets[0]
             .engine
             .backing_short


### PR DESCRIPTION
## Impact
A publicly reachable Live account can have source backing that is fresh at the committed market slot but lapsed at the authenticated execution slot. Auto-crank classifies the expiry as actionable at the authenticated slot, then the refresh path rechecks against the older committed slot and can reject every crank candidate instead of progressing. The owner exit remains live, so this is a crank-only partial DoS rather than a permanent funds lock.

## Fix
When the selected plan is RefreshAccount, expire the first account-scoped backing bucket using the same authenticated `work.now_slot` used by classification, before ordinary refresh/accrual. The call remains one bounded transition.

## TDD evidence
- Parent: `v16_auto_crank_expires_authenticated_slot_backing_before_live_refresh` fails because the first call returns AccountCurrent and leaves the lapsed bucket Fresh.
- Head: the first call returns SourceBackingExpired, and the next call performs ordinary catch-up.
- All 23 `v16_auto_crank_` spec tests pass.
- Wrapper PR135 has an independent public LiteSVM scenario that exposed the contradiction after its legacy failure quarantine was removed.