### PR TITLE
[BLOCKER LoF] Preserve resolved receipts across late backing expiry

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -1965,6 +1965,25 @@ impl V16Core {
         Ok((ledger, legacy_snapshot))
     }
 
+    /// A haircut payout rate is final only after both claim discovery and every
+    /// still-fresh backing source are exhausted. Fresh backing can later expire
+    /// into post-snapshot residual and raise the common receipt rate. A full
+    /// rate is already final because recomputation caps it at one.
+    #[cfg_attr(all(kani, feature = "contracts"), kani::ensures(|result: &bool| {
+        *result
+            == (ledger.terminal_claim_bound_unreceipted_num == 0
+                && (ledger.current_payout_rate_num == ledger.current_payout_rate_den
+                    || source_fresh_backing_total_num == 0))
+    }))]
+    pub(crate) fn kernel_resolved_payout_rate_is_terminal(
+        ledger: ResolvedPayoutLedgerV16,
+        source_fresh_backing_total_num: u128,
+    ) -> bool {
+        ledger.terminal_claim_bound_unreceipted_num == 0
+            && (ledger.current_payout_rate_num == ledger.current_payout_rate_den
+                || source_fresh_backing_total_num == 0)
+    }
+
     /// PRODUCTION KERNEL (roadmap 3A.1 trade spine): classify a position change
     /// from (current signed, new signed) into its leg route — the EXACT total
     /// decision the position-delta body dispatches on. `delta != 0` is enforced
@@ -9509,6 +9528,44 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             slot += 1;
         }
         Ok(selected)
+    }
+
+    /// Finds one elapsed Fresh backing bucket across the bounded configured
+    /// market. Resolved receipts can outlive their account-local source entries,
+    /// while expiry of any remaining bucket can still raise the global payout
+    /// rate, so terminal receipt progress cannot use account-local discovery.
+    fn first_lapsed_source_backing_at_slot(&self, now_slot: u64) -> V16Result<Option<usize>> {
+        if self.header.source_fresh_backing_total_num.get() == 0 {
+            return Ok(None);
+        }
+        let configured_assets = self.header.config.max_market_slots.get() as usize;
+        let mut asset_index = 0usize;
+        while asset_index < configured_assets {
+            let slot = self
+                .markets
+                .get(asset_index)
+                .ok_or(V16Error::InvalidConfig)?
+                .engine_slot();
+            let (long_domain, short_domain) = v16_domain_pair_for_asset_index(asset_index)?;
+            for (domain, status, expiry_slot) in [
+                (
+                    long_domain,
+                    decode_backing_bucket_status(slot.backing_long.status)?,
+                    slot.backing_long.expiry_slot.get(),
+                ),
+                (
+                    short_domain,
+                    decode_backing_bucket_status(slot.backing_short.status)?,
+                    slot.backing_short.expiry_slot.get(),
+                ),
+            ] {
+                if status == BackingBucketStatusV16::Fresh && expiry_slot <= now_slot {
+                    return Ok(Some(domain));
+                }
+            }
+            asset_index += 1;
+        }
+        Ok(None)
     }
 
     fn expire_first_lapsed_source_backing_for_account_not_atomic(
@@ -18922,14 +18979,11 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(())
     }
 
-    // A resolved-payout receipt that has been paid its full entitlement at the TERMINAL
-    // payout rate (no unreceipted bound remains, so the rate can no longer rise) holds
-    // only unrecoverable insolvency bad debt: the haircut shortfall (face - paid) is not
-    // an open obligation. The only finalize site requires paid_effective == FULL face,
-    // which is unreachable under a haircut, so the receipt would otherwise stay
-    // `present && !finalized` forever and permanently block the portfolio from
-    // dematerializing (stranding insurance + backing earnings + residual vault + rent).
-    // Clear such a fully-diluted receipt so the account can close.
+    // A resolved-payout receipt that has been paid its full entitlement at the terminal
+    // payout rate holds only unrecoverable insolvency bad debt. Claim discovery alone is
+    // insufficient to make a haircut rate terminal: any Fresh backing can later expire
+    // into post-snapshot residual and raise the rate. Keep the receipt until that latent
+    // source is gone (or the rate is already full), then clear it so the account can close.
     fn clear_fully_diluted_resolved_receipt_if_terminal(
         &mut self,
         account: &mut PortfolioV16ViewMut<'_>,
@@ -18939,8 +18993,10 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             return Ok(());
         }
         let ledger = self.header.resolved_payout_ledger.try_to_runtime()?;
