### PR TITLE
[BLOCKER DoS] Reserve source capacity for latent active positions

### DIFF
--- a/src/v16.rs
+++ b/src/v16.rs
@@ -36,6 +36,25 @@ pub const BACKING_FEE_RATE_DEN_E9: u128 = 1_000_000_000;
 pub const MAX_BACKING_FEE_RATE_E9_PER_SLOT: u64 = 1_000_000_000;
 pub const MAX_BACKING_FEE_UTIL_BPS: u64 = 10_000;
 
+/// Admission resource invariant for latent favorable settlement domains.
+/// `occupied + missing_active` is the reserved pre-state; admission adds the
+/// candidate only when its favorable source is not already materialized.
+#[inline]
+fn source_domain_capacity_after_admission(
+    occupied: usize,
+    missing_active: usize,
+    candidate_missing: bool,
+) -> V16Result<usize> {
+    let required = occupied
+        .checked_add(missing_active)
+        .and_then(|value| value.checked_add(usize::from(candidate_missing)))
+        .ok_or(V16Error::ArithmeticOverflow)?;
+    if required > PORTFOLIO_SOURCE_DOMAIN_CAP {
+        return Err(V16Error::LockActive);
+    }
+    Ok(required)
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct BackingDomainFeeSplitV16 {
     pub lien_delta_atoms: u128,
@@ -16119,6 +16138,7 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         validate_basis(basis_pos_q)?;
         let asset = self.asset_state(asset_index)?;
         self.require_asset_risk_change_allowed(asset_index, true)?;
+        self.ensure_source_domain_capacity_for_new_exposure(&account.as_view(), asset_index, side)?;
         let a_basis = match side {
             SideV16::Long => asset.a_long,
             SideV16::Short => asset.a_short,
@@ -16132,6 +16152,60 @@ impl<'a, T> MarketGroupV16ViewMut<'a, T> {
         account.header.active_bitmap = bitmap.map(V16PodU64::new);
         account.header.health_cert.valid = 0;
         self.set_asset_state(asset_index, asset)?;
+        Ok(())
+    }
+
+    fn ensure_source_domain_capacity_for_new_exposure(
+        &self,
+        account: &PortfolioV16View<'_>,
+        asset_index: usize,
+        side: SideV16,
+    ) -> V16Result<()> {
+        // PortfolioV16ViewMut compacts source entries. Below this threshold, the configured
+        // active-leg bound proves that every current leg plus this candidate can materialize a
+        // distinct favorable domain, so ordinary admission avoids both bounded scans.
+        let max_active = self.header.config.max_portfolio_assets.get() as usize;
+        if max_active != 0 && max_active <= PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let safe_occupied = PORTFOLIO_SOURCE_DOMAIN_CAP - max_active;
+            if account.header.source_domains[safe_occupied].is_sparse_tail_default() {
+                return Ok(());
+            }
+        }
+
+        let candidate_domain = self.insurance_domain_index(asset_index, opposite_side(side))?;
+        let candidate_missing = account.source_domain_slot(candidate_domain)?.is_none();
+
+        let mut occupied = 0usize;
+        let mut source_slot = 0usize;
+        while source_slot < PORTFOLIO_SOURCE_DOMAIN_CAP {
+            let source = account.header.source_domains[source_slot];
+            if source.is_sparse_tail_default() {
+                break;
+            }
+            if source.is_occupied() {
+                occupied += 1;
+            }
+            source_slot += 1;
+        }
+
+        // A favorable K/F move can create one source record for every active leg. Reserving
+        // those absent domains before attaching another leg prevents future settle/close paths
+        // from discovering that the fixed table has no insertion slot.
+        let mut missing_active = 0usize;
+        let mut leg_slot = 0usize;
+        while leg_slot < V16_MAX_PORTFOLIO_ASSETS_N {
+            let leg = account.header.legs[leg_slot].try_to_runtime()?;
+            if leg.active {
+                let domain =
+                    self.insurance_domain_index(leg.asset_index as usize, opposite_side(leg.side))?;
+                if account.source_domain_slot(domain)?.is_none() {
+                    missing_active += 1;
+                }
+            }
+            leg_slot += 1;
+        }
+
+        source_domain_capacity_after_admission(occupied, missing_active, candidate_missing)?;
         Ok(())
     }
 

--- a/src/v16_kani_api.rs
+++ b/src/v16_kani_api.rs
@@ -182,6 +182,14 @@ pub fn kani_unattributed_loss_lock_after_pnl(
     unattributed_loss_lock_after_pnl(was_locked, active_bitmap, new_pnl)
 }
 
+pub fn kani_source_domain_capacity_after_admission(
+    occupied: usize,
+    missing_active: usize,
+    candidate_missing: bool,
+) -> V16Result<usize> {
+    source_domain_capacity_after_admission(occupied, missing_active, candidate_missing)
+}
+
 pub fn kani_liquidation_projected_health_deficit_from_parts(
     certified_equity: i128,
     certified_maintenance_req: u128,

--- a/tests/proofs_v16.rs
+++ b/tests/proofs_v16.rs
@@ -23,7 +23,8 @@ use percolator::v16::{
     kani_select_auto_crank_plan, kani_settle_kf_stale_cohort,
     kani_should_clear_prior_reset_obligation, kani_source_claim_domain_first_burn_partition,
     kani_source_credit_state_realizable_support_for_claim_num,
-    kani_source_credit_state_realizable_support_for_face, kani_target_effective_lag_adverse_delta,
+    kani_source_credit_state_realizable_support_for_face,
+    kani_source_domain_capacity_after_admission, kani_target_effective_lag_adverse_delta,
     kani_terminal_claim_free_overlap_recredit, kani_terminal_slab_asset_step,
     kani_terminal_slab_wait_continuation, kani_trade_preexisting_oi_reduction_gate,
     kani_trade_preflight_risk_gate, kani_unattributed_loss_lock_after_pnl,
@@ -1948,6 +1949,61 @@ fn proof_v16_sparse_source_domain_cap_full_rejects_new_domain() {
         "sparse source-domain cap-full rejection covers symbolic new domain"
     );
     assert_eq!(rejected, Err(V16Error::LockActive));
+}
+
+// Every active leg has one distinct latent favorable source domain. An accepted candidate must
+// leave enough physical slots to materialize that entire reserved union in any settlement order.
+#[kani::proof]
+#[kani::unwind(6)]
+#[kani::solver(cadical)]
+fn proof_v16_source_capacity_admission_closes_all_favorable_domains() {
+    let occupied_raw: u8 = kani::any();
+    let missing_active_raw: u8 = kani::any();
+    let candidate_missing: bool = kani::any();
+    kani::assume(occupied_raw as usize <= PORTFOLIO_SOURCE_DOMAIN_CAP);
+    kani::assume(missing_active_raw as usize <= PORTFOLIO_SOURCE_DOMAIN_CAP);
+
+    let occupied = occupied_raw as usize;
+    let missing_active = missing_active_raw as usize;
+    let reserved_before = occupied + missing_active;
+    kani::assume(reserved_before <= PORTFOLIO_SOURCE_DOMAIN_CAP);
+    let candidate_reservation = usize::from(candidate_missing);
+    let required = reserved_before + candidate_reservation;
+    let admission =
+        kani_source_domain_capacity_after_admission(occupied, missing_active, candidate_missing);
+
+    if required > PORTFOLIO_SOURCE_DOMAIN_CAP {
+        assert_eq!(admission, Err(V16Error::LockActive));
+        assert!(candidate_missing);
+        assert_eq!(reserved_before, PORTFOLIO_SOURCE_DOMAIN_CAP);
+        kani::cover!(
+            occupied < PORTFOLIO_SOURCE_DOMAIN_CAP && missing_active > 0,
+            "latent active domains reject over-admission before the table is physically full"
+        );
+        return;
+    }
+
+    let admitted_required = admission.unwrap();
+    assert_eq!(admitted_required, required);
+    let mut materialized = occupied;
+    let mut latent = missing_active + candidate_reservation;
+    while latent != 0 {
+        assert!(materialized < PORTFOLIO_SOURCE_DOMAIN_CAP);
+        materialized += 1;
+        latent -= 1;
+        assert_eq!(materialized + latent, admitted_required);
+    }
+    assert_eq!(materialized, admitted_required);
+    assert!(materialized <= PORTFOLIO_SOURCE_DOMAIN_CAP);
+
+    kani::cover!(
+        candidate_missing && missing_active > 0 && admitted_required == PORTFOLIO_SOURCE_DOMAIN_CAP,
+        "multiple latent domains materialize at the exact capacity boundary"
+    );
+    kani::cover!(
+        !candidate_missing && reserved_before == PORTFOLIO_SOURCE_DOMAIN_CAP,
+        "a represented candidate remains admissible at full reserved capacity"
+    );
 }
 
 #[kani::proof]

--- a/tests/v16_fuzzing.rs
+++ b/tests/v16_fuzzing.rs
@@ -3,9 +3,10 @@
 use percolator::{
     EngineAssetSlotV16Account, LiquidationRequestV16, Market, MarketGroupV16HeaderAccount,
     MarketGroupV16ViewMut, PermissionlessCrankActionV16, PermissionlessCrankRequestV16,
-    PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16, PortfolioV16View,
-    PortfolioV16ViewMut, ProvenanceHeaderV16, ProvenanceHeaderV16Account, TradeRequestV16,
-    V16Config, V16Error, V16PodU128, MAX_VAULT_TVL,
+    PermissionlessRecoveryReasonV16, PortfolioAccountV16Account, PortfolioLegV16,
+    PortfolioSourceDomainV16Account, PortfolioV16View, PortfolioV16ViewMut, ProvenanceHeaderV16,
+    ProvenanceHeaderV16Account, SideV16, TradeRequestV16, V16Config, V16Error, V16PodU128,
+    V16PodU32, V16PodU64, MAX_VAULT_TVL, PORTFOLIO_SOURCE_DOMAIN_CAP,
 };
 use percolator::{BOUND_SCALE, POS_SCALE, SOCIAL_LOSS_DEN};
 use proptest::prelude::*;
@@ -627,4 +628,118 @@ proptest! {
             );
         }
     }
+}
+
+#[test]
+fn v16_source_domain_capacity_reserves_favorable_settlement_for_each_active_leg() {
+    const MARKET_SLOTS: usize = 17;
+    const CANDIDATE_ASSET: usize = 16;
+    const EXISTING_ASSET: usize = 15;
+
+    let (market_id, _, _, _) = ids();
+    let cfg = V16Config::public_user_fund_with_market_slots(16, MARKET_SLOTS as u32, 0, 10);
+    let mut header =
+        MarketGroupV16HeaderAccount::new_dynamic(market_id, cfg, MARKET_SLOTS as u32, 0).unwrap();
+    let mut markets = (0..MARKET_SLOTS)
+        .map(|index| Market::new(index as u64, EngineAssetSlotV16Account::default()))
+        .collect::<Vec<_>>();
+    for (asset_index, market) in markets.iter_mut().enumerate() {
+        header
+            .activate_empty_asset_slot_not_atomic(
+                asset_index as u32,
+                &mut market.engine,
+                100,
+                asset_index as u64 + 1,
+            )
+            .unwrap();
+    }
+
+    let occupied_source = |domain: usize| PortfolioSourceDomainV16Account {
+        domain: V16PodU32::new(domain as u32),
+        source_claim_market_id: V16PodU64::new(1),
+        source_claim_bound_num: V16PodU128::new(BOUND_SCALE),
+        ..PortfolioSourceDomainV16Account::default()
+    };
+
+    let mut full = fuzz_account([20; 32]);
+    for (domain, source) in full.source_domains.iter_mut().enumerate() {
+        *source = occupied_source(domain);
+    }
+    let full_before = full;
+    let candidate_asset_before = markets[CANDIDATE_ASSET].engine.asset;
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut full);
+        assert_eq!(
+            market.kani_attach_leg_at_slot(
+                &mut account,
+                CANDIDATE_ASSET,
+                SideV16::Long,
+                POS_SCALE as i128,
+                0,
+            ),
+            Err(V16Error::LockActive)
+        );
+    }
+    assert_eq!(full, full_before);
+    assert_eq!(
+        markets[CANDIDATE_ASSET].engine.asset,
+        candidate_asset_before
+    );
+
+    // A full table remains usable when it already contains the candidate's favorable domain.
+    let mut represented = fuzz_account([21; 32]);
+    for (domain, source) in represented.source_domains.iter_mut().enumerate() {
+        *source = occupied_source(domain);
+    }
+    represented.source_domains[PORTFOLIO_SOURCE_DOMAIN_CAP - 1] =
+        occupied_source(CANDIDATE_ASSET * 2 + 1);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut represented);
+        assert!(market
+            .kani_attach_leg_at_slot(
+                &mut account,
+                CANDIDATE_ASSET,
+                SideV16::Long,
+                POS_SCALE as i128,
+                0,
+            )
+            .is_ok());
+    }
+
+    // An active leg reserves capacity before its first favorable settlement creates a record.
+    let mut reserved = fuzz_account([22; 32]);
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut reserved);
+        market
+            .kani_attach_leg_at_slot(
+                &mut account,
+                EXISTING_ASSET,
+                SideV16::Long,
+                POS_SCALE as i128,
+                0,
+            )
+            .unwrap();
+    }
+    for domain in 0..PORTFOLIO_SOURCE_DOMAIN_CAP - 1 {
+        reserved.source_domains[domain] = occupied_source(domain);
+    }
+    let reserved_before = reserved;
+    {
+        let mut market = MarketGroupV16ViewMut::new(&mut header, &mut markets);
+        let mut account = PortfolioV16ViewMut::new(&mut reserved);
+        assert_eq!(
+            market.kani_attach_leg_at_slot(
+                &mut account,
+                CANDIDATE_ASSET,
+                SideV16::Long,
+                POS_SCALE as i128,
+                1,
+            ),
+            Err(V16Error::LockActive)
+        );
+    }
+    assert_eq!(reserved, reserved_before);
 }