-        // Rate is terminal only once all junior bound has been receipted/refined.
-        if ledger.terminal_claim_bound_unreceipted_num != 0 {
+        if !V16Core::kernel_resolved_payout_rate_is_terminal(
+            ledger,
+            self.header.source_fresh_backing_total_num.get(),
+        ) {
             return Ok(());
         }
         if self.resolved_receipt_claimable_now(receipt)? != 0 {
@@ -19284,6 +19340,27 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             self.validate_shape()?;
             account.validate_with_market(&self.as_view())?;
             return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
+        }
+        let receipt = account.header.resolved_payout_receipt.try_to_runtime()?;
+        let ledger = self.header.resolved_payout_ledger.try_to_runtime()?;
+        if receipt.present
+            && !receipt.finalized
+            && !V16Core::kernel_resolved_payout_rate_is_terminal(
+                ledger,
+                self.header.source_fresh_backing_total_num.get(),
+            )
+        {
+            if let Some(domain) =
+                self.first_lapsed_source_backing_at_slot(self.header.current_slot.get())?
+            {
+                self.expire_source_backing_bucket_not_atomic(
+                    domain,
+                    self.header.current_slot.get(),
+                )?;
+                self.validate_shape()?;
+                account.validate_with_market(&self.as_view())?;
+                return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
+            }
         }
         if let PermissionlessProgressOutcomeV16::AccountBChunk(_) = self
             .settle_account_side_effects_not_atomic(

--- a/src/v16.rs
+++ b/src/v16.rs
@@ -6255,10 +6255,11 @@ impl ActionableSummaryV16 {
     }
 }
 
-/// One oracle observation a keeper submits to the auto-crank (engine.md). The
-/// caller supplies a bounded set of these for the assets it has fresh data for;
-/// the ENGINE selects which (if any) the highest-priority step needs. The caller
-/// never chooses the action TYPE or the asset.
+/// One asset observation a keeper submits to the auto-crank (engine.md). In live
+/// mode its price and funding inputs are wrapper-authenticated. In resolved mode
+/// only `asset_index` is used, as a discovery hint for elapsed backing; the
+/// engine re-derives status and expiry from committed state. The caller never
+/// chooses the action type or its economic result.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AutoCrankObservationV16 {
     pub asset_index: usize,
@@ -9530,40 +9531,43 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         Ok(selected)
     }
 
-    /// Finds one elapsed Fresh backing bucket across the bounded configured
-    /// market. Resolved receipts can outlive their account-local source entries,
-    /// while expiry of any remaining bucket can still raise the global payout
-    /// rate, so terminal receipt progress cannot use account-local discovery.
-    fn first_lapsed_source_backing_at_slot(&self, now_slot: u64) -> V16Result<Option<usize>> {
+    /// Validates a caller's discovery-only asset hint and finds one elapsed
+    /// Fresh bucket in that asset's two source domains. The engine derives the
+    /// bucket status and expiry from committed state; the hint cannot choose an
+    /// economic outcome.
+    fn first_lapsed_source_backing_for_asset_at_slot(
+        &self,
+        asset_index: usize,
+        now_slot: u64,
+    ) -> V16Result<Option<usize>> {
         if self.header.source_fresh_backing_total_num.get() == 0 {
             return Ok(None);
         }
         let configured_assets = self.header.config.max_market_slots.get() as usize;
-        let mut asset_index = 0usize;
-        while asset_index < configured_assets {
-            let slot = self
-                .markets
-                .get(asset_index)
-                .ok_or(V16Error::InvalidConfig)?
-                .engine_slot();
-            let (long_domain, short_domain) = v16_domain_pair_for_asset_index(asset_index)?;
-            for (domain, status, expiry_slot) in [
-                (
-                    long_domain,
-                    decode_backing_bucket_status(slot.backing_long.status)?,
-                    slot.backing_long.expiry_slot.get(),
-                ),
-                (
-                    short_domain,
-                    decode_backing_bucket_status(slot.backing_short.status)?,
-                    slot.backing_short.expiry_slot.get(),
-                ),
-            ] {
-                if status == BackingBucketStatusV16::Fresh && expiry_slot <= now_slot {
-                    return Ok(Some(domain));
-                }
+        if asset_index >= configured_assets {
+            return Err(V16Error::InvalidLeg);
+        }
+        let slot = self
+            .markets
+            .get(asset_index)
+            .ok_or(V16Error::InvalidConfig)?
+            .engine_slot();
+        let (long_domain, short_domain) = v16_domain_pair_for_asset_index(asset_index)?;
+        for (domain, status, expiry_slot) in [
+            (
+                long_domain,
+                decode_backing_bucket_status(slot.backing_long.status)?,
+                slot.backing_long.expiry_slot.get(),
+            ),
+            (
+                short_domain,
+                decode_backing_bucket_status(slot.backing_short.status)?,
+                slot.backing_short.expiry_slot.get(),
+            ),
+        ] {
+            if status == BackingBucketStatusV16::Fresh && expiry_slot <= now_slot {
+                return Ok(Some(domain));
             }
-            asset_index += 1;
         }
         Ok(None)
     }
@@ -15285,6 +15289,42 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             AutoCrankPlanV16::FinalizeRecovery => return Err(V16Error::InvalidConfig),
             AutoCrankPlanV16::CloseResolved => {
                 self.advance_resolved_slot_not_atomic(work.now_slot)?;
+                let receipt = account.header.resolved_payout_receipt.try_to_runtime()?;
+                let ledger = self.header.resolved_payout_ledger.try_to_runtime()?;
+                let waiting_for_rate = receipt.present
+                    && !receipt.finalized
+                    && !V16Core::kernel_resolved_payout_rate_is_terminal(
+                        ledger,
+                        self.header.source_fresh_backing_total_num.get(),
+                    );
+                if waiting_for_rate {
+                    if let Some(asset_index) = work
+                        .observations
+                        .first()
+                        .map(|observation| observation.asset_index)
+                    {
+                        if let Some(domain) = self.first_lapsed_source_backing_for_asset_at_slot(
+                            asset_index,
+                            self.header.current_slot.get(),
+                        )? {
+                            self.expire_source_backing_bucket_not_atomic(
+                                domain,
+                                self.header.current_slot.get(),
+                            )?;
+                            self.validate_shape()?;
+                            account.validate_with_market(&self.as_view())?;
+                            return Ok(AutoCrankResultV16 {
+                                selected: plan,
+                                outcome: AutoCrankOutcomeV16::ResolvedClose(
+                                    ResolvedCloseOutcomeV16::ProgressOnly,
+                                ),
+                            });
+                        }
+                    }
+                    if self.resolved_receipt_claimable_now(receipt)? == 0 {
+                        return Err(V16Error::NonProgress);
+                    }
+                }
                 AutoCrankOutcomeV16::ResolvedClose(self.close_resolved_account_not_atomic(
                     account,
                     work.resolved_close_fee_rate_per_slot,
@@ -19340,27 +19380,6 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
             self.validate_shape()?;
             account.validate_with_market(&self.as_view())?;
             return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
-        }
-        let receipt = account.header.resolved_payout_receipt.try_to_runtime()?;
-        let ledger = self.header.resolved_payout_ledger.try_to_runtime()?;
-        if receipt.present
-            && !receipt.finalized
-            && !V16Core::kernel_resolved_payout_rate_is_terminal(
-                ledger,
-                self.header.source_fresh_backing_total_num.get(),
-            )
-        {
-            if let Some(domain) =
-                self.first_lapsed_source_backing_at_slot(self.header.current_slot.get())?
-            {
-                self.expire_source_backing_bucket_not_atomic(
-                    domain,
-                    self.header.current_slot.get(),
-                )?;
-                self.validate_shape()?;
-                account.validate_with_market(&self.as_view())?;
-                return Ok(ResolvedCloseOutcomeV16::ProgressOnly);
-            }
         }
         if let PermissionlessProgressOutcomeV16::AccountBChunk(_) = self
             .settle_account_side_effects_not_atomic(

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -762,6 +762,13 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         V16Core::kernel_credit_post_snapshot_residual(ledger, legacy_snapshot, released)
     }
 
+    pub fn kani_kernel_resolved_payout_rate_is_terminal(
+        ledger: ResolvedPayoutLedgerV16,
+        source_fresh_backing_total_num: u128,
+    ) -> bool {
+        V16Core::kernel_resolved_payout_rate_is_terminal(ledger, source_fresh_backing_total_num)
+    }
+
     pub fn kani_kernel_unilateral_close_capacity(
         account_effective_abs: u128,
         oi_eff_long_q: u128,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -16364,10 +16364,55 @@ fn proof_v16_terminal_resolved_receipt_core_restores_dematerialization() {
 // paid at most floor(face * rate) < face, so paid_effective never reaches face: the
 // receipt stays present && !finalized forever, the portfolio can never dematerialize,
 // and the market (insurance + earnings + residual vault + rent) is stranded permanently.
-// Fix: once a receipt is fully paid at the TERMINAL rate (no unreceipted bound remains,
-// so the rate can no longer rise), it is fully diluted -- the shortfall is unrecoverable
-// bad debt, not an obligation -- so it is cleared, letting the portfolio close. RED until
-// claim_resolved_payout_topup_not_atomic clears a fully-diluted-at-terminal receipt.
+// A zero unreceipted bound is not sufficient by itself: Fresh backing can later expire into
+// post-snapshot residual. This scalar proof pins the complete terminal-rate gate. Haircut receipts
+// remain live while either undiscovered claims or latent Fresh backing can improve their rate;
+// full-rate receipts and haircut receipts with neither source can be dematerialized.
+#[kani::proof]
+fn proof_v16_resolved_payout_rate_terminal_gate_includes_fresh_backing() {
+    let exact_receipts_num: u128 = kani::any();
+    let unreceipted_num: u128 = kani::any();
+    let rate_num: u128 = kani::any();
+    let rate_den: u128 = kani::any();
+    let fresh_backing_num: u128 = kani::any();
+    let ledger = ResolvedPayoutLedgerV16 {
+        snapshot_residual: 0,
+        terminal_claim_exact_receipts_num: exact_receipts_num,
+        terminal_claim_bound_unreceipted_num: unreceipted_num,
+        current_payout_rate_num: rate_num,
+        current_payout_rate_den: rate_den,
+        snapshot_slot: 0,
+        payout_halted: false,
+        finalized: false,
+    };
+
+    let terminal = MarketGroupV16ViewMut::<u64>::kani_kernel_resolved_payout_rate_is_terminal(
+        ledger,
+        fresh_backing_num,
+    );
+    assert_eq!(
+        terminal,
+        unreceipted_num == 0 && (rate_num == rate_den || fresh_backing_num == 0)
+    );
+    if unreceipted_num != 0 || (rate_num != rate_den && fresh_backing_num != 0) {
+        assert!(!terminal);
+    }
+    if unreceipted_num == 0 && (rate_num == rate_den || fresh_backing_num == 0) {
+        assert!(terminal);
+    }
+    kani::cover!(
+        unreceipted_num == 0 && rate_num != rate_den && fresh_backing_num != 0 && !terminal,
+        "haircut receipt remains live while Fresh backing can raise its rate"
+    );
+    kani::cover!(
+        unreceipted_num == 0 && rate_num != rate_den && fresh_backing_num == 0 && terminal,
+        "haircut receipt clears after every rate-increasing source is exhausted"
+    );
+}
+
+// Once a receipt is fully paid at the TERMINAL rate (no unreceipted bound or latent Fresh backing
+// remains), it is fully diluted -- the shortfall is unrecoverable bad debt, not an obligation --
+// so it is cleared, letting the portfolio close.
 #[kani::proof]
 #[kani::unwind(40)]
 #[kani::solver(cadical)]
@@ -16384,6 +16429,7 @@ fn proof_v16_insolvent_resolved_receipt_clears_at_terminal_rate() {
     let (mut header, mut markets, mut account_header) = one_market_view_fixture();
     header.mode = 1; // Resolved
     header.vault = V16PodU128::new(residual);
+    header.source_fresh_backing_total_num = V16PodU128::new(0);
     header.payout_snapshot_captured = 1;
     header.resolved_payout_ledger =
         ResolvedPayoutLedgerV16Account::from_runtime(&ResolvedPayoutLedgerV16 {


### PR DESCRIPTION
## Impact

A public resolved-market lifecycle can erase a haircut winner receipt while unrelated Fresh backing still exists. When that backing later expires, it raises post-snapshot payout residual, but the winner no longer has a receipt. Terminal slab closure then retires the 500 newly claimable atoms instead of paying the winner.

The regression uses only public wrapper instructions and valid accounts; it does not mutate program-owned state.

## Fix

- Treat a resolved haircut rate as terminal only when all unreceipted claim bound is gone and either the rate is full or no Fresh backing remains.
- Keep the receipt live while latent backing can improve its entitlement.
- Reuse one resolved auto-crank asset observation as a discovery-only backing hint. The engine reads both source domains from committed state and expires at most one elapsed bucket.
- Return `NonProgress` for premature, absent, or unrelated hints when no receipt value is claimable. Work remains constant in configured market size.

## Verification

- Engine unit regression: PASS.
- New Kani terminal-rate proof: 3/3 assertions and 2/2 nonvacuous covers -> PASS.
- Existing whole receipt-clear Kani proof: 0/5967 failed and 1/1 cover -> PASS.
- Exact parent wrapper `d5e2ec6fa727a1049a62851c3be19c638815b4e2`, engine `495a5590c97055bd71c6f94d849ff0298f243145`, SBF SHA256 `230b6db1278dbff258c84f9a3df78c7d9decc6f8653fe06c46fa5ea9834afb20`: RED, winner `1250 -> 1250`, mint `4500000000 -> 4499999500`, max CU `207832`.
- Fixed engine `0bb6f93a3b95457110aca491f3ed5729606502e1`, wrapper SBF SHA256 `bfe4e7fbf9cf392ee9ca20dc9bee414dd2b7c1313cc3096d9fcc679a9f02be69`: GREEN, winner `1250 -> 1750`, mint unchanged at `4500000000`, max CU `207833`.
- Premature, missing, and unrelated hints each reject with exact market, portfolio, and SPL rollback.
- Existing 128/5,782-slot resolved lifecycle CU test passes below its 1,375,000-CU bound.

Wrapper branch is pushed and paired with a separate wrapper PR.