### PR DESCRIPTION
## Finding

The fixed portfolio source-domain table can be exhausted after valid admission because existing active legs may not yet have materialized their favorable settlement domains. The current admission check accounts for physically occupied source records and the current candidate, but not the absent favorable domains of previously admitted active legs.

A public wrapper trace can therefore retain five active LP legs, churn 28 historical source claims, materialize four latent claims into slots 29-32, then permanently fail the fifth. Crank, conversion, owner reduction, forfeit, withdrawal, matched close, and Resolved close all reject before that portfolio can exit. One honest cranker and favorable terminal ordering do not restore progress.

This is the source-capacity invariant from former engine PR #142. PR #142 was closed as superseded by #195, but the merged #195 tree at `8eb7142` does not contain `ensure_source_domain_capacity_for_new_exposure`; the invariant was lost during consolidation.

## Fix

Before attaching new exposure, reserve the union of:

```text
occupied source domains
+ absent favorable domains for every active leg
+ absent favorable domain for the candidate
<= PORTFOLIO_SOURCE_DOMAIN_CAP
```

The check runs before mutation. A compact-tail fast path avoids either bounded scan for ordinary portfolios. Full tables remain usable when the candidate domain is already represented.

## Verification

- Runtime test covers full represented tables, exact rollback, and one latent active domain.
- Kani proves admitted latent domains can all materialize in any sequence within the physical cap: 108 checks and 3 cover properties.
- Public wrapper parent RED leaves five active legs, 1,000,000 capital, 32 PnL, and zero payout; every available exit rejects.
- Fixed wrapper rejects the unsafe admission atomically at 154,680 CU, then settles all previously admitted legs; payouts are 1,000,032 and 999,968.
- 14-leg max-shape batch: 931,475 CU parent, 933,687 CU fixed, +2,212 CU (+0.24%), below 1.4M.
- `cargo fmt --all -- --check` and `git diff --check` pass.

No account layout or public API changes